### PR TITLE
[DSCP-102] Provide SQLite context

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -37,6 +37,7 @@ library:
     - rocksdb-haskell
     - serialise
     - snowdrop
+    - sqlite-simple
     - stm
     - time-units
     - unliftio

--- a/src/Dscp/CLI/Common.hs
+++ b/src/Dscp/CLI/Common.hs
@@ -5,6 +5,7 @@
 module Dscp.CLI.Common
        ( logParamsParser
        , dbPathParser
+       , sqliteDbPathParser
        , versionOption
        ) where
 
@@ -38,6 +39,13 @@ dbPathParser = strOption $
     metavar "FILEPATH" <>
     help "Path to database directory for witness node." <>
     value "witness-db"
+
+sqliteDbPathParser :: Parser FilePath
+sqliteDbPathParser = strOption $
+    long "db-path" <>
+    metavar "FILEPATH" <>
+    help "Path to database directory for educator's private data." <>
+    value "educator-db"
 
 versionOption :: Parser (a -> a)
 versionOption = infoOption ("disciplina-" <> (showVersion version)) $

--- a/src/Dscp/DB.hs
+++ b/src/Dscp/DB.hs
@@ -2,6 +2,7 @@
 module Dscp.DB (module M) where
 
 import Dscp.DB.Class as M
-import Dscp.DB.Real as M
 import Dscp.DB.DSL.Class as M
 import Dscp.DB.DSL.Interpret.SimpleTxDB as M
+import Dscp.DB.Real as M
+import Dscp.DB.SQLite as M

--- a/src/Dscp/DB.hs
+++ b/src/Dscp/DB.hs
@@ -1,8 +1,7 @@
 
 module Dscp.DB (module M) where
 
-import Dscp.DB.Class as M
 import Dscp.DB.DSL.Class as M
 import Dscp.DB.DSL.Interpret.SimpleTxDB as M
-import Dscp.DB.Real as M
+import Dscp.DB.Rocks as M
 import Dscp.DB.SQLite as M

--- a/src/Dscp/DB/Real.hs
+++ b/src/Dscp/DB/Real.hs
@@ -1,5 +1,0 @@
-
-module Dscp.DB.Real (module M) where
-
-import Dscp.DB.Real.Functions as M
-import Dscp.DB.Real.Types as M

--- a/src/Dscp/DB/Rocks.hs
+++ b/src/Dscp/DB/Rocks.hs
@@ -1,0 +1,4 @@
+module Dscp.DB.Rocks (module M) where
+
+import Dscp.DB.Rocks.Class as M
+import Dscp.DB.Rocks.Real as M

--- a/src/Dscp/DB/Rocks.hs
+++ b/src/Dscp/DB/Rocks.hs
@@ -1,4 +1,4 @@
 module Dscp.DB.Rocks (module M) where
 
 import Dscp.DB.Rocks.Class as M
-import Dscp.DB.Rocks.Real as M
+import Dscp.DB.Rocks.Real as M hiding (DB)

--- a/src/Dscp/DB/Rocks/Class.hs
+++ b/src/Dscp/DB/Rocks/Class.hs
@@ -1,4 +1,4 @@
-module Dscp.DB.Class where
+module Dscp.DB.Rocks.Class where
 
 import Universum
 

--- a/src/Dscp/DB/Rocks/Real.hs
+++ b/src/Dscp/DB/Rocks/Real.hs
@@ -1,0 +1,5 @@
+
+module Dscp.DB.Rocks.Real (module M) where
+
+import Dscp.DB.Rocks.Real.Functions as M
+import Dscp.DB.Rocks.Real.Types as M

--- a/src/Dscp/DB/Rocks/Real/Functions.hs
+++ b/src/Dscp/DB/Rocks/Real/Functions.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TypeApplications #-}
 
