### PR TITLE
[DSCP-106] Rename `*Params` types in executables' param modules

### DIFF
--- a/src/educator/EducatorParams.hs
+++ b/src/educator/EducatorParams.hs
@@ -2,7 +2,7 @@
 -- | Command-line options and flags for Educator node
 
 module EducatorParams
-       ( EducatorParams (..)
+       ( EducatorOptParams (..)
        , getEducatorParams
        ) where
 
@@ -13,16 +13,16 @@ import Options.Applicative (Parser, execParser, fullDesc, helper, info, progDesc
 import Disciplina.CLI (dbPathParser, logParamsParser, versionOption)
 import Disciplina.Launcher (LoggingParams)
 
-data EducatorParams = EducatorParams
+data EducatorOptParams = EducatorOptParams
     { epDbPath    :: !FilePath
     , epLogParams :: !LoggingParams
     }
 
-educatorParamsParser :: Parser EducatorParams
+educatorParamsParser :: Parser EducatorOptParams
 educatorParamsParser =
-    EducatorParams <$> dbPathParser <*> logParamsParser "educator"
+    EducatorOptParams <$> dbPathParser <*> logParamsParser "educator"
 
-getEducatorParams :: IO EducatorParams
+getEducatorParams :: IO EducatorOptParams
 getEducatorParams =
     execParser $ info (helper <*> versionOption <*> educatorParamsParser) $
     fullDesc <> progDesc "Discplina educator node."

--- a/src/educator/Main.hs
+++ b/src/educator/Main.hs
@@ -11,11 +11,10 @@ import Disciplina.DB (DBParams (..))
 import Disciplina.Educator (EducatorParams (..), launchEducatorRealMode)
 import Disciplina.Witness (WitnessParams (..))
 
-import qualified EducatorParams as Params
-
+import EducatorParams (EducatorOptParams (..), getEducatorParams)
 main :: IO ()
 main = do
-    Params.EducatorParams {..} <- Params.getEducatorParams
+    EducatorOptParams {..} <- getEducatorParams
     let educatorParams = EducatorParams
             { epWitnessParams = WitnessParams
                 { wpLoggingParams = epLogParams

--- a/src/witness/Main.hs
+++ b/src/witness/Main.hs
@@ -21,11 +21,11 @@ import Disciplina.Messages (serialisePacking)
 import Disciplina.Transport (bracketTransportTCP)
 import Disciplina.Witness (WitnessParams (..), launchWitnessRealMode)
 import Disciplina.Workers (witnessWorkers)
-import qualified WitnessParams as Params
+import WitnessParams (WitnessOptParams (..), getWitnessParams)
 
 main :: IO ()
 main = do
-    Params.WitnessParams {..} <- Params.getWitnessParams
+    WitnessOptParams {..} <- getWitnessParams
     let witnessParams = WitnessParams
             { wpLoggingParams = wpLogParams
             , wpDBParams = DBParams{ dbpPath = wpDbPath }

--- a/src/witness/WitnessParams.hs
+++ b/src/witness/WitnessParams.hs
@@ -2,7 +2,7 @@
 -- | Command-line options and flags for Witness nodes
 
 module WitnessParams
-       ( WitnessParams (..)
+       ( WitnessOptParams (..)
        , getWitnessParams
        ) where
 
@@ -13,16 +13,16 @@ import Options.Applicative (Parser, execParser, fullDesc, help, helper, info, lo
 import Disciplina.CLI (dbPathParser, logParamsParser, versionOption)
 import Disciplina.Launcher (LoggingParams)
 
-data WitnessParams = WitnessParams
+data WitnessOptParams = WitnessOptParams
     { wpDbPath    :: !FilePath
     , wpLogParams :: !LoggingParams
     }
 
-witnessParamsParser :: Parser WitnessParams
+witnessParamsParser :: Parser WitnessOptParams
 witnessParamsParser =
-    WitnessParams <$> dbPathParser <*> logParamsParser "witness"
+    WitnessOptParams <$> dbPathParser <*> logParamsParser "witness"
 
-getWitnessParams :: IO WitnessParams
+getWitnessParams :: IO WitnessOptParams
 getWitnessParams =
     execParser $ info (helper <*> versionOption <*> witnessParamsParser) $
     fullDesc <> progDesc "Disciplina witness node."


### PR DESCRIPTION
To avoid name conflict with types defined in `Disciplina/*/Launcher/Params.hs`