### PR TITLE
Rename `Params.hs` modules to get unique names

### DIFF
--- a/disciplina.cabal
+++ b/disciplina.cabal
@@ -143,7 +143,7 @@ library
 executable disciplina-witness
   hs-source-dirs:      src/witness
   main-is:             Main.hs
-  other-modules:       Params
+  other-modules:       WitnessParams
   build-depends:       base
                      , bytestring
                      , disciplina
@@ -193,7 +193,7 @@ executable disciplina-witness
 executable disciplina-educator
   hs-source-dirs:      src/educator
   main-is:             Main.hs
-  other-modules:       Params
+  other-modules:       EducatorParams
   build-depends:       base
                      , disciplina
                      , cardano-sl-networking

--- a/src/educator/EducatorParams.hs
+++ b/src/educator/EducatorParams.hs
@@ -1,7 +1,7 @@
 
 -- | Command-line options and flags for Educator node
 
-module Params
+module EducatorParams
        ( EducatorParams (..)
        , getEducatorParams
        ) where

--- a/src/educator/Main.hs
+++ b/src/educator/Main.hs
@@ -11,7 +11,7 @@ import System.Wlog (logInfo, logWarning)
 import Disciplina.DB (DBType (EducatorDB))
 import Disciplina.Launcher (BasicNodeParams (..), bracketBasicNodeResources, runBasicRealMode)
 
-import Params (EducatorParams (..), getEducatorParams)
+import EducatorParams (EducatorParams (..), getEducatorParams)
 
 main :: IO ()
 main = do

--- a/src/witness/Main.hs
+++ b/src/witness/Main.hs
@@ -22,7 +22,7 @@ import Disciplina.Listeners (witnessListeners)
 import Disciplina.Messages (serialisePacking)
 import Disciplina.Transport (bracketTransportTCP)
 import Disciplina.Workers (witnessWorkers)
-import Params (WitnessParams (..), getWitnessParams)
+import WitnessParams (WitnessParams (..), getWitnessParams)
 
 main :: IO ()
 main = do

--- a/src/witness/WitnessParams.hs
+++ b/src/witness/WitnessParams.hs
@@ -1,7 +1,7 @@
 
 -- | Command-line options and flags for Witness nodes
 
-module Params
+module WitnessParams
        ( WitnessParams (..)
        , getWitnessParams
        ) where


### PR DESCRIPTION
Having plain 'Params' modules is really something pleasant, but
unfortunately duplications break ghci and deliver inconviniencies into work
with intero, so I'm for having unique module names in favor of faster builds.