### PR TITLE
Import Universum implicitely

### DIFF
--- a/hpack/definitions.yaml
+++ b/hpack/definitions.yaml
@@ -27,7 +27,6 @@ _definitions:
         - MultiParamTypeClasses
         - MultiWayIf
         - NamedFieldPuns
-        - NoImplicitPrelude
         - OverloadedStrings
         - RankNTypes
         - RecordWildCards

--- a/src/Dscp/Accounts/Account.hs
+++ b/src/Dscp/Accounts/Account.hs
@@ -3,8 +3,6 @@
 
 module Dscp.Accounts.Account where
 
-import Universum
-
 import Codec.Serialise (Serialise)
 import Control.Lens (makeLenses)
 import Data.Default (Default)

--- a/src/Dscp/CLI/Common.hs
+++ b/src/Dscp/CLI/Common.hs
@@ -14,8 +14,6 @@ module Dscp.CLI.Common
        , netServParamsParser
        ) where
 
-import Universum
-
 import qualified Data.Set as Set
 import Data.Version (showVersion)
 import qualified Loot.Log as Log

--- a/src/Dscp/Core/ATG.hs
+++ b/src/Dscp/Core/ATG.hs
@@ -12,8 +12,6 @@ module Dscp.Core.ATG
        , activityTypeGraphIndexed
        ) where
 
-import Universum
-
 import Control.Lens (makeLenses)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M

--- a/src/Dscp/Core/Types.hs
+++ b/src/Dscp/Core/Types.hs
@@ -39,8 +39,6 @@ module Dscp.Core.Types
        , ATG (..)
        ) where
 
-import Universum
-
 import Control.Lens (makeLenses)
 import Data.Map (Map)
 

--- a/src/Dscp/Crypto/ByteArray.hs
+++ b/src/Dscp/Crypto/ByteArray.hs
@@ -7,8 +7,6 @@ module Dscp.Crypto.ByteArray
        , hashBytes
        ) where
 
-import Universum
-
 import Crypto.Error (CryptoFailable, eitherCryptoError)
 import qualified Crypto.Hash as Crypto
 import qualified Crypto.PubKey.Ed25519 as Ed25519

--- a/src/Dscp/Crypto/Hash/Class.hs
+++ b/src/Dscp/Crypto/Hash/Class.hs
@@ -10,8 +10,6 @@ module Dscp.Crypto.Hash.Class
        , abstractHash
        ) where
 
-import Universum
-
 import Data.ByteArray (ByteArrayAccess)
 
 -- | Class of algorithms which can produce some hash value.

--- a/src/Dscp/Crypto/Hash/Cryptonite.hs
+++ b/src/Dscp/Crypto/Hash/Cryptonite.hs
@@ -7,8 +7,6 @@ module Dscp.Crypto.Hash.Cryptonite
        ( CryptoniteFunc
        ) where
 
-import Universum
-
 import Crypto.Hash (Digest, HashAlgorithm)
 import qualified Crypto.Hash as Crypto
 import Data.ByteArray (ByteArrayAccess, Bytes)

--- a/src/Dscp/Crypto/Hash/Hashable.hs
+++ b/src/Dscp/Crypto/Hash/Hashable.hs
@@ -7,8 +7,6 @@ module Dscp.Crypto.Hash.Hashable
        ( HashableFunc
        ) where
 
-import Universum
-
 import Data.Hashable (Hashable)
 import qualified Data.Hashable as H
 

--- a/src/Dscp/Crypto/Impl.hs
+++ b/src/Dscp/Crypto/Impl.hs
@@ -19,8 +19,6 @@ module Dscp.Crypto.Impl
        , unsafeVerify
        ) where
 
-import Universum
-
 import Crypto.Hash.Algorithms (Blake2sp_256)
 
 import Dscp.Crypto.Hash (AbstractHash (..), CryptoniteFunc, HasAbstractHash (..),

--- a/src/Dscp/Crypto/MerkleTree.hs
+++ b/src/Dscp/Crypto/MerkleTree.hs
@@ -24,8 +24,6 @@ module Dscp.Crypto.MerkleTree
        , mkLeaf
        ) where
 
-import Universum
-
 import Dscp.Crypto.Hash.Class (AbstractHash (..))
 import Dscp.Crypto.Impl (HasHash, Hash, hash, unsafeHash)
 import Dscp.Crypto.Serialise (Raw)

--- a/src/Dscp/Crypto/Serialise.hs
+++ b/src/Dscp/Crypto/Serialise.hs
@@ -6,8 +6,6 @@ module Dscp.Crypto.Serialise
        ( Raw
        ) where
 
-import Universum
-
 import Codec.Serialise (Serialise (..), serialise)
 import Codec.Serialise.Decoding (decodeBytes)
 import Codec.Serialise.Encoding (encodeBytes)

--- a/src/Dscp/Crypto/Signing/Class.hs
+++ b/src/Dscp/Crypto/Signing/Class.hs
@@ -12,8 +12,6 @@ module Dscp.Crypto.Signing.Class
        , AbstractSig (..)
        ) where
 
-import Universum
-
 import Data.ByteArray (ByteArrayAccess)
 
 -- | Class of signature schemes with defined format of keys and

--- a/src/Dscp/Crypto/Signing/Cryptonite.hs
+++ b/src/Dscp/Crypto/Signing/Cryptonite.hs
@@ -6,8 +6,6 @@ module Dscp.Crypto.Signing.Cryptonite
        ( CryptoEd25519
        ) where
 
-import Universum
-
 import qualified Crypto.PubKey.Ed25519 as Ed25519
 import Data.ByteArray (ByteArrayAccess, Bytes)
 import qualified Data.ByteString.Lazy as BSL

--- a/src/Dscp/DB/DSL/Class.hs
+++ b/src/Dscp/DB/DSL/Class.hs
@@ -14,8 +14,6 @@ module Dscp.DB.DSL.Class
        , WHERE (..)
        ) where
 
-import Universum
-
 import Dscp.Educator.Txs (PrivateTxId, PrivateTx(..))
 import Dscp.Crypto (Hash)
 

--- a/src/Dscp/DB/DSL/Interpret/IO.hs
+++ b/src/Dscp/DB/DSL/Interpret/IO.hs
@@ -3,8 +3,6 @@ module Dscp.DB.DSL.Interpret.IO
        )
        where
 
-import Universum
-
 import Data.List (intersect, union)
 
 import qualified Dscp.Core as Core (Grade (..), SubjectId (..))

--- a/src/Dscp/DB/DSL/Interpret/SimpleTxDB.hs
+++ b/src/Dscp/DB/DSL/Interpret/SimpleTxDB.hs
@@ -2,8 +2,6 @@ module Dscp.DB.DSL.Interpret.SimpleTxDB
        ( runSimpleTxDBQuery
        ) where
 
-import Universum
-
 import Control.Lens (filtered, makePrisms, traversed)
 import Data.List (intersect, union)
 import Data.Map.Strict (Map)

--- a/src/Dscp/DB/Rocks/Class.hs
+++ b/src/Dscp/DB/Rocks/Class.hs
@@ -1,7 +1,5 @@
 module Dscp.DB.Rocks.Class where
 
-import Universum
-
 -- | Read-only interface to key-value DB storing serialized data.
 class Monad m => MonadDBRead m where
     dbGet :: ByteString -> m (Maybe ByteString)

--- a/src/Dscp/DB/Rocks/Real/Functions.hs
+++ b/src/Dscp/DB/Rocks/Real/Functions.hs
@@ -12,8 +12,6 @@ module Dscp.DB.Rocks.Real.Functions
        , rocksDelete
        ) where
 
-import Universum
-
 import qualified Database.RocksDB as Rocks
 import Loot.Base.HasLens (HasLens (..), HasLens')
 

--- a/src/Dscp/DB/Rocks/Real/Types.hs
+++ b/src/Dscp/DB/Rocks/Real/Types.hs
@@ -6,8 +6,6 @@ module Dscp.DB.Rocks.Real.Types
        , rdDatabase
        ) where
 
-import Universum
-
 import Control.Lens (makeLenses)
 import qualified Database.RocksDB as Rocks
 import Loot.Base.HasLens (HasLens')

--- a/src/Dscp/DB/SQLite/Class.hs
+++ b/src/Dscp/DB/SQLite/Class.hs
@@ -1,7 +1,5 @@
 module Dscp.DB.SQLite.Class where
 
-import Universum
-
 import Database.SQLite.Simple (FromRow, Query, ToRow)
 
 -- There are more functions in that library, feel free

--- a/src/Dscp/DB/SQLite/Error.hs
+++ b/src/Dscp/DB/SQLite/Error.hs
@@ -6,8 +6,6 @@ module Dscp.DB.SQLite.Error
     , rethrowSQLRequestError
     ) where
 
-import Universum
-
 import Database.SQLite.Simple as SQLite
 import Dscp.Util (wrapRethrow)
 

--- a/src/Dscp/DB/SQLite/Functions.hs
+++ b/src/Dscp/DB/SQLite/Functions.hs
@@ -6,8 +6,6 @@ module Dscp.DB.SQLite.Functions
        , closeSQLiteDB
        ) where
 
-import Universum
-
 import qualified Database.SQLite.Simple as Lower
 import Loot.Base.HasLens (HasLens (..))
 

--- a/src/Dscp/DB/SQLite/Types.hs
+++ b/src/Dscp/DB/SQLite/Types.hs
@@ -4,8 +4,6 @@ module Dscp.DB.SQLite.Types
        , SQLiteParams (..)
        ) where
 
-import Universum
-
 import Database.SQLite.Simple (Connection)
 
 -- | Where database lies.

--- a/src/Dscp/Educator/Block.hs
+++ b/src/Dscp/Educator/Block.hs
@@ -21,8 +21,6 @@ module Dscp.Educator.Block
        , getPrevBlockRefMaybe
        ) where
 
-import Universum
-
 import Control.Lens (makeLenses)
 import Dscp.Core.Types (ATGDelta (..))
 import Dscp.Crypto (Hash, unsafeHash)

--- a/src/Dscp/Educator/CLI.hs
+++ b/src/Dscp/Educator/CLI.hs
@@ -6,8 +6,6 @@ module Dscp.Educator.CLI
     ( educatorParamsParser
     ) where
 
-import Universum
-
 import Options.Applicative (Parser)
 
 import Dscp.CLI (sqliteParamsParser)

--- a/src/Dscp/Educator/Launcher/Mode.hs
+++ b/src/Dscp/Educator/Launcher/Mode.hs
@@ -15,8 +15,6 @@ module Dscp.Educator.Launcher.Mode
     , ecDB
     ) where
 
-import Universum
-
 import Control.Lens (makeLenses)
 import Loot.Base.HasLens (HasLens (..))
 import Loot.Log.Rio (LoggingIO)

--- a/src/Dscp/Educator/Launcher/Resource.hs
+++ b/src/Dscp/Educator/Launcher/Resource.hs
@@ -5,8 +5,6 @@ module Dscp.Educator.Launcher.Resource
        , erWitnessResources
        ) where
 
-import Universum
-
 import Control.Lens (makeLenses)
 import Loot.Base.HasLens (HasLens (..))
 import Loot.Log.Rio (LoggingIO)

--- a/src/Dscp/Educator/Launcher/Runner.hs
+++ b/src/Dscp/Educator/Launcher/Runner.hs
@@ -2,8 +2,6 @@
 
 module Dscp.Educator.Launcher.Runner where
 
-import Universum
-
 import Control.Monad.Component (runComponentM)
 
 import Dscp.Educator.Launcher.Mode (EducatorContext (..), EducatorRealMode)

--- a/src/Dscp/Educator/State.hs
+++ b/src/Dscp/Educator/State.hs
@@ -2,6 +2,4 @@ module Dscp.Educator.State
        (
        ) where
 
--- import Universum
-
 -- import Snowdrop.Model.Expander (Expander (..), expandRawTxs)

--- a/src/Dscp/Educator/Txs.hs
+++ b/src/Dscp/Educator/Txs.hs
@@ -17,8 +17,6 @@ module Dscp.Educator.Txs
        , ptwSig
        ) where
 
-import Universum
-
 import Control.Lens (makeLenses)
 import Data.Time.Clock (UTCTime)
 

--- a/src/Dscp/Launcher/Mode.hs
+++ b/src/Dscp/Launcher/Mode.hs
@@ -24,8 +24,6 @@ module Dscp.Launcher.Mode
          BasicWorkMode
        ) where
 
-import Universum
-
 import Loot.Log (WithLogging)
 import UnliftIO (MonadUnliftIO)
 

--- a/src/Dscp/Launcher/Rio.hs
+++ b/src/Dscp/Launcher/Rio.hs
@@ -5,8 +5,6 @@ module Dscp.Launcher.Rio
     , runRIO
     ) where
 
-import Universum
-
 import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
 import Loot.Base.HasLens (HasLens)
 import Loot.Log (ModifyLogName (..), MonadLogging (..))

--- a/src/Dscp/Listeners/Listener.hs
+++ b/src/Dscp/Listeners/Listener.hs
@@ -6,8 +6,6 @@ module Dscp.Listeners.Listener
     ( witnessListeners
     ) where
 
-import Universum
-
 import Control.Concurrent (threadDelay)
 import Loot.Log (logInfo)
 

--- a/src/Dscp/Network/Messages.hs
+++ b/src/Dscp/Network/Messages.hs
@@ -14,8 +14,6 @@ module Dscp.Network.Messages
     , PongTx(..)
     ) where
 
-import Universum
-
 import Codec.Serialise (Serialise)
 import Loot.Network.Message (Message (..))
 

--- a/src/Dscp/Network/Wrapped.hs
+++ b/src/Dscp/Network/Wrapped.hs
@@ -35,8 +35,6 @@ module Dscp.Network.Wrapped
     ) where
 
 
-import Universum
-
 import Codec.Serialise (serialise)
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.STM (orElse, retry)

--- a/src/Dscp/Resource/Logging.hs
+++ b/src/Dscp/Resource/Logging.hs
@@ -3,8 +3,6 @@ module Dscp.Resource.Logging
     ( LoggingParams(..)
     ) where
 
-import Universum
-
 import Control.Monad.Component (buildComponent)
 import Data.Aeson (encode)
 import Fmt ((+|), (|+))

--- a/src/Dscp/Resource/Network.hs
+++ b/src/Dscp/Resource/Network.hs
@@ -14,8 +14,6 @@ module Dscp.Resource.Network
     , NetServResources(..)
     ) where
 
-import Universum
-
 import Control.Lens (makeLenses)
 import Control.Monad.Component (buildComponent)
 import Data.Reflection (Given (given), give)

--- a/src/Dscp/Util.hs
+++ b/src/Dscp/Util.hs
@@ -9,8 +9,6 @@ module Dscp.Util
        , module Snowdrop.Util
        ) where
 
-import Universum
-
 import Snowdrop.Util
 
 deriving instance Container (b a) => Container (OldestFirst b a)

--- a/src/Dscp/Witness/CLI.hs
+++ b/src/Dscp/Witness/CLI.hs
@@ -6,8 +6,6 @@ module Dscp.Witness.CLI
     ( witnessParamsParser
     ) where
 
-import Universum
-
 import Options.Applicative (Parser)
 
 import Dscp.CLI.Common (logParamsParser, netServParamsParser, rocksParamsParser)

--- a/src/Dscp/Witness/Instances.hs
+++ b/src/Dscp/Witness/Instances.hs
@@ -2,8 +2,6 @@
 
 module Dscp.Witness.Instances () where
 
-import Universum
-
 import Codec.Serialise (Serialise (..))
 import qualified Codec.Serialise as S
 import Control.Monad.Free (Free (..))

--- a/src/Dscp/Witness/Launcher/Mode.hs
+++ b/src/Dscp/Witness/Launcher/Mode.hs
@@ -14,8 +14,6 @@ module Dscp.Witness.Launcher.Mode
     , WitnessRealMode
     ) where
 
-import Universum
-
 import Control.Lens (makeLenses)
 import Loot.Base.HasLens (HasLens (..))
 import Loot.Log.Rio (LoggingIO)

--- a/src/Dscp/Witness/Launcher/Params.hs
+++ b/src/Dscp/Witness/Launcher/Params.hs
@@ -2,8 +2,6 @@ module Dscp.Witness.Launcher.Params
        ( WitnessParams (..)
        ) where
 
-import Universum
-
 import Dscp.DB.Rocks.Real.Types (RocksDBParams)
 import Dscp.Resource.Logging (LoggingParams)
 import Dscp.Resource.Network (NetServParams)

--- a/src/Dscp/Witness/Launcher/Resource.hs
+++ b/src/Dscp/Witness/Launcher/Resource.hs
@@ -4,8 +4,6 @@ module Dscp.Witness.Launcher.Resource
        ( WitnessResources (..)
        ) where
 
-import Universum
-
 import Loot.Log.Internal (logNameSelL, _GivenName)
 import Loot.Log.Rio (LoggingIO)
 

--- a/src/Dscp/Witness/Launcher/Runner.hs
+++ b/src/Dscp/Witness/Launcher/Runner.hs
@@ -2,8 +2,6 @@
 
 module Dscp.Witness.Launcher.Runner where
 
-import Universum
-
 import Control.Monad.Component (runComponentM)
 
 import Dscp.Launcher.Rio (runRIO)

--- a/src/Dscp/Workers/Worker.hs
+++ b/src/Dscp/Workers/Worker.hs
@@ -6,8 +6,6 @@ module Dscp.Workers.Worker
     ( witnessWorkers
     ) where
 
-import Universum
-
 import Control.Concurrent (threadDelay)
 import Fmt ((+|), (||+))
 import Loot.Log (logError, logInfo)

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,8 +1,4 @@
 module Main where
 
-import Universum
-
-
-
 main :: IO ()
 main = return ()

--- a/src/educator/Main.hs
+++ b/src/educator/Main.hs
@@ -2,8 +2,6 @@
 
 module Main where
 
-import Universum
-
 import Loot.Log (logInfo, logWarning, modifyLogName)
 import Options.Applicative (execParser, fullDesc, helper, info, progDesc)
 

--- a/src/witness/Main.hs
+++ b/src/witness/Main.hs
@@ -2,8 +2,6 @@
 
 module Main where
 
-import Universum
-
 import Control.Concurrent (threadDelay)
 import qualified Data.ByteString.Char8 as B8
 import Loot.Log (logInfo, logWarning, modifyLogName)

--- a/tests/Test/Common.hs
+++ b/tests/Test/Common.hs
@@ -15,12 +15,12 @@ module Test.Common
        ( module Test.Common
        , module Control.Lens
        , module T
-       , module Universum
        ) where
+
+import Prelude hiding (show, unlines)
 
 import Data.List (unlines)
 import GHC.Show (Show (show))
-import Universum hiding (show, unlines)
 
 import Data.Time.Clock (UTCTime)
 import Data.Time.Format (defaultTimeLocale, parseTimeOrError)


### PR DESCRIPTION
Remove `NoImplicitPrelude` option and all explicit `Universum` imports.
I do not remove `universum` dependency for the sake of `Universum.Unsafe` module.

Tested with `stack build`, `stack ghci` and `intero`.