### PR TITLE
[DSCP-119] Utility functions for AES encryption.

### DIFF
--- a/src/Dscp/Crypto/Encrypt.hs
+++ b/src/Dscp/Crypto/Encrypt.hs
@@ -1,0 +1,116 @@
+
+-- | Utilities for encrypting/decrypting byte arrays
+
+module Dscp.Crypto.Encrypt
+       ( -- * Passphrases
+         PassPhrase
+       , getPassPhrase
+       , mkPassPhrase
+       , minPassPhraseLength
+
+         -- * Encrypted bytearray
+       , Encrypted
+       , eAuthTag
+       , eCiphertext
+
+         -- * Utility functions
+       , encrypt
+       , decrypt
+       ) where
+
+import Crypto.Cipher.AES (AES256)
+import Crypto.Cipher.Types (AEAD, AEADMode (AEAD_GCM), AuthTag, BlockCipher (aeadInit),
+                            Cipher (cipherInit), IV, aeadSimpleDecrypt, aeadSimpleEncrypt, nullIV)
+import Crypto.Error (onCryptoFailure)
+import Data.ByteArray (ByteArray, ByteArrayAccess)
+import qualified Data.ByteArray as BA
+import Fmt ((+|), (|+))
+
+import Dscp.Crypto.Impl (hash)
+
+-------------------------------------------------------------
+-- Passphrases
+-------------------------------------------------------------
+
+newtype PassPhrase = PassPhrase
+    { getPassPhrase :: ByteString
+    } deriving (Eq, Ord, Show, Monoid, ByteArray, ByteArrayAccess)
+
+-- | Minimal passphrase length. Should be enough.
+minPassPhraseLength :: Int
+minPassPhraseLength = 8
+
+mkPassPhrase :: ByteString -> Either Text PassPhrase
+mkPassPhrase bs
+    | length bs < minPassPhraseLength = Left shortPassErr
+    | otherwise = Right $ PassPhrase bs
+  where
+    shortPassErr = "Passphrase is too short, minimal length is "+|minPassPhraseLength|+" chars."
+
+-------------------------------------------------------------
+-- Encryption/decryption
+-------------------------------------------------------------
+
+-- | Datatype which combines ciphertext with cipher authentication tag.
+data Encrypted ba = Encrypted
+    { eAuthTag    :: !AuthTag
+    , eCiphertext :: !ba
+    } deriving (Eq)
+
+-- | Authentication tag length. Number 16 is the same as in the
+-- `Crypto.MAC.Poly1305.Auth` tag datatype.
+-- TODO: probably it can be made shorter without any problems?
+authTagLength :: Int
+authTagLength = 16
+
+-- | Chosen cipher. We'll stick with AES256 for now.
+-- TODO: are there better alternatives?
+type CipherType = AES256
+
+-- | Authentication header used for our encryption (empty one).
+authHeader :: ByteString
+authHeader = ""
+
+-- | AEAD mode used for our encryption scheme.
+-- We use GCM mode, because it's the most modern and performant one
+-- among available in Cryptonite, and it's also unencumbered
+-- by patents.
+--
+-- See: AEAD_OCB: https://en.wikipedia.org/wiki/OCB_mode
+--      AEAD_CCM: https://en.wikipedia.org/wiki/CCM_mode
+--      AEAD_CWC: https://en.wikipedia.org/wiki/CWC_mode
+--      AEAD_EAX: https://en.wikipedia.org/wiki/EAX_mode
+--      AEAD_GCM: https://en.wikipedia.org/wiki/Galois/Counter_Mode
+aeadMode :: AEADMode
+aeadMode = AEAD_GCM
+
+-- | Initial vector for chosen cipher.
+initIV :: IV CipherType
+initIV = nullIV
+
+-- | Prepare an AEAD context from a 'PassPhrase'.
+prepareAEAD :: PassPhrase -> AEAD CipherType
+prepareAEAD (PassPhrase pp) =
+    let impossible err =
+            error $ "encrypt: impossible: " <> show err
+        ppHashKey :: ByteString =
+            BA.convert $ hash pp
+        cipher :: CipherType =
+            onCryptoFailure impossible identity $
+            cipherInit ppHashKey
+    in onCryptoFailure impossible identity $
+       aeadInit aeadMode cipher initIV
+
+-- | Encrypt given 'ByteArray' with AES.
+encrypt :: ByteArray ba => PassPhrase -> ba -> Encrypted ba
+encrypt pp plaintext =
+    let aead = prepareAEAD pp
+    in uncurry Encrypted $
+       aeadSimpleEncrypt aead authHeader plaintext authTagLength
+
+-- | Decrypt given 'Encrypted' datatype or fail, if passphrase
+-- doesn't match.
+decrypt :: ByteArray ba => PassPhrase -> Encrypted ba -> Maybe ba
+decrypt pp (Encrypted tag ciphertext) =
+    let aead = prepareAEAD pp
+    in aeadSimpleDecrypt aead authHeader ciphertext tag

--- a/src/Dscp/Crypto/Encrypt.hs
+++ b/src/Dscp/Crypto/Encrypt.hs
@@ -37,9 +37,18 @@ import Dscp.Crypto.Impl (hash)
 -- Passphrases
 -------------------------------------------------------------
 
+-- | Newtype for passphrase. Uses blind instances for
+-- 'Buildable' and 'Show' in order to avoid accidental
+-- appearance of actual passphrases in logs.
 newtype PassPhrase = PassPhrase
     { getPassPhrase :: ByteString
-    } deriving (Eq, Ord, Show, Monoid, ByteArray, ByteArrayAccess)
+    } deriving (Eq, Ord, Monoid, ByteArray, ByteArrayAccess)
+
+instance Buildable PassPhrase where
+    build _ = "<passphrase>"
+
+instance Show PassPhrase where
+    show _ = "<passphrase>"
 
 -- | Minimum passphrase length. Should be enough.
 minPassPhraseLength :: Int

--- a/src/Dscp/Crypto/Encrypt.hs
+++ b/src/Dscp/Crypto/Encrypt.hs
@@ -16,7 +16,7 @@ module Dscp.Crypto.Encrypt
        , eCiphertext
 
          -- * Utility functions
-       , DecryptionError
+       , DecryptionError (..)
        , encrypt
        , decrypt
        ) where

--- a/tests/Test/Dscp/Crypto/Encrypt.hs
+++ b/tests/Test/Dscp/Crypto/Encrypt.hs
@@ -18,4 +18,4 @@ spec_encryption = describe "AES encryption functions" $ do
     it "should encrypt differently for different passphrases" $ property $
         \(pp, pp', bs :: ByteString) -> pp /= pp' ==> encrypt pp bs /= encrypt pp' bs
     it "should fail when trying to decrypt a ciphertext with wrong passphrase" $ property $
-        \(pp, pp', bs :: ByteString) -> decrypt pp (encrypt pp' bs) === Nothing
+        \(pp, pp', bs :: ByteString) -> pp /= pp' ==> decrypt pp (encrypt pp' bs) === Nothing

--- a/tests/Test/Dscp/Crypto/Encrypt.hs
+++ b/tests/Test/Dscp/Crypto/Encrypt.hs
@@ -3,7 +3,7 @@ module Test.Dscp.Crypto.Encrypt where
 import qualified Data.ByteString as BS
 import Test.Common
 
-import Dscp.Crypto (Encrypted, PassPhrase, decrypt, encrypt, minPassPhraseLength, mkPassPhrase)
+import Dscp.Crypto (PassPhrase, decrypt, encrypt, minPassPhraseLength, mkPassPhrase)
 
 instance Arbitrary PassPhrase where
     arbitrary = either error identity . mkPassPhrase <$>

--- a/tests/Test/Dscp/Crypto/Encrypt.hs
+++ b/tests/Test/Dscp/Crypto/Encrypt.hs
@@ -3,19 +3,20 @@ module Test.Dscp.Crypto.Encrypt where
 import qualified Data.ByteString as BS
 import Test.Common
 
-import Dscp.Crypto (PassPhrase, decrypt, encrypt, minPassPhraseLength, mkPassPhrase)
+import Dscp.Crypto (DecryptionError (..), PassPhrase, decrypt, encrypt, maxPassPhraseLength,
+                    minPassPhraseLength, mkPassPhrase)
 
 instance Arbitrary PassPhrase where
-    arbitrary = either error identity . mkPassPhrase <$>
-        arbitrary `suchThat` ((>= minPassPhraseLength) . BS.length)
+    arbitrary = either (error . show) identity . mkPassPhrase <$> arbitrary `suchThat`
+        (\bs -> BS.length bs >= minPassPhraseLength && BS.length bs <= maxPassPhraseLength)
 
 spec_encryption :: Spec
 spec_encryption = describe "AES encryption functions" $ do
     it "should stay the same after encryption and decryption" $ property $
-        \(pp, bs :: ByteString) -> decrypt pp (encrypt pp bs) === Just bs
+        \(pp, bs :: ByteString) -> decrypt pp (encrypt pp bs) === Right bs
     it "should yield different ciphertexts for different plaintexts" $ property $
         \(pp, bs :: ByteString, bs' :: ByteString) -> bs /= bs' ==> encrypt pp bs /= encrypt pp bs'
     it "should encrypt differently for different passphrases" $ property $
         \(pp, pp', bs :: ByteString) -> pp /= pp' ==> encrypt pp bs /= encrypt pp' bs
     it "should fail when trying to decrypt a ciphertext with wrong passphrase" $ property $
-        \(pp, pp', bs :: ByteString) -> pp /= pp' ==> decrypt pp (encrypt pp' bs) === Nothing
+        \(pp, pp', bs :: ByteString) -> pp /= pp' ==> decrypt pp (encrypt pp' bs) === Left PassPhraseInvalid

--- a/tests/Test/Dscp/Crypto/Encrypt.hs
+++ b/tests/Test/Dscp/Crypto/Encrypt.hs
@@ -1,0 +1,21 @@
+module Test.Dscp.Crypto.Encrypt where
+
+import qualified Data.ByteString as BS
+import Test.Common
+
+import Dscp.Crypto (Encrypted, PassPhrase, decrypt, encrypt, minPassPhraseLength, mkPassPhrase)
+
+instance Arbitrary PassPhrase where
+    arbitrary = either error identity . mkPassPhrase <$>
+        arbitrary `suchThat` ((>= minPassPhraseLength) . BS.length)
+
+spec_encryption :: Spec
+spec_encryption = describe "AES encryption functions" $ do
+    it "should stay the same after encryption and decryption" $ property $
+        \(pp, bs :: ByteString) -> decrypt pp (encrypt pp bs) === Just bs
+    it "should yield different ciphertexts for different plaintexts" $ property $
+        \(pp, bs :: ByteString, bs' :: ByteString) -> bs /= bs' ==> encrypt pp bs /= encrypt pp bs'
+    it "should encrypt differently for different passphrases" $ property $
+        \(pp, pp', bs :: ByteString) -> pp /= pp' ==> encrypt pp bs /= encrypt pp' bs
+    it "should fail when trying to decrypt a ciphertext with wrong passphrase" $ property $
+        \(pp, pp', bs :: ByteString) -> decrypt pp (encrypt pp' bs) === Nothing

--- a/tests/Test/Dscp/DB/DSL/Interpret/SimpleTxDB.hs
+++ b/tests/Test/Dscp/DB/DSL/Interpret/SimpleTxDB.hs
@@ -5,7 +5,8 @@ import Test.Common
 import Dscp.Core (CourseId (..), Grade (..), SubjectId)
 import Dscp.Crypto (PublicKey, SecretKey, hash)
 import Dscp.DB (Obj, ObjHashEq (..), QueryObj (..), QueryTx (..), QueryTxs (..), TxGrade (..),
-                TxIdEq (..), TxsFilterExpr (..), WHERE (..), runSimpleTxDBQuery)
+                TxIdEq (..), TxsFilterExpr (..), WHERE (..))
+import Dscp.DB.DSL.Interpret.SimpleTxDB (runSimpleTxDBQuery)
 import Dscp.Educator (PrivateTx (..))
 
 -- | Made up courses


### PR DESCRIPTION
Simple utility functions and datatypes which greatly simplify the usage of `cryptonite` encryption primitives. Currently only for encrypting/decrypting a secret key with a passphrase.