-module Dscp.DB.Real.Functions
+module Dscp.DB.Rocks.Real.Functions
        ( -- * Closing/opening
          openRocksDB
        , closeRocksDB
@@ -17,8 +17,8 @@ import Universum
 import qualified Database.RocksDB as Rocks
 import Ether.Internal (HasLens (..))
 
-import Dscp.DB.Class (MonadDB (..), MonadDBRead (..))
-import Dscp.DB.Real.Types (DB (..), DBParams (..), MonadRealDB, NodeDB (..), ndbDatabase)
+import Dscp.DB.Rocks.Class (MonadDB (..), MonadDBRead (..))
+import Dscp.DB.Rocks.Real.Types (DB (..), DBParams (..), MonadRealDB, NodeDB (..), ndbDatabase)
 
 -----------------------------------------------------------
 -- Opening/closing

--- a/src/Dscp/DB/Rocks/Real/Functions.hs
+++ b/src/Dscp/DB/Rocks/Real/Functions.hs
@@ -18,7 +18,7 @@ import qualified Database.RocksDB as Rocks
 import Ether.Internal (HasLens (..))
 
 import Dscp.DB.Rocks.Class (MonadDB (..), MonadDBRead (..))
-import Dscp.DB.Rocks.Real.Types (DB (..), DBParams (..), MonadRealDB, NodeDB (..), ndbDatabase)
+import Dscp.DB.Rocks.Real.Types (DB (..), MonadRealDB, RocksDB (..), RocksDBParams (..), rdDatabase)
 
 -----------------------------------------------------------
 -- Opening/closing
@@ -38,11 +38,11 @@ openRocksDB path = do
 closeRocksDB :: MonadIO m => DB -> m ()
 closeRocksDB = Rocks.close . rocksDB
 
-openNodeDB :: MonadIO m => DBParams -> m NodeDB
-openNodeDB DBParams{..} = NodeDB <$> openRocksDB dbpPath
+openNodeDB :: MonadIO m => RocksDBParams -> m RocksDB
+openNodeDB RocksDBParams{..} = RocksDB <$> openRocksDB rdpPath
 
-closeNodeDB :: MonadIO m => NodeDB -> m ()
-closeNodeDB = closeRocksDB . _ndbDatabase
+closeNodeDB :: MonadIO m => RocksDB -> m ()
+closeNodeDB = closeRocksDB . _rdDatabase
 
 ------------------------------------------------------------
 -- Reading/writing
@@ -64,8 +64,8 @@ rocksDelete k DB {..} = Rocks.delete rocksDB rocksWriteOpts k
 -- Instances
 ------------------------------------------------------------
 
-getDB :: (MonadReader ctx m, HasLens NodeDB ctx NodeDB) => m DB
-getDB = view $ lensOf @NodeDB . ndbDatabase
+getDB :: (MonadReader ctx m, HasLens RocksDB ctx RocksDB) => m DB
+getDB = view $ lensOf @RocksDB . rdDatabase
 
 instance MonadRealDB ctx m => MonadDBRead m where
     dbGet key = getDB >>= rocksGetBytes key

--- a/src/Dscp/DB/Rocks/Real/Types.hs
+++ b/src/Dscp/DB/Rocks/Real/Types.hs
@@ -1,4 +1,4 @@
-module Dscp.DB.Real.Types
+module Dscp.DB.Rocks.Real.Types
        ( MonadRealDB
        , DB (..)
        , DBParams (..)

--- a/src/Dscp/DB/Rocks/Real/Types.hs
+++ b/src/Dscp/DB/Rocks/Real/Types.hs
@@ -1,9 +1,9 @@
 module Dscp.DB.Rocks.Real.Types
        ( MonadRealDB
        , DB (..)
-       , DBParams (..)
-       , NodeDB (..)
-       , ndbDatabase
+       , RocksDBParams (..)
+       , RocksDB (..)
+       , rdDatabase
        ) where
 
 import Universum
@@ -15,11 +15,12 @@ import Ether.Internal (HasLens)
 -- | Set of constraints necessary to operate on real DB.
 type MonadRealDB ctx m =
     ( MonadReader ctx m
-    , HasLens NodeDB ctx NodeDB
+    , HasLens RocksDB ctx RocksDB
     , MonadIO m
     , Monad m
     )
 
+-- | Internal helper to carry Rocks parameters and handlers.
 data DB = DB
     { rocksReadOpts  :: !Rocks.ReadOptions
     , rocksWriteOpts :: !Rocks.WriteOptions
@@ -28,13 +29,13 @@ data DB = DB
     }
 
 -- | Set of parameters provided on opening connection.
-data DBParams = DBParams
-    { dbpPath :: !FilePath
+data RocksDBParams = RocksDBParams
+    { rdpPath :: !FilePath
     -- ^ Path to the database
     } deriving Show
 
-data NodeDB = NodeDB
-    { _ndbDatabase :: !DB
+data RocksDB = RocksDB
+    { _rdDatabase :: !DB
     }
 
-makeLenses ''NodeDB
+makeLenses ''RocksDB

--- a/src/Dscp/DB/SQLite.hs
+++ b/src/Dscp/DB/SQLite.hs
@@ -1,0 +1,5 @@
+
+module Dscp.DB.SQLite (module M) where
+
+import Dscp.DB.SQLite.Functions as M
+import Dscp.DB.SQLite.Types as M

--- a/src/Dscp/DB/SQLite.hs
+++ b/src/Dscp/DB/SQLite.hs
@@ -1,5 +1,6 @@
 
 module Dscp.DB.SQLite (module M) where
 
+import Dscp.DB.SQLite.Class as M
 import Dscp.DB.SQLite.Functions as M
 import Dscp.DB.SQLite.Types as M

--- a/src/Dscp/DB/SQLite/Class.hs
+++ b/src/Dscp/DB/SQLite/Class.hs
@@ -1,0 +1,22 @@
+module Dscp.DB.SQLite.Class where
+
+import Universum
+
+import Database.SQLite.Simple (FromRow, Query, ToRow)
+
+-- There are more functions in that library, feel free
+-- to add them to typeclass below if there are needed.
+
+-- | Full interface to SQLite DB.
+class Monad m => MonadSQLiteDB m where
+    -- | Make a simple @INSERT@ or other SQL query.
+    query :: (FromRow row, ToRow params) => Query -> params -> m [row]
+
+    -- | Make an @INSERT@ SQL query, feeding result to given function on per-row
+    -- basis.
+    queryStreamed
+        :: (FromRow row, ToRow params)
+        => Query -> params -> a -> (a -> row -> m a) -> m a
+
+    -- | Perform a simple SQL query which does not return any result.
+    execute :: ToRow q => Query -> q -> m ()

--- a/src/Dscp/DB/SQLite/Error.hs
+++ b/src/Dscp/DB/SQLite/Error.hs
@@ -1,0 +1,38 @@
+-- | Exceptions happening during work with SQLLite.
+
+module Dscp.DB.SQLite.Error
+    ( SQLConnectionOpenningError (..)
+    , SQLRequestError (..)
+    , rethrowSQLRequestError
+    ) where
+
+import Universum
+
+import Database.SQLite.Simple as SQLite
+import Dscp.Util (wrapRethrow)
+
+-- | All errors which may happen on DB openning.
+data SQLConnectionOpenningError
+    = SQLInvalidPathError !FilePath
+      -- ^ Used 'SQLiteReal' constructor with bad filepath
+    | SQLConnectionOpenningError !Text
+      -- ^ Exception in SQL backend, doc doesn't specify which one
+    deriving (Show)
+
+instance Exception SQLConnectionOpenningError
+
+-- | All errors which may happen on any SQL query.
+data SQLRequestError
+    = SQLFormatError SQLite.FormatError
+      -- ^ Query string mismatched with given parameters.
+    | SQLResultError SQLite.ResultError
+      -- ^ Result conversion failed.
+    deriving (Show)
+
+instance Exception SQLRequestError
+
+-- | Wrap possible appropriate exceptions into 'SQLRequestError'.
+rethrowSQLRequestError :: MonadCatch m => m a -> m a
+rethrowSQLRequestError =
+    wrapRethrow SQLFormatError .
+    wrapRethrow SQLResultError

--- a/src/Dscp/DB/SQLite/Functions.hs
+++ b/src/Dscp/DB/SQLite/Functions.hs
@@ -9,20 +9,20 @@ module Dscp.DB.SQLite.Functions
 import Universum
 
 import qualified Database.SQLite.Simple as Lower
+import Ether.Internal (HasLens (..))
 
+import Dscp.DB.SQLite.Class (MonadSQLiteDB (..))
+import Dscp.DB.SQLite.Error (SQLConnectionOpenningError (..), rethrowSQLRequestError)
 import Dscp.DB.SQLite.Types (SQLiteDB (..), SQLiteDBLocation (..), SQLiteParams (..))
+import Dscp.Launcher.Mode (RIO, runRIO)
+import Dscp.Util (wrapRethrowIO)
 
 -----------------------------------------------------------
 -- Opening/closing
 -----------------------------------------------------------
 
-newtype InvalidSQLitePathException = InvalidSQLitePathException FilePath
-    deriving (Show)
-
-instance Exception InvalidSQLitePathException
-
 openSQLiteDB
-    :: (MonadIO m, MonadThrow m)
+    :: (MonadIO m, MonadCatch m)
     => SQLiteParams -> m SQLiteDB
 openSQLiteDB SQLiteParams{..} = do
     path <- case sdpLocation of
@@ -31,10 +31,12 @@ openSQLiteDB SQLiteParams{..} = do
         SQLiteReal path ->
             -- some paths produce db in memory, can't use them
             if any (== path) ["", ":memory:"]
-            then throwM (InvalidSQLitePathException path)
+            then throwM (SQLInvalidPathError path)
             else return path
 
-    sdConn <- liftIO $ Lower.open path
+    sdConn <-
+        wrapRethrowIO @SomeException (SQLConnectionOpenningError . show) $
+        Lower.open path
     return SQLiteDB {..}
 
 closeSQLiteDB :: MonadIO m => SQLiteDB -> m ()
@@ -43,3 +45,18 @@ closeSQLiteDB = liftIO . Lower.close . sdConn
 ------------------------------------------------------------
 -- Instances
 ------------------------------------------------------------
+
+instance HasLens SQLiteDB ctx SQLiteDB => MonadSQLiteDB (RIO ctx) where
+    query q params =
+        rethrowSQLRequestError $ do
+            SQLiteDB{..} <- view $ lensOf @SQLiteDB
+            liftIO $ Lower.query sdConn q params
+    queryStreamed q params acc f =
+        rethrowSQLRequestError $ do
+            ctx <- ask
+            let SQLiteDB{..} = ctx ^. lensOf @SQLiteDB
+            liftIO $ Lower.fold sdConn q params acc (runRIO ctx ... f)
+    execute q params = do
+        rethrowSQLRequestError $ do
+            SQLiteDB{..} <- view $ lensOf @SQLiteDB
+            liftIO $ Lower.execute sdConn q params

--- a/src/Dscp/DB/SQLite/Functions.hs
+++ b/src/Dscp/DB/SQLite/Functions.hs
@@ -14,7 +14,7 @@ import Ether.Internal (HasLens (..))
 import Dscp.DB.SQLite.Class (MonadSQLiteDB (..))
 import Dscp.DB.SQLite.Error (SQLConnectionOpenningError (..), rethrowSQLRequestError)
 import Dscp.DB.SQLite.Types (SQLiteDB (..), SQLiteDBLocation (..), SQLiteParams (..))
-import Dscp.Launcher.Mode (RIO, runRIO)
+import Dscp.Launcher.Rio (RIO, runRIO)
 import Dscp.Util (wrapRethrowIO)
 
 -----------------------------------------------------------

--- a/src/Dscp/DB/SQLite/Functions.hs
+++ b/src/Dscp/DB/SQLite/Functions.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Dscp.DB.SQLite.Functions
+       ( -- * Closing/opening
+         openSQLiteDB
+       , closeSQLiteDB
+       ) where
+
+import Universum
+
+import qualified Database.SQLite.Simple as Lower
+
+import Dscp.DB.SQLite.Types (SQLiteDB (..), SQLiteDBLocation (..), SQLiteParams (..))
+
+-----------------------------------------------------------
+-- Opening/closing
+-----------------------------------------------------------
+
+newtype InvalidSQLitePathException = InvalidSQLitePathException FilePath
+    deriving (Show)
+
+instance Exception InvalidSQLitePathException
+
+openSQLiteDB
+    :: (MonadIO m, MonadThrow m)
+    => SQLiteParams -> m SQLiteDB
+openSQLiteDB SQLiteParams{..} = do
+    path <- case sdpLocation of
+        SQLiteInMemory ->
+            return ":memory:"
+        SQLiteReal path ->
+            -- some paths produce db in memory, can't use them
+            if any (== path) ["", ":memory:"]
+            then throwM (InvalidSQLitePathException path)
+            else return path
+
+    sdConn <- liftIO $ Lower.open path
+    return SQLiteDB {..}
+
+closeSQLiteDB :: MonadIO m => SQLiteDB -> m ()
+closeSQLiteDB = liftIO . Lower.close . sdConn
+
+------------------------------------------------------------
+-- Instances
+------------------------------------------------------------

--- a/src/Dscp/DB/SQLite/Types.hs
+++ b/src/Dscp/DB/SQLite/Types.hs
@@ -1,6 +1,5 @@
 module Dscp.DB.SQLite.Types
-       ( MonadSQLiteDB
-       , SQLiteDBLocation (..)
+       ( SQLiteDBLocation (..)
        , SQLiteDB (..)
        , SQLiteParams (..)
        ) where
@@ -8,15 +7,6 @@ module Dscp.DB.SQLite.Types
 import Universum
 
 import Database.SQLite.Simple (Connection)
-import Ether.Internal (HasLens)
-
--- | Set of constraints necessary to operate on SQLite database.
-type MonadSQLiteDB ctx m =
-    ( MonadReader ctx m
-    , HasLens SQLiteDB ctx SQLiteDB
-    , MonadIO m
-    , Monad m
-    )
 
 -- | Where database lies.
 data SQLiteDBLocation

--- a/src/Dscp/DB/SQLite/Types.hs
+++ b/src/Dscp/DB/SQLite/Types.hs
@@ -1,0 +1,30 @@
+module Dscp.DB.SQLite.Types
+       ( MonadSQLiteDB
+       , SQLiteDBLocation (..)
+       , SQLiteDB (..)
+       , SQLiteParams (..)
+       ) where
+
+import Universum
+
+import Database.SQLite.Simple (Connection)
+import Ether.Internal (HasLens)
+
+-- | Set of constraints necessary to operate on SQLite database.
+type MonadSQLiteDB ctx m =
+    ( MonadReader ctx m
+    , HasLens SQLiteDB ctx SQLiteDB
+    , MonadIO m
+    , Monad m
+    )
+
+-- | Where database lies.
+data SQLiteDBLocation
+    = SQLiteReal !FilePath  -- ^ In given file
+    | SQLiteInMemory        -- ^ In memory
+
+data SQLiteParams = SQLiteParams
+    { sdpLocation :: SQLiteDBLocation
+    }
+
+newtype SQLiteDB = SQLiteDB { sdConn :: Connection }

--- a/src/Dscp/Educator/Launcher/Mode.hs
+++ b/src/Dscp/Educator/Launcher/Mode.hs
@@ -12,7 +12,7 @@ module Dscp.Educator.Launcher.Mode
     , EducatorContext (..)
     , EducatorRealMode
     , ecWitnessCtx
-    , ecSqliteDB
+    , ecDB
     ) where
 
 import Universum
@@ -48,7 +48,7 @@ type CombinedWorkMode m =
 
 data EducatorContext = EducatorContext
     { _ecWitnessCtx :: Witness.WitnessContext
-    , _ecSqliteDB   :: SQLiteDB
+    , _ecDB         :: SQLiteDB
     }
 
 makeLenses ''EducatorContext
@@ -66,4 +66,4 @@ instance HasLens LoggingIO EducatorContext LoggingIO where
     lensOf = ecWitnessCtx . Witness.wcLogging
 
 instance HasLens SQLiteDB EducatorContext SQLiteDB where
-    lensOf = ecSqliteDB
+    lensOf = ecDB

--- a/src/Dscp/Educator/Launcher/Mode.hs
+++ b/src/Dscp/Educator/Launcher/Mode.hs
@@ -20,7 +20,7 @@ import Universum
 import Control.Lens (makeLenses)
 import Loot.Log.Rio (LoggingIO)
 
-import Dscp.DB.Rocks.Real.Types (NodeDB)
+import Dscp.DB.Rocks.Real.Types (RocksDB)
 import Dscp.DB.SQLite (MonadSQLiteDB, SQLiteDB)
 import qualified Dscp.Launcher.Mode as Basic
 import qualified Dscp.Witness.Launcher as Witness
@@ -59,7 +59,7 @@ type EducatorRealMode = Basic.RIO EducatorContext
 -- Instances
 ---------------------------------------------------------------------
 
-instance HasLens NodeDB EducatorContext NodeDB where
+instance HasLens RocksDB EducatorContext RocksDB where
     lensOf = ecWitnessCtx . Witness.wcDB
 
 instance HasLens LoggingIO EducatorContext LoggingIO where

--- a/src/Dscp/Educator/Launcher/Mode.hs
+++ b/src/Dscp/Educator/Launcher/Mode.hs
@@ -12,6 +12,7 @@ module Dscp.Educator.Launcher.Mode
     , EducatorContext (..)
     , EducatorRealMode
     , ecWitnessCtx
+    , ecSqliteDB
     ) where
 
 import Universum
@@ -20,6 +21,7 @@ import Control.Lens (makeLenses)
 import Loot.Log.Rio (LoggingIO)
 
 import Dscp.DB.Real.Types (NodeDB)
+import Dscp.DB.SQLite (SQLiteDB)
 import qualified Dscp.Launcher.Mode as Basic
 import qualified Dscp.Witness.Launcher as Witness
 import Ether.Internal (HasLens (..))
@@ -45,6 +47,7 @@ type CombinedWorkMode m =
 
 data EducatorContext = EducatorContext
     { _ecWitnessCtx :: Witness.WitnessContext
+    , _ecSqliteDB   :: SQLiteDB
     }
 
 makeLenses ''EducatorContext

--- a/src/Dscp/Educator/Launcher/Mode.hs
+++ b/src/Dscp/Educator/Launcher/Mode.hs
@@ -21,7 +21,7 @@ import Control.Lens (makeLenses)
 import Loot.Log.Rio (LoggingIO)
 
 import Dscp.DB.Real.Types (NodeDB)
-import Dscp.DB.SQLite (SQLiteDB)
+import Dscp.DB.SQLite (MonadSQLiteDB, SQLiteDB)
 import qualified Dscp.Launcher.Mode as Basic
 import qualified Dscp.Witness.Launcher as Witness
 import Ether.Internal (HasLens (..))
@@ -33,6 +33,7 @@ import Ether.Internal (HasLens (..))
 -- | Set of typeclasses which define capabilities of bare Educator node.
 type EducatorWorkMode m =
     ( Basic.BasicWorkMode m
+    , MonadSQLiteDB m
     )
 
 -- | Set of typeclasses which define capabilities both of Educator and Witness.
@@ -63,3 +64,6 @@ instance HasLens NodeDB EducatorContext NodeDB where
 
 instance HasLens LoggingIO EducatorContext LoggingIO where
     lensOf = ecWitnessCtx . Witness.wcLogging
+
+instance HasLens SQLiteDB EducatorContext SQLiteDB where
+    lensOf = ecSqliteDB

--- a/src/Dscp/Educator/Launcher/Mode.hs
+++ b/src/Dscp/Educator/Launcher/Mode.hs
@@ -20,7 +20,7 @@ import Universum
 import Control.Lens (makeLenses)
 import Loot.Log.Rio (LoggingIO)
 
-import Dscp.DB.Real.Types (NodeDB)
+import Dscp.DB.Rocks.Real.Types (NodeDB)
 import Dscp.DB.SQLite (MonadSQLiteDB, SQLiteDB)
 import qualified Dscp.Launcher.Mode as Basic
 import qualified Dscp.Witness.Launcher as Witness

--- a/src/Dscp/Educator/Launcher/Mode.hs
+++ b/src/Dscp/Educator/Launcher/Mode.hs
@@ -23,6 +23,7 @@ import Loot.Log.Rio (LoggingIO)
 import Dscp.DB.Rocks.Real.Types (RocksDB)
 import Dscp.DB.SQLite (MonadSQLiteDB, SQLiteDB)
 import qualified Dscp.Launcher.Mode as Basic
+import Dscp.Launcher.Rio (RIO)
 import qualified Dscp.Witness.Launcher as Witness
 import Ether.Internal (HasLens (..))
 
@@ -53,7 +54,7 @@ data EducatorContext = EducatorContext
 
 makeLenses ''EducatorContext
 
-type EducatorRealMode = Basic.RIO EducatorContext
+type EducatorRealMode = RIO EducatorContext
 
 ---------------------------------------------------------------------
 -- Instances

--- a/src/Dscp/Educator/Launcher/Params.hs
+++ b/src/Dscp/Educator/Launcher/Params.hs
@@ -7,6 +7,6 @@ import Dscp.Witness.Launcher.Params (WitnessParams)
 data EducatorParams = EducatorParams
     { epWitnessParams :: !WitnessParams
     -- ^ Witness parameters
-    , epSQLiteParams  :: !SQLiteParams
+    , epDBParams      :: !SQLiteParams
     -- ^ Handler to SQLite database
     }

--- a/src/Dscp/Educator/Launcher/Params.hs
+++ b/src/Dscp/Educator/Launcher/Params.hs
@@ -1,9 +1,12 @@
 module Dscp.Educator.Launcher.Params where
 
+import Dscp.DB.SQLite (SQLiteParams)
 import Dscp.Witness.Launcher.Params (WitnessParams)
 
 -- | Contains all initialization parameters of Educator node.
 data EducatorParams = EducatorParams
     { epWitnessParams :: !WitnessParams
     -- ^ Witness parameters
+    , epSQLiteParams  :: !SQLiteParams
+    -- ^ Handler to SQLite database
     }

--- a/src/Dscp/Educator/Launcher/Resource.hs
+++ b/src/Dscp/Educator/Launcher/Resource.hs
@@ -7,6 +7,7 @@ module Dscp.Educator.Launcher.Resource
 
 import Universum
 
+import Dscp.DB.SQLite (SQLiteDB)
 import Dscp.Educator.Launcher.Params (EducatorParams (..))
 import Dscp.Launcher.Resource (AllocResource (..))
 import qualified Dscp.Witness.Launcher.Resource as Witness
@@ -15,10 +16,11 @@ import qualified Dscp.Witness.Launcher.Resource as Witness
 -- to start working.
 data EducatorResources = EducatorResources
     { erWitnessResources :: !Witness.WitnessResources
+    , erSQLiteDB         :: !SQLiteDB
     }
 
 instance AllocResource EducatorParams EducatorResources where
     allocResource EducatorParams{..} = do
         erWitnessResources <- allocResource epWitnessParams
+        erSQLiteDB <- allocResource epSQLiteParams
         return EducatorResources {..}
-

--- a/src/Dscp/Educator/Launcher/Resource.hs
+++ b/src/Dscp/Educator/Launcher/Resource.hs
@@ -16,11 +16,11 @@ import qualified Dscp.Witness.Launcher.Resource as Witness
 -- to start working.
 data EducatorResources = EducatorResources
     { erWitnessResources :: !Witness.WitnessResources
-    , erSQLiteDB         :: !SQLiteDB
+    , erDB               :: !SQLiteDB
     }
 
 instance AllocResource EducatorParams EducatorResources where
     allocResource EducatorParams{..} = do
         erWitnessResources <- allocResource epWitnessParams
-        erSQLiteDB <- allocResource epSQLiteParams
+        erDB <- allocResource epDBParams
         return EducatorResources {..}

--- a/src/Dscp/Educator/Launcher/Runner.hs
+++ b/src/Dscp/Educator/Launcher/Runner.hs
@@ -19,6 +19,7 @@ formEducatorContext :: EducatorResources -> EducatorContext
 formEducatorContext EducatorResources{..} =
     EducatorContext
     { _ecWitnessCtx = formWitnessContext erWitnessResources
+    , _ecSqliteDB = erSQLiteDB
     }
 
 runEducatorRealMode :: EducatorContext -> EducatorRealMode a -> IO a

--- a/src/Dscp/Educator/Launcher/Runner.hs
+++ b/src/Dscp/Educator/Launcher/Runner.hs
@@ -19,7 +19,7 @@ formEducatorContext :: EducatorResources -> EducatorContext
 formEducatorContext EducatorResources{..} =
     EducatorContext
     { _ecWitnessCtx = formWitnessContext erWitnessResources
-    , _ecSqliteDB = erSQLiteDB
+    , _ecDB = erDB
     }
 
 runEducatorRealMode :: EducatorContext -> EducatorRealMode a -> IO a

--- a/src/Dscp/Educator/Launcher/Runner.hs
+++ b/src/Dscp/Educator/Launcher/Runner.hs
@@ -10,8 +10,8 @@ import Control.Monad.Component (runComponentM)
 import Dscp.Educator.Launcher.Mode (EducatorContext (..), EducatorRealMode)
 import Dscp.Educator.Launcher.Params (EducatorParams (..))
 import Dscp.Educator.Launcher.Resource (EducatorResources (..))
-import Dscp.Launcher.Mode (runRIO)
 import Dscp.Launcher.Resource (AllocResource (..))
+import Dscp.Launcher.Rio (runRIO)
 import Dscp.Witness.Launcher.Runner (formWitnessContext)
 
 -- | Make up Educator context from dedicated pack of allocated resources.

--- a/src/Dscp/Launcher/Mode.hs
+++ b/src/Dscp/Launcher/Mode.hs
@@ -21,19 +21,11 @@ module Dscp.Launcher.Mode
        (
          -- * Constraints
          BasicWorkMode
-
-         -- * RIO monad
-       , RIO (..)
-       , runRIO
        ) where
 
 import Universum
 
-import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
-import Ether.Internal (HasLens)
-import Loot.Log (ModifyLogName (..), MonadLogging (..), WithLogging)
-import Loot.Log.Rio (LoggingIO)
-import qualified Loot.Log.Rio as Rio
+import Loot.Log (WithLogging)
 import UnliftIO (MonadUnliftIO)
 
 ---------------------------------------------------------------------
@@ -46,33 +38,3 @@ type BasicWorkMode m =
     , MonadIO m
     , MonadUnliftIO m  -- allows to use lifted-async
     )
-
----------------------------------------------------------------------
--- WorkMode implementations
----------------------------------------------------------------------
-
-{- | Conventional "ReaderT over IO" monad stack.
-
-Lootbox bases on 'caps' library which allows the only 'ReaderT' instance for
-used typeclasses, e.g.
-@instance (r ~ Capabilities caps) => MonadLogging (ReaderT r IO)@.
-To avoid instances overlapping, we use this wrapper.
-
-This also allows us to remorselessly define one global
-@instance HasLens Smth ctx Smth => MonadSmth (RIO ctx)@ per every @Smth@.
--}
-newtype RIO ctx a = RIO { unRIO :: ReaderT ctx IO a }
-    deriving (Functor, Applicative, Monad, MonadIO, MonadReader ctx,
-              MonadThrow, MonadCatch, MonadMask)
-
-runRIO :: MonadIO m => ctx -> RIO ctx a -> m a
-runRIO ctx (RIO act) = liftIO $ runReaderT act ctx
-
-instance HasLens LoggingIO ctx LoggingIO =>
-         MonadLogging (RIO ctx) where
-    log = Rio.defaultLog
-    logName = Rio.defaultLogName
-
-instance HasLens LoggingIO ctx LoggingIO =>
-         ModifyLogName (RIO ctx) where
-    modifyLogNameSel = Rio.defaultModifyLogNameSel

--- a/src/Dscp/Launcher/Resource.hs
+++ b/src/Dscp/Launcher/Resource.hs
@@ -18,8 +18,8 @@ import System.Wlog (maybeLogsDirB, parseLoggerConfig, productionB, removeAllHand
 
 import Dscp.DB.Rocks.Real (RocksDB, RocksDBParams, closeNodeDB, openNodeDB)
 import Dscp.DB.SQLite (SQLiteDB, SQLiteParams, closeSQLiteDB, openSQLiteDB)
-import Dscp.Launcher.Mode (runRIO)
 import Dscp.Launcher.Params (LoggingParams (..))
+import Dscp.Launcher.Rio (runRIO)
 
 ----------------------------------------------------------------------------
 -- Resources

--- a/src/Dscp/Launcher/Resource.hs
+++ b/src/Dscp/Launcher/Resource.hs
@@ -17,6 +17,7 @@ import Loot.Log.Warper (LoggerConfig, prepareLogWarper)
 import System.Wlog (maybeLogsDirB, parseLoggerConfig, productionB, removeAllHandlers, showTidB)
 
 import Dscp.DB.Real (DBParams, NodeDB, closeNodeDB, openNodeDB)
+import Dscp.DB.SQLite (SQLiteDB, SQLiteParams, closeSQLiteDB, openSQLiteDB)
 import Dscp.Launcher.Mode (runRIO)
 import Dscp.Launcher.Params (LoggingParams (..))
 
@@ -65,3 +66,6 @@ instance AllocResource LoggingParams LoggingIO where
 
 instance AllocResource DBParams NodeDB where
     allocResource p = buildComponent "RocksDB" (openNodeDB p) closeNodeDB
+
+instance AllocResource SQLiteParams SQLiteDB where
+    allocResource p = buildComponent "SQLite DB" (openSQLiteDB p) closeSQLiteDB

--- a/src/Dscp/Launcher/Resource.hs
+++ b/src/Dscp/Launcher/Resource.hs
@@ -16,7 +16,7 @@ import Loot.Log.Rio (LoggingIO)
 import Loot.Log.Warper (LoggerConfig, prepareLogWarper)
 import System.Wlog (maybeLogsDirB, parseLoggerConfig, productionB, removeAllHandlers, showTidB)
 
-import Dscp.DB.Rocks.Real (DBParams, NodeDB, closeNodeDB, openNodeDB)
+import Dscp.DB.Rocks.Real (RocksDB, RocksDBParams, closeNodeDB, openNodeDB)
 import Dscp.DB.SQLite (SQLiteDB, SQLiteParams, closeSQLiteDB, openSQLiteDB)
 import Dscp.Launcher.Mode (runRIO)
 import Dscp.Launcher.Params (LoggingParams (..))
@@ -64,7 +64,7 @@ instance AllocResource LoggingParams LoggingIO where
 -- Bracket
 ----------------------------------------------------------------------------
 
-instance AllocResource DBParams NodeDB where
+instance AllocResource RocksDBParams RocksDB where
     allocResource p = buildComponent "RocksDB" (openNodeDB p) closeNodeDB
 
 instance AllocResource SQLiteParams SQLiteDB where

--- a/src/Dscp/Launcher/Resource.hs
+++ b/src/Dscp/Launcher/Resource.hs
@@ -16,7 +16,7 @@ import Loot.Log.Rio (LoggingIO)
 import Loot.Log.Warper (LoggerConfig, prepareLogWarper)
 import System.Wlog (maybeLogsDirB, parseLoggerConfig, productionB, removeAllHandlers, showTidB)
 
-import Dscp.DB.Real (DBParams, NodeDB, closeNodeDB, openNodeDB)
+import Dscp.DB.Rocks.Real (DBParams, NodeDB, closeNodeDB, openNodeDB)
 import Dscp.DB.SQLite (SQLiteDB, SQLiteParams, closeSQLiteDB, openSQLiteDB)
 import Dscp.Launcher.Mode (runRIO)
 import Dscp.Launcher.Params (LoggingParams (..))

--- a/src/Dscp/Launcher/Rio.hs
+++ b/src/Dscp/Launcher/Rio.hs
@@ -1,0 +1,40 @@
+-- | RIO monad we may wish to use all over the project.
+
+module Dscp.Launcher.Rio
+    ( RIO (..)
+    , runRIO
+    ) where
+
+import Universum
+
+import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
+import Ether.Internal (HasLens)
+import Loot.Log (ModifyLogName (..), MonadLogging (..))
+import Loot.Log.Rio (LoggingIO)
+import qualified Loot.Log.Rio as Rio
+
+{- | Conventional "ReaderT over IO" monad stack.
+
+Lootbox bases on 'caps' library which allows the only 'ReaderT' instance for
+used typeclasses, e.g.
+@instance (r ~ Capabilities caps) => MonadLogging (ReaderT r IO)@.
+To avoid instances overlapping, we use this wrapper.
+
+This also allows us to remorselessly define one global
+@instance HasLens Smth ctx Smth => MonadSmth (RIO ctx)@ per every @Smth@.
+-}
+newtype RIO ctx a = RIO { unRIO :: ReaderT ctx IO a }
+    deriving (Functor, Applicative, Monad, MonadIO, MonadReader ctx,
+              MonadThrow, MonadCatch, MonadMask)
+
+runRIO :: MonadIO m => ctx -> RIO ctx a -> m a
+runRIO ctx (RIO act) = liftIO $ runReaderT act ctx
+
+instance HasLens LoggingIO ctx LoggingIO =>
+         MonadLogging (RIO ctx) where
+    log = Rio.defaultLog
+    logName = Rio.defaultLogName
+
+instance HasLens LoggingIO ctx LoggingIO =>
+         ModifyLogName (RIO ctx) where
+    modifyLogNameSel = Rio.defaultModifyLogNameSel

--- a/src/Dscp/Transport/TCP.hs
+++ b/src/Dscp/Transport/TCP.hs
@@ -19,7 +19,7 @@ import Network.Transport.Abstract (Transport)
 import Network.Transport.Concrete (concrete)
 import qualified Network.Transport.TCP as TCP
 
-import Dscp.Launcher.Mode (RIO, runRIO)
+import Dscp.Launcher.Rio (RIO, runRIO)
 
 bracketTransportTCP
     :: ( MonadIO n

--- a/src/Dscp/Util.hs
+++ b/src/Dscp/Util.hs
@@ -3,6 +3,8 @@
 
 module Dscp.Util
        ( anyMapM
+       , wrapRethrow
+       , wrapRethrowIO
          -- * Re-exports
        , module Snowdrop.Util
        ) where
@@ -19,3 +21,16 @@ anyMapM _ [] = return False
 anyMapM f (a:as) = f a >>= \case
     True -> return True
     False -> anyMapM f as
+
+-- | Converts a possible error, used for wrapping exceptions using given
+-- constructor into ADT-sum of exceptions.
+wrapRethrow
+    :: (Exception e1, Exception e2, MonadCatch m)
+    => (e1 -> e2) -> m a -> m a
+wrapRethrow wrap action = catch action (throwM . wrap)
+
+-- | Handy for wrapping exceptions provided by libraries.
+wrapRethrowIO
+    :: (Exception e1, Exception e2, MonadCatch m, MonadIO m)
+    => (e1 -> e2) -> IO a -> m a
+wrapRethrowIO wrap action = wrapRethrow wrap (liftIO action)

--- a/src/Dscp/Witness/Launcher/Mode.hs
+++ b/src/Dscp/Witness/Launcher/Mode.hs
@@ -21,6 +21,7 @@ import Loot.Log.Rio (LoggingIO)
 import Dscp.DB.Rocks.Class (MonadDB)
 import Dscp.DB.Rocks.Real.Types (RocksDB)
 import qualified Dscp.Launcher.Mode as Basic
+import Dscp.Launcher.Rio (RIO)
 
 ---------------------------------------------------------------------
 -- WorkMode class
@@ -43,7 +44,7 @@ data WitnessContext = WitnessContext
 
 makeLenses ''WitnessContext
 
-type WitnessRealMode = Basic.RIO WitnessContext
+type WitnessRealMode = RIO WitnessContext
 
 ---------------------------------------------------------------------
 -- Instances

--- a/src/Dscp/Witness/Launcher/Mode.hs
+++ b/src/Dscp/Witness/Launcher/Mode.hs
@@ -18,8 +18,8 @@ import Control.Lens (makeLenses)
 import Ether.Internal (HasLens (..))
 import Loot.Log.Rio (LoggingIO)
 
-import Dscp.DB.Class (MonadDB)
-import Dscp.DB.Real.Types (NodeDB)
+import Dscp.DB.Rocks.Class (MonadDB)
+import Dscp.DB.Rocks.Real.Types (NodeDB)
 import qualified Dscp.Launcher.Mode as Basic
 
 ---------------------------------------------------------------------

--- a/src/Dscp/Witness/Launcher/Mode.hs
+++ b/src/Dscp/Witness/Launcher/Mode.hs
@@ -19,7 +19,7 @@ import Ether.Internal (HasLens (..))
 import Loot.Log.Rio (LoggingIO)
 
 import Dscp.DB.Rocks.Class (MonadDB)
-import Dscp.DB.Rocks.Real.Types (NodeDB)
+import Dscp.DB.Rocks.Real.Types (RocksDB)
 import qualified Dscp.Launcher.Mode as Basic
 
 ---------------------------------------------------------------------
@@ -37,7 +37,7 @@ type WitnessWorkMode m =
 ---------------------------------------------------------------------
 
 data WitnessContext = WitnessContext
-    { _wcDB      :: NodeDB
+    { _wcDB      :: RocksDB
     , _wcLogging :: LoggingIO
     }
 
@@ -49,7 +49,7 @@ type WitnessRealMode = Basic.RIO WitnessContext
 -- Instances
 ---------------------------------------------------------------------
 
-instance HasLens NodeDB WitnessContext NodeDB where
+instance HasLens RocksDB WitnessContext RocksDB where
     lensOf = wcDB
 
 instance HasLens LoggingIO WitnessContext LoggingIO where

--- a/src/Dscp/Witness/Launcher/Params.hs
+++ b/src/Dscp/Witness/Launcher/Params.hs
@@ -4,13 +4,13 @@ module Dscp.Witness.Launcher.Params
 
 import Universum
 
-import Dscp.DB.Rocks.Real.Types (DBParams)
+import Dscp.DB.Rocks.Real.Types (RocksDBParams)
 import Dscp.Launcher.Params (LoggingParams)
 
 -- | Contains all initialization parameters of Witness node.
 data WitnessParams = WitnessParams
     { wpLoggingParams :: !LoggingParams
     -- ^ Basic parameters for any node
-    , wpDBParams      :: !DBParams
+    , wpDBParams      :: !RocksDBParams
     -- ^ DB parameters
     } deriving Show

--- a/src/Dscp/Witness/Launcher/Params.hs
+++ b/src/Dscp/Witness/Launcher/Params.hs
@@ -4,7 +4,7 @@ module Dscp.Witness.Launcher.Params
 
 import Universum
 
-import Dscp.DB.Real.Types (DBParams)
+import Dscp.DB.Rocks.Real.Types (DBParams)
 import Dscp.Launcher.Params (LoggingParams)
 
 -- | Contains all initialization parameters of Witness node.
@@ -14,4 +14,3 @@ data WitnessParams = WitnessParams
     , wpDBParams      :: !DBParams
     -- ^ DB parameters
     } deriving Show
-

--- a/src/Dscp/Witness/Launcher/Resource.hs
+++ b/src/Dscp/Witness/Launcher/Resource.hs
@@ -9,7 +9,7 @@ import Universum
 
 import Loot.Log.Rio (LoggingIO)
 
-import Dscp.DB.Rocks.Real (NodeDB)
+import Dscp.DB.Rocks.Real (RocksDB)
 import Dscp.Launcher.Resource (AllocResource (..))
 import Dscp.Witness.Launcher.Params (WitnessParams (..))
 
@@ -17,7 +17,7 @@ import Dscp.Witness.Launcher.Params (WitnessParams (..))
 -- working.
 data WitnessResources = WitnessResources
     { wrLogging :: !LoggingIO
-    , wrDB      :: !NodeDB
+    , wrDB      :: !RocksDB
     }
 
 instance AllocResource WitnessParams WitnessResources where

--- a/src/Dscp/Witness/Launcher/Resource.hs
+++ b/src/Dscp/Witness/Launcher/Resource.hs
@@ -9,7 +9,7 @@ import Universum
 
 import Loot.Log.Rio (LoggingIO)
 
-import Dscp.DB.Real (NodeDB)
+import Dscp.DB.Rocks.Real (NodeDB)
 import Dscp.Launcher.Resource (AllocResource (..))
 import Dscp.Witness.Launcher.Params (WitnessParams (..))
 

--- a/src/Dscp/Witness/Launcher/Runner.hs
+++ b/src/Dscp/Witness/Launcher/Runner.hs
@@ -7,8 +7,8 @@ import Universum
 
 import Control.Monad.Component (runComponentM)
 
-import Dscp.Launcher.Mode (runRIO)
 import Dscp.Launcher.Resource (AllocResource (..))
+import Dscp.Launcher.Rio (runRIO)
 import Dscp.Witness.Launcher.Mode (WitnessContext (..), WitnessRealMode)
 import Dscp.Witness.Launcher.Params (WitnessParams (..))
 import Dscp.Witness.Launcher.Resource (WitnessResources (..))

--- a/src/educator/EducatorParams.hs
+++ b/src/educator/EducatorParams.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ApplicativeDo #-}
 
 -- | Command-line options and flags for Educator node
 
@@ -10,17 +11,21 @@ import Universum
 
 import Options.Applicative (Parser, execParser, fullDesc, helper, info, progDesc)
 
-import Dscp.CLI (dbPathParser, logParamsParser, versionOption)
+import Dscp.CLI (dbPathParser, logParamsParser, sqliteDbPathParser, versionOption)
 import Dscp.Launcher (LoggingParams)
 
 data EducatorParams = EducatorParams
-    { epDbPath    :: !FilePath
-    , epLogParams :: !LoggingParams
+    { epDbPath       :: !FilePath
+    , epLogParams    :: !LoggingParams
+    , epSqliteDbPath :: !FilePath
     }
 
 educatorParamsParser :: Parser EducatorParams
-educatorParamsParser =
-    EducatorParams <$> dbPathParser <*> logParamsParser "educator"
+educatorParamsParser = do
+    epDbPath <- dbPathParser
+    epLogParams <- logParamsParser "educator"
+    epSqliteDbPath <- sqliteDbPathParser
+    return EducatorParams{..}
 
 getEducatorParams :: IO EducatorParams
 getEducatorParams =

--- a/src/educator/EducatorParams.hs
+++ b/src/educator/EducatorParams.hs
@@ -15,14 +15,14 @@ import Dscp.CLI (dbPathParser, logParamsParser, sqliteDbPathParser, versionOptio
 import Dscp.Launcher (LoggingParams)
 
 data EducatorParams = EducatorParams
-    { epDbPath       :: !FilePath
+    { epRocksDbPath  :: !FilePath
     , epLogParams    :: !LoggingParams
     , epSqliteDbPath :: !FilePath
     }
 
 educatorParamsParser :: Parser EducatorParams
 educatorParamsParser = do
-    epDbPath <- dbPathParser
+    epRocksDbPath <- dbPathParser
     epLogParams <- logParamsParser "educator"
     epSqliteDbPath <- sqliteDbPathParser
     return EducatorParams{..}

--- a/src/educator/Main.hs
+++ b/src/educator/Main.hs
@@ -21,7 +21,7 @@ main = do
                 { wpLoggingParams = epLogParams
                 , wpDBParams = RocksDBParams{ rdpPath = epRocksDbPath }
                 }
-            , epSQLiteParams = SQLiteParams
+            , epDBParams = SQLiteParams
                 { sdpLocation = SQLiteReal epSqliteDbPath }
             }
     launchEducatorRealMode educatorParams $

--- a/src/educator/Main.hs
+++ b/src/educator/Main.hs
@@ -7,7 +7,7 @@ import Universum
 
 import Loot.Log (logInfo, logWarning, modifyLogName)
 
-import Dscp.DB (DBParams (..))
+import Dscp.DB (DBParams (..), SQLiteDBLocation (..), SQLiteParams (..))
 import Dscp.Educator (EducatorParams (..), launchEducatorRealMode)
 import Dscp.Witness (WitnessParams (..))
 
@@ -21,6 +21,8 @@ main = do
                 { wpLoggingParams = epLogParams
                 , wpDBParams = DBParams{ dbpPath = epDbPath }
                 }
+            , epSQLiteParams = SQLiteParams
+                { sdpLocation = SQLiteReal epSqliteDbPath }
             }
     launchEducatorRealMode educatorParams $
       modifyLogName (<> "node") $ do

--- a/src/educator/Main.hs
+++ b/src/educator/Main.hs
@@ -7,7 +7,7 @@ import Universum
 
 import Loot.Log (logInfo, logWarning, modifyLogName)
 
-import Dscp.DB (DBParams (..), SQLiteDBLocation (..), SQLiteParams (..))
+import Dscp.DB (RocksDBParams (..), SQLiteDBLocation (..), SQLiteParams (..))
 import Dscp.Educator (EducatorParams (..), launchEducatorRealMode)
 import Dscp.Witness (WitnessParams (..))
 
@@ -19,7 +19,7 @@ main = do
     let educatorParams = EducatorParams
             { epWitnessParams = WitnessParams
                 { wpLoggingParams = epLogParams
-                , wpDBParams = DBParams{ dbpPath = epDbPath }
+                , wpDBParams = RocksDBParams{ rdpPath = epRocksDbPath }
                 }
             , epSQLiteParams = SQLiteParams
                 { sdpLocation = SQLiteReal epSqliteDbPath }

--- a/src/witness/Main.hs
+++ b/src/witness/Main.hs
@@ -14,7 +14,7 @@ import System.IO (getChar)
 import System.Random (mkStdGen)
 import UnliftIO.Async (async)
 
-import Dscp.DB (DBParams (..))
+import Dscp.DB (RocksDBParams (..))
 import Dscp.Listeners (witnessListeners)
 import Dscp.Messages (serialisePacking)
 import Dscp.Transport (bracketTransportTCP)
@@ -27,7 +27,7 @@ main = do
     Params.WitnessParams {..} <- Params.getWitnessParams
     let witnessParams = WitnessParams
             { wpLoggingParams = wpLogParams
-            , wpDBParams = DBParams{ dbpPath = wpDbPath }
+            , wpDBParams = RocksDBParams{ rdpPath = wpDbPath }
             }
     launchWitnessRealMode witnessParams $
       modifyLogName (<> "node") $ do


### PR DESCRIPTION
Within this PR we do:
* add access to SQL DB operations into context to educator
* along with adding dedicated typeclasses into workmode
* allowing both real and in-memory work in theory (thus no separated `SQLite/Real/*` modules)
* rename `DB` -> `RocksDB` for existing types/functions, move modules in `DB` into `Rocks` subfolder