### PR TITLE
[DSCP-127] Pretty errors on application failure

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -32,6 +32,7 @@ library:
     - monad-control
     - mtl
     - optparse-applicative
+    - prettyprinter
     - random
     - reflection
     - rocksdb-haskell

--- a/src/Dscp/Educator/Launcher/Runner.hs
+++ b/src/Dscp/Educator/Launcher/Runner.hs
@@ -2,13 +2,11 @@
 
 module Dscp.Educator.Launcher.Runner where
 
-import Control.Monad.Component (runComponentM)
-
 import Dscp.Educator.Launcher.Mode (EducatorContext (..), EducatorRealMode)
 import Dscp.Educator.Launcher.Params (EducatorParams (..))
 import Dscp.Educator.Launcher.Resource (EducatorResources (..))
 import Dscp.Launcher.Rio (runRIO)
-import Dscp.Resource (AllocResource (..))
+import Dscp.Resource (tryRunComponentM, AllocResource (..))
 import Dscp.Witness.Launcher.Runner (formWitnessContext)
 
 -- | Make up Educator context from dedicated pack of allocated resources.
@@ -23,10 +21,10 @@ runEducatorRealMode :: EducatorContext -> EducatorRealMode a -> IO a
 runEducatorRealMode = runRIO
 
 -- | Given params, allocate resources, construct node context and run
--- `EducatorWorkMode` monad.
-launchEducatorRealMode :: EducatorParams -> EducatorRealMode a -> IO a
+-- `EducatorWorkMode` monad. Any synchronous exceptions are handled inside.
+launchEducatorRealMode :: EducatorParams -> EducatorRealMode () -> IO ()
 launchEducatorRealMode params action =
-    runComponentM "Educator (real mode)" (allocResource params) $
+    void . tryRunComponentM "Educator (real mode)" (allocResource params) $
       \resources ->
         let ctx = formEducatorContext resources
         in runEducatorRealMode ctx action

--- a/src/Dscp/Resource/Class.hs
+++ b/src/Dscp/Resource/Class.hs
@@ -2,12 +2,25 @@
 
 module Dscp.Resource.Class
        ( AllocResource(..)
+       , tryRunComponentM
        ) where
 
-import Control.Monad.Component (ComponentM)
+import Control.Monad.Component (ComponentM, ComponentError, runComponentM)
+import qualified Data.Text.Prettyprint.Doc as Doc (pretty)
 
 -- | Resources safe allocation.
 class AllocResource param resource | param -> resource, resource -> param where
     -- | Construct a resource using given parameters. Automatic cleanup.
     -- Use 'buildComponent' to construct function of this type.
     allocResource :: param -> ComponentM resource
+
+-- | Runs a component, handling and printing possible synchronous exceptions.
+tryRunComponentM
+    :: Text
+    -> ComponentM a
+    -> (a -> IO b)
+    -> IO (Either ComponentError b)
+tryRunComponentM appName component main = do
+    res <- try $ runComponentM appName component main
+    whenLeft res $ print . Doc.pretty
+    return res

--- a/src/Dscp/Witness/Launcher/Runner.hs
+++ b/src/Dscp/Witness/Launcher/Runner.hs
@@ -2,10 +2,8 @@
 
 module Dscp.Witness.Launcher.Runner where
 
-import Control.Monad.Component (runComponentM)
-
 import Dscp.Launcher.Rio (runRIO)
-import Dscp.Resource (AllocResource (..))
+import Dscp.Resource (tryRunComponentM, AllocResource (..))
 import Dscp.Witness.Launcher.Mode (WitnessContext (..), WitnessRealMode)
 import Dscp.Witness.Launcher.Params (WitnessParams (..))
 import Dscp.Witness.Launcher.Resource (WitnessResources (..))
@@ -21,10 +19,10 @@ runWitnessRealMode :: WitnessContext -> WitnessRealMode () -> IO ()
 runWitnessRealMode = runRIO
 
 -- | Given params, allocate resources, construct node context and run
--- `WitnessWorkMode` monad.
+-- `WitnessWorkMode` monad. Any synchronous exceptions are handled inside.
 launchWitnessRealMode ::WitnessParams -> WitnessRealMode () -> IO ()
 launchWitnessRealMode params action =
-    runComponentM "Witness (real mode)" (allocResource params) $
+    void . tryRunComponentM "Witness (real mode)" (allocResource params) $
       \resources ->
         let ctx = formWitnessContext resources
-        in            runWitnessRealMode ctx action
+        in runWitnessRealMode ctx action


### PR DESCRIPTION
By default exceptions on resource allocation are just rethrown and printed by ghc using 'Show' instance. In this PR exceptions are handled and printed nicely.
 

Before:
``
disciplina-educator: ComponentBuildFailed {componentErrorBuildErrors = [ComponentAllocationFailed "Educator secret key storage" /home/elena/.local/share/disciplina/secret.key: openBinaryFile: does not exist (No such file or directory)], componentErrorTeardownResult = BranchResult {resultDescription = "Educator (real mode)", resultElapsedTime = 0.000652s, resultDidFail = False, resultListing = [EmptyResult {resultDescription = "Educator secret key storage"},LeafResult {resultDescription = "SQLite DB", resultElapsedTime = 0.000108s, resultError = Nothing},LeafResult {resultDescription = "netcli", resultElapsedTime = 0.000003s, resultError = Nothing},LeafResult {resultDescription = "RocksDB", resultElapsedTime = 0.000529s, resultError = Nothing},LeafResult {resultDescription = "logging", resultElapsedTime = 0.000011s, resultError = Nothing},LeafResult {resultDescription = "Application directory", resultElapsedTime = 0.000001s, resultError = Nothing}]}}
``

After:
```
Application failed on initialization, following are the exceptions that made it failed:

  * ComponentAllocationFailed "Educator secret key storage" - the following error was reported:
    |
    `- Some I/O error occured: ./secret.key: getFileStatus: does not exist (No such file or directory)
  
Following, we have the information of application resources cleanup:

✓ Educator (real mode) (0.000531s)
  ✓ Educator secret key storage (empty)
  ✓ SQLite DB (0.000094s)
  ✓ netcli (0.000001s)
  ✓ RocksDB (0.000427s)
  ✓ logging (0.000008s)
  ✓ Application directory (0.000001s)
```