### PR TITLE
[DSCP-104] Loot log

### DIFF
--- a/disciplina.cabal
+++ b/disciplina.cabal
@@ -88,7 +88,7 @@ library
 
                      , Dscp.CLI.Common
   -- other-extensions:
-  build-depends:       base >= 4.9 && < 5
+  build-depends:       base-noprelude >= 4.9 && < 5
                      , aeson
                      , autoexporter
                      , array
@@ -109,6 +109,7 @@ library
                      , lifted-async
                      , log-warper
                      , loot-log
+                     , loot-prelude
                      , memory
                      , monad-control
                      , mtl
@@ -161,13 +162,14 @@ executable disciplina-witness
   hs-source-dirs:      src/witness
   main-is:             Main.hs
   other-modules:       WitnessParams
-  build-depends:       base
+  build-depends:       base-noprelude >= 4.9 && < 5
                      , bytestring
                      , disciplina
                      , cardano-sl-networking
                      , disciplina
                      , formatting
                      , loot-log
+                     , loot-prelude
                      , network-transport-tcp
                      , time-units
                      , optparse-applicative
@@ -212,11 +214,12 @@ executable disciplina-educator
   hs-source-dirs:      src/educator
   main-is:             Main.hs
   other-modules:       EducatorParams
-  build-depends:       base
+  build-depends:       base-noprelude >= 4.9 && < 5
                      , disciplina
                      , cardano-sl-networking
                      , formatting
                      , loot-log
+                     , loot-prelude
                      , network-transport-tcp
                      , optparse-applicative
                      , universum >= 1.0.0
@@ -262,7 +265,7 @@ test-suite disciplina-test
                             Test.Dscp.Witness
                             Test.Dscp.Core.ATG
                             Test.Dscp.Crypto.MerkleTree
-  build-depends:             base >= 0.4 && < 5
+  build-depends:             base-noprelude >= 4.9 && < 5
                            , AVL
                            , bytestring
                            , containers
@@ -271,6 +274,7 @@ test-suite disciplina-test
                            , data-default
                            , hspec
                            , lens
+                           , loot-prelude
                            , tasty
                            , tasty-hspec
                            , tasty-discover

--- a/disciplina.cabal
+++ b/disciplina.cabal
@@ -89,6 +89,7 @@ library
                      , Dscp.CLI.Common
   -- other-extensions:
   build-depends:       base >= 4.9 && < 5
+                     , aeson
                      , autoexporter
                      , array
                      , AVL
@@ -101,11 +102,13 @@ library
                      , ether
                      , exceptions
                      , formatting
+                     , fmt
                      , free
                      , hashable
                      , lens
                      , lifted-async
                      , log-warper
+                     , loot-log
                      , memory
                      , monad-control
                      , mtl
@@ -148,6 +151,7 @@ library
                        TypeFamilies
                        UndecidableInstances
                        ViewPatterns
+                       TypeApplications
 
   ghc-options:         -Wall
                        -Werror
@@ -163,7 +167,7 @@ executable disciplina-witness
                      , cardano-sl-networking
                      , disciplina
                      , formatting
-                     , log-warper
+                     , loot-log
                      , network-transport-tcp
                      , time-units
                      , optparse-applicative
@@ -212,7 +216,7 @@ executable disciplina-educator
                      , disciplina
                      , cardano-sl-networking
                      , formatting
-                     , log-warper
+                     , loot-log
                      , network-transport-tcp
                      , optparse-applicative
                      , universum >= 1.0.0

--- a/log-config.yaml
+++ b/log-config.yaml
@@ -1,0 +1,12 @@
+loggerTree:
+  handlers:
+    - file: node.log
+
+  severity: Info+
+
+  node:
+    severity: Debug+
+
+  init:
+    log:
+      severity: Debug+

--- a/src/Dscp/CLI/Common.hs
+++ b/src/Dscp/CLI/Common.hs
@@ -11,13 +11,13 @@ module Dscp.CLI.Common
 import Universum
 
 import Data.Version (showVersion)
+import qualified Loot.Log as Log
 import Options.Applicative (Parser, help, infoOption, long, metavar, optional, strOption, value)
-import System.Wlog (LoggerName)
 
 import Dscp.Launcher.Params (LoggingParams (..))
 import Paths_disciplina (version)
 
-logParamsParser :: LoggerName -> Parser LoggingParams
+logParamsParser :: Log.Name -> Parser LoggingParams
 logParamsParser lpDefaultName = do
     lpConfigPath <- logConfigParser
     lpDirectory <- logDirParser

--- a/src/Dscp/Educator/Launcher/Mode.hs
+++ b/src/Dscp/Educator/Launcher/Mode.hs
@@ -11,17 +11,18 @@ module Dscp.Educator.Launcher.Mode
       -- * Implementations
     , EducatorContext (..)
     , EducatorRealMode
+    , ecWitnessCtx
     ) where
 
 import Universum
 
 import Control.Lens (makeLenses)
+import Loot.Log.Rio (LoggingIO)
 
 import Dscp.DB.Real.Types (NodeDB)
 import qualified Dscp.Launcher.Mode as Basic
 import qualified Dscp.Witness.Launcher as Witness
 import Ether.Internal (HasLens (..))
-import System.Wlog (HasLoggerName (..))
 
 ---------------------------------------------------------------------
 -- WorkMode class
@@ -48,7 +49,7 @@ data EducatorContext = EducatorContext
 
 makeLenses ''EducatorContext
 
-type EducatorRealMode = ReaderT EducatorContext IO
+type EducatorRealMode = Basic.RIO EducatorContext
 
 ---------------------------------------------------------------------
 -- Instances
@@ -57,6 +58,5 @@ type EducatorRealMode = ReaderT EducatorContext IO
 instance HasLens NodeDB EducatorContext NodeDB where
     lensOf = ecWitnessCtx . Witness.wcDB
 
-instance {-# OVERLAPPING #-} HasLoggerName EducatorRealMode where
-    askLoggerName = view (ecWitnessCtx . Witness.wcLoggerName)
-    modifyLoggerName name = local $ (ecWitnessCtx . Witness.wcLoggerName) %~ name
+instance HasLens LoggingIO EducatorContext LoggingIO where
+    lensOf = ecWitnessCtx . Witness.wcLogging

--- a/src/Dscp/Educator/Launcher/Runner.hs
+++ b/src/Dscp/Educator/Launcher/Runner.hs
@@ -10,6 +10,7 @@ import Control.Monad.Component (runComponentM)
 import Dscp.Educator.Launcher.Mode (EducatorContext (..), EducatorRealMode)
 import Dscp.Educator.Launcher.Params (EducatorParams (..))
 import Dscp.Educator.Launcher.Resource (EducatorResources (..))
+import Dscp.Launcher.Mode (runRIO)
 import Dscp.Launcher.Resource (AllocResource (..))
 import Dscp.Witness.Launcher.Runner (formWitnessContext)
 
@@ -21,7 +22,7 @@ formEducatorContext EducatorResources{..} =
     }
 
 runEducatorRealMode :: EducatorContext -> EducatorRealMode a -> IO a
-runEducatorRealMode ctx action = runReaderT action ctx
+runEducatorRealMode = runRIO
 
 -- | Given params, allocate resources, construct node context and run
 -- `EducatorWorkMode` monad.

--- a/src/Dscp/Launcher/Mode.hs
+++ b/src/Dscp/Launcher/Mode.hs
@@ -21,11 +21,19 @@ module Dscp.Launcher.Mode
        (
          -- * Constraints
          BasicWorkMode
+
+         -- * RIO monad
+       , RIO (..)
+       , runRIO
        ) where
 
 import Universum
 
-import System.Wlog (WithLogger)
+import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
+import Ether.Internal (HasLens)
+import Loot.Log (ModifyLogName (..), MonadLogging (..), WithLogging)
+import Loot.Log.Rio (LoggingIO)
+import qualified Loot.Log.Rio as Rio
 import UnliftIO (MonadUnliftIO)
 
 ---------------------------------------------------------------------
@@ -34,7 +42,7 @@ import UnliftIO (MonadUnliftIO)
 
 -- | Set of typeclasses which define basic capabilities of Disciplina node
 type BasicWorkMode m =
-    ( WithLogger m
+    ( WithLogging m
     , MonadIO m
     , MonadUnliftIO m  -- allows to use lifted-async
     )
@@ -43,4 +51,28 @@ type BasicWorkMode m =
 -- WorkMode implementations
 ---------------------------------------------------------------------
 
+{- | Conventional "ReaderT over IO" monad stack.
 
+Lootbox bases on 'caps' library which allows the only 'ReaderT' instance for
+used typeclasses, e.g.
+@instance (r ~ Capabilities caps) => MonadLogging (ReaderT r IO)@.
+To avoid instances overlapping, we use this wrapper.
+
+This also allows us to remorselessly define one global
+@instance HasLens Smth ctx Smth => MonadSmth (RIO ctx)@ per every @Smth@.
+-}
+newtype RIO ctx a = RIO { unRIO :: ReaderT ctx IO a }
+    deriving (Functor, Applicative, Monad, MonadIO, MonadReader ctx,
+              MonadThrow, MonadCatch, MonadMask)
+
+runRIO :: MonadIO m => ctx -> RIO ctx a -> m a
+runRIO ctx (RIO act) = liftIO $ runReaderT act ctx
+
+instance HasLens LoggingIO ctx LoggingIO =>
+         MonadLogging (RIO ctx) where
+    log = Rio.defaultLog
+    logName = Rio.defaultLogName
+
+instance HasLens LoggingIO ctx LoggingIO =>
+         ModifyLogName (RIO ctx) where
+    modifyLogNameSel = Rio.defaultModifyLogNameSel

--- a/src/Dscp/Launcher/Params.hs
+++ b/src/Dscp/Launcher/Params.hs
@@ -4,11 +4,11 @@ module Dscp.Launcher.Params
 
 import Universum
 
-import System.Wlog (LoggerName)
+import qualified Loot.Log as Log
 
 -- | Contains all parameters required for hierarchical logger initialization.
 data LoggingParams = LoggingParams
-    { lpDefaultName :: !LoggerName
+    { lpDefaultName :: !Log.Name
     -- ^ Logger name which will be used by default
     , lpDirectory   :: !(Maybe FilePath)
     -- ^ Path to log directory

--- a/src/Dscp/Launcher/Resource.hs
+++ b/src/Dscp/Launcher/Resource.hs
@@ -54,7 +54,7 @@ instance AllocResource LoggingParams LoggingIO where
             printCfg logging config'
             return logging
         printCfg logging finalConfig =
-            runRIO logging $ modifyLogName (<> "log" <> "init") $ do
+            runRIO logging $ modifyLogName (<> "init" <> "log") $ do
                 let configText = decodeUtf8 (encode finalConfig) :: Text
                 logDebug $ "Logging config: "+|configText|+""
         fin _ = removeAllHandlers

--- a/src/Dscp/Listeners/Listener.hs
+++ b/src/Dscp/Listeners/Listener.hs
@@ -6,8 +6,8 @@ module Dscp.Listeners.Listener where
 import Universum
 
 import qualified Data.ByteString as BS
+import Loot.Log (logInfo)
 import Node (ConversationActions, Listener (..), NodeId, send)
-import System.Wlog (logInfo)
 
 import Dscp.Messages (Packing, PingBlk, PingTx, PongBlk (..), PongTx (..))
 import Dscp.Witness.Launcher (WitnessWorkMode)

--- a/src/Dscp/Witness/Internal.hs
+++ b/src/Dscp/Witness/Internal.hs
@@ -3,14 +3,13 @@
 
 module Dscp.Witness.Internal where
 
-import qualified Prelude (show)
-
-import Universum hiding (Hashable, get, trace, use)
+import Prelude hiding (Hashable, get, trace, use)
 
 import Codec.Serialise (Serialise (..))
 import Control.Lens (makeLenses, makePrisms, to, use, zoom, (+~), (-~), (.=))
 import Control.Monad.RWS (RWST (..), get, listen, tell)
 import Data.Default (Default, def)
+import qualified Text.Show
 
 import qualified Data.Tree.AVL as AVL
 import qualified Debug.Trace as Debug

--- a/src/Dscp/Witness/Launcher/Mode.hs
+++ b/src/Dscp/Witness/Launcher/Mode.hs
@@ -11,14 +11,12 @@ module Dscp.Witness.Launcher.Mode
     , WitnessContext (..)
     , WitnessRealMode
     , wcDB
-    , wcLoggerName
+    , wcLogging
     ) where
-
-import Universum
 
 import Control.Lens (makeLenses)
 import Ether.Internal (HasLens (..))
-import System.Wlog (HasLoggerName (..), LoggerName)
+import Loot.Log.Rio (LoggingIO)
 
 import Dscp.DB.Class (MonadDB)
 import Dscp.DB.Real.Types (NodeDB)
@@ -39,13 +37,13 @@ type WitnessWorkMode m =
 ---------------------------------------------------------------------
 
 data WitnessContext = WitnessContext
-    { _wcDB         :: NodeDB
-    , _wcLoggerName :: LoggerName
+    { _wcDB      :: NodeDB
+    , _wcLogging :: LoggingIO
     }
 
 makeLenses ''WitnessContext
 
-type WitnessRealMode = ReaderT WitnessContext IO
+type WitnessRealMode = Basic.RIO WitnessContext
 
 ---------------------------------------------------------------------
 -- Instances
@@ -54,7 +52,5 @@ type WitnessRealMode = ReaderT WitnessContext IO
 instance HasLens NodeDB WitnessContext NodeDB where
     lensOf = wcDB
 
-instance {-# OVERLAPPING #-} HasLoggerName WitnessRealMode where
-    askLoggerName = view wcLoggerName
-    modifyLoggerName name = local $ wcLoggerName %~ name
-
+instance HasLens LoggingIO WitnessContext LoggingIO where
+    lensOf = wcLogging

--- a/src/Dscp/Witness/Launcher/Resource.hs
+++ b/src/Dscp/Witness/Launcher/Resource.hs
@@ -7,7 +7,7 @@ module Dscp.Witness.Launcher.Resource
 
 import Universum
 
-import System.Wlog (LoggerName)
+import Loot.Log.Rio (LoggingIO)
 
 import Dscp.DB.Real (NodeDB)
 import Dscp.Launcher.Resource (AllocResource (..))
@@ -16,13 +16,12 @@ import Dscp.Witness.Launcher.Params (WitnessParams (..))
 -- | Datatype which contains resources required by witness node to start
 -- working.
 data WitnessResources = WitnessResources
-    { wrLoggerName :: !LoggerName
-    , wrDB         :: !NodeDB
+    { wrLogging :: !LoggingIO
+    , wrDB      :: !NodeDB
     }
 
 instance AllocResource WitnessParams WitnessResources where
     allocResource WitnessParams{..} = do
-        wrLoggerName <- allocResource wpLoggingParams
+        wrLogging <- allocResource wpLoggingParams
         wrDB <- allocResource wpDBParams
         return WitnessResources {..}
-

--- a/src/Dscp/Witness/Launcher/Runner.hs
+++ b/src/Dscp/Witness/Launcher/Runner.hs
@@ -7,6 +7,7 @@ import Universum
 
 import Control.Monad.Component (runComponentM)
 
+import Dscp.Launcher.Mode (runRIO)
 import Dscp.Launcher.Resource (AllocResource (..))
 import Dscp.Witness.Launcher.Mode (WitnessContext (..), WitnessRealMode)
 import Dscp.Witness.Launcher.Params (WitnessParams (..))
@@ -16,12 +17,12 @@ import Dscp.Witness.Launcher.Resource (WitnessResources (..))
 formWitnessContext :: WitnessResources -> WitnessContext
 formWitnessContext WitnessResources{..} =
     WitnessContext
-    { _wcLoggerName = wrLoggerName
+    { _wcLogging = wrLogging
     , _wcDB = wrDB
     }
 
 runWitnessRealMode :: WitnessContext -> WitnessRealMode a -> IO a
-runWitnessRealMode ctx action = runReaderT action ctx
+runWitnessRealMode = runRIO
 
 -- | Given params, allocate resources, construct node context and run
 -- `WitnessWorkMode` monad.
@@ -31,4 +32,3 @@ launchWitnessRealMode params action =
       \resources ->
         let ctx = formWitnessContext resources
         in runWitnessRealMode ctx action
-

--- a/src/Dscp/Workers/Worker.hs
+++ b/src/Dscp/Workers/Worker.hs
@@ -6,8 +6,8 @@ import Universum
 
 import UnliftIO.Async (forConcurrently_)
 
+import Loot.Log (logInfo)
 import Node (Conversation (..), ConversationActions, Converse, NodeId, converseWith, recv)
-import System.Wlog (logInfo)
 
 import Dscp.Messages (Packing, PingBlk (..), PingTx (..), PongBlk (..), PongTx (..))
 import Dscp.Witness.Launcher (WitnessWorkMode)
@@ -64,4 +64,3 @@ witnessBlkWorker _anId peerIds conv = logInfo "blk worker initialized" >> worker
             forConcurrently_ peerIds $ \peerId ->
                 converseWith converse peerId (\_ -> Conversation (pongBlk peerId))
             loop
-

--- a/src/educator/Main.hs
+++ b/src/educator/Main.hs
@@ -5,7 +5,7 @@ module Main where
 
 import Universum
 
-import Loot.Log (logInfo, logWarning)
+import Loot.Log (logInfo, logWarning, modifyLogName)
 
 import Dscp.DB (DBParams (..))
 import Dscp.Educator (EducatorParams (..), launchEducatorRealMode)
@@ -22,6 +22,7 @@ main = do
                 , wpDBParams = DBParams{ dbpPath = epDbPath }
                 }
             }
-    launchEducatorRealMode educatorParams $ do
+    launchEducatorRealMode educatorParams $
+      modifyLogName (<> "node") $ do
         logInfo "This is the stub for Educator node executable"
         logWarning "Please don't forget to implement everything else!"

--- a/src/educator/Main.hs
+++ b/src/educator/Main.hs
@@ -5,7 +5,7 @@ module Main where
 
 import Universum
 
-import System.Wlog (logInfo, logWarning)
+import Loot.Log (logInfo, logWarning)
 
 import Dscp.DB (DBParams (..))
 import Dscp.Educator (EducatorParams (..), launchEducatorRealMode)

--- a/src/witness/Main.hs
+++ b/src/witness/Main.hs
@@ -5,9 +5,8 @@ module Main where
 
 import Universum
 
-import System.Wlog (logInfo, logWarning)
-
 import qualified Data.ByteString.Char8 as B8
+import Loot.Log (logInfo, logWarning)
 import qualified Network.Transport.TCP as TCP
 import Node (NodeAction (..), defaultNodeEnvironment, noReceiveDelay, node, nodeId,
              simpleNodeEndPoint)

--- a/src/witness/Main.hs
+++ b/src/witness/Main.hs
@@ -6,7 +6,7 @@ module Main where
 import Universum
 
 import qualified Data.ByteString.Char8 as B8
-import Loot.Log (logInfo, logWarning)
+import Loot.Log (logInfo, logWarning, modifyLogName)
 import qualified Network.Transport.TCP as TCP
 import Node (NodeAction (..), defaultNodeEnvironment, noReceiveDelay, node, nodeId,
              simpleNodeEndPoint)
@@ -29,7 +29,8 @@ main = do
             { wpLoggingParams = wpLogParams
             , wpDBParams = DBParams{ dbpPath = wpDbPath }
             }
-    launchWitnessRealMode witnessParams $ do
+    launchWitnessRealMode witnessParams $
+      modifyLogName (<> "node") $ do
             logInfo "Starting node"
             -- TODO: This networking can't live without Production and Mockables
             --       so leaving it commented for now

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
 resolver:
-    https://raw.githubusercontent.com/serokell/lootbox/db765836e61f11350519d95ca3a0cb74d0b5a94c/snapshot.yaml
+    https://raw.githubusercontent.com/serokell/lootbox/e445a9729e6d203234e9a3135d9c1fc99949da39/snapshot.yaml
 
 packages:
 - '.'

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,4 @@
-resolver:
-    https://raw.githubusercontent.com/serokell/lootbox/e445a9729e6d203234e9a3135d9c1fc99949da39/snapshot.yaml
+resolver: lts-10.7
 
 packages:
 - '.'
@@ -9,11 +8,8 @@ nix:
   shell-file: shell.nix
 
 extra-deps:
-- serialise-0.2.0.0
-- cborg-0.2.0.0
 - ether-0.5.1.0
 - log-warper-1.8.11
-- o-clock-0.1.1
 - pretty-tree-0.1.0.0
 - serokell-util-0.8.0
 - time-units-1.0.0
@@ -22,8 +18,6 @@ extra-deps:
 - typed-process-0.2.2.0
 - teardown-0.5.0.0
 - unliftio-0.2.7.0
-- universum-1.1.0
-- base-noprelude-4.10.1.0
 
 - git: https://github.com/serokell/kademlia.git
   commit: 7120bb4d28e708acd52dfd61d3dca7914fac7d7f # master
@@ -63,6 +57,28 @@ extra-deps:
   subdirs:
     - code/prelude
     - code/log
+
+# Forced by lootbox #
+- base-noprelude-4.10.1.0
+# - log-warper-1.8.9 - overriden above
+- serialise-0.2.0.0
+# - serokell-util-0.6.0 - overriden above
+- vinyl-0.8.1.1
+- universum-1.1.0
+
+- git: https://github.com/int-index/caps
+  commit: 2f46fc6d5480bdef0a17f64359ad6eb29510dba4
+
+# for caps
+- git: https://github.com/mokus0/dependent-sum
+  commit: f8909cb323b4ffa63af6c4e7cb3a9745e6199080
+
+# for log-warper
+- o-clock-0.1.1
+
+# for serialise
+- cborg-0.2.0.0
+# Lootbox dependencies end #
 
 # Needed to build `cardano-sl-networking` with newer GHC
 ghc-options:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,5 @@
-resolver: lts-10.8
+resolver:
+    https://raw.githubusercontent.com/serokell/lootbox/db765836e61f11350519d95ca3a0cb74d0b5a94c/snapshot.yaml
 
 packages:
 - '.'
@@ -22,6 +23,7 @@ extra-deps:
 - teardown-0.5.0.0
 - unliftio-0.2.7.0
 - universum-1.1.0
+- base-noprelude-4.10.1.0
 
 - git: https://github.com/serokell/kademlia.git
   commit: 7120bb4d28e708acd52dfd61d3dca7914fac7d7f # master
@@ -55,6 +57,12 @@ extra-deps:
 
 - git: https://github.com/serokell/rocksdb-haskell.git
   commit: 2dd6b4ffdc4edb86b477273ee3c8416a1520f4e1
+
+- git: https://github.com/serokell/lootbox.git
+  commit: f287dd6cfe29707b28cc0418e8aa099de3bfbe77
+  subdirs:
+    - code/prelude
+    - code/log
 
 # Needed to build `cardano-sl-networking` with newer GHC
 ghc-options:

--- a/tools/disciplina-tools.cabal
+++ b/tools/disciplina-tools.cabal
@@ -12,7 +12,8 @@ executable disciplina-simulacrum
   hs-source-dirs:      src/simulacrum
   main-is:             Main.hs
   build-depends:       universum
-                     , base >= 4.9
+                     , base-noprelude >= 4.9 && < 5
+                     , loot-prelude
                      , mtl
 
   default-language:    Haskell2010

--- a/tools/src/simulacrum/Main.hs
+++ b/tools/src/simulacrum/Main.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE LambdaCase   #-}
 {-# LANGUAGE TypeFamilies #-}
 
-import           Prelude
+import Prelude hiding (State)
 
-import           Control.Arrow          ((&&&), (***))
-import           Control.Monad.Identity
+import Control.Arrow ((&&&), (***))
+import Data.List ((!!))
 
 -- | Buyer decisions.
 data Input
@@ -191,12 +191,12 @@ evilBuyer (input, problems) = case input of
   KeySent -> Reject
 
 main = do
-    putStrLn "Good buyer:"
+    putTextLn "Good buyer:"
     forM_ goodBuyerTrades $ \(problems, badThings) -> do
         when (not $ null badThings) $ do
             putStrLn (show problems ++ " -> " ++ show badThings)
 
-    putStrLn "Evil buyer:"
+    putTextLn "Evil buyer:"
     forM_ evilBuyerTrades $ \(problems, badThings) -> do
         when (not $ null badThings) $ do
             putStrLn (show problems ++ " -> " ++ show badThings)


### PR DESCRIPTION
This switches logging to one based on lootbox.

There were several technical decisions taken:
* Using `RIO` newtype instead of `ReaderT ctx IO`. Simply speaking, it is done because `MonadLogging` typeclass provided by lootbox is already instantiated with `instance (r ~ Capabilities) => MonadLogging (ReaderT r IO)`, and I wanted to avoid defining overlapping instances.

* Logs of educators and witnesses are assumed to go into different folders (`logs/educator` and `logs/witness` accordingly) via passing `--log-dif` cmd line parameter, so educators and witnesses can share the same config without printing to the same file. (perhaps the time has come to write a simple launcher script).

Also see https://github.com/serokell/lootbox/pull/15.

Can not be merged until:
- [x] Depends on lootbox'es commit not in master
- [ ] Wait for DSCP-105 to be merged (with some neat technical decisions)