### PR TITLE
[DSCP-130] Use non-static IV for symmetric encryption scheme

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -61,6 +61,8 @@ tests:
       - data-default
       - hspec
       - lens
+      - memory
+      - serialise
       - tasty
       - tasty-hspec
       - tasty-discover

--- a/src/Dscp/Crypto/Encrypt.hs
+++ b/src/Dscp/Crypto/Encrypt.hs
@@ -19,7 +19,7 @@ module Dscp.Crypto.Encrypt
        , decrypt
        ) where
 
-import Codec.Serialise (Serialise (..))
+import Codec.Serialise (Serialise (..), serialise)
 import Codec.Serialise.Decoding (decodeBytes)
 import Codec.Serialise.Encoding (encodeBytes)
 import Crypto.Cipher.AES (AES256)
@@ -32,12 +32,14 @@ import qualified Crypto.KDF.PBKDF2 as PBKDF2
 import Crypto.Random (getRandomBytes)
 import Data.ByteArray (ByteArray, ByteArrayAccess)
 import qualified Data.ByteArray as BA
+import qualified Data.ByteString.Lazy as BSL
 import Data.Text.Buildable (build)
 import Fmt ((+|), (|+))
 import System.IO.Unsafe (unsafePerformIO)
 import Text.Show (show)
 
 import Dscp.Crypto.ByteArray (FromByteArray (..))
+import Dscp.Util (toBase64)
 
 -------------------------------------------------------------
 -- Passphrases
@@ -176,6 +178,12 @@ instance FromByteArray ba => Serialise (Encrypted ba) where
         eCiphertext <- either fail pure .
             fromByteArray =<< decodeBytes
         return Encrypted {..}
+
+instance FromByteArray ba => Buildable (Encrypted ba) where
+    build = build . toBase64 . BSL.toStrict . serialise
+
+instance FromByteArray ba => Show (Encrypted ba) where
+    show = toString . pretty
 
 -------------------------------------------------------------
 -- Encryption/decryption logic

--- a/src/Dscp/Crypto/Encrypt.hs
+++ b/src/Dscp/Crypto/Encrypt.hs
@@ -1,6 +1,12 @@
+{-|
+Module      : Dscp.Crypto.Encrypt
+Description : Functions and datatypes for symmetric encryption
+Copyright   : (c) Serokell, 2018
+Maintainer  : dimq@serokell.io
 
--- | Utilities for encrypting/decrypting byte arrays
-
+Functions and datatypes which wrap around `cryptonite` interface
+for authenticated AES encryption.
+-}
 module Dscp.Crypto.Encrypt
        ( -- * Passphrases
          PassPhrase

--- a/src/Dscp/Util.hs
+++ b/src/Dscp/Util.hs
@@ -5,11 +5,21 @@ module Dscp.Util
        ( anyMapM
        , wrapRethrow
        , wrapRethrowIO
+
+         -- * Formatting
+       , toBase64
+       , fromBase64
+       , toHex
+       , fromHex
          -- * Re-exports
        , module Snowdrop.Util
        ) where
 
+import Data.ByteArray (ByteArrayAccess)
+import Data.ByteArray.Encoding (Base (..), convertFromBase, convertToBase)
 import Snowdrop.Util
+
+import Dscp.Crypto.ByteArray (FromByteArray (..))
 
 deriving instance Container (b a) => Container (OldestFirst b a)
 deriving instance Container (b a) => Container (NewestFirst b a)
@@ -32,3 +42,23 @@ wrapRethrowIO
     :: (Exception e1, Exception e2, MonadCatch m, MonadIO m)
     => (e1 -> e2) -> IO a -> m a
 wrapRethrowIO wrap action = wrapRethrow wrap (liftIO action)
+
+-----------------------------------------------------------
+-- Bytestrings formatting
+-----------------------------------------------------------
+
+toBase :: ByteArrayAccess ba => Base -> ba -> Text
+toBase base = decodeUtf8 @Text @ByteString . convertToBase base
+
+fromBase :: forall ba. FromByteArray ba => Base -> Text -> Either String ba
+fromBase base =
+    convertFromBase base . encodeUtf8 @Text @ByteString >=>
+    fromByteArray @ba @ByteString
+
+toBase64, toHex :: ByteArrayAccess ba => ba -> Text
+toBase64 = toBase Base64
+toHex    = toBase Base16
+
+fromBase64, fromHex :: FromByteArray ba => Text -> Either String ba
+fromBase64 = fromBase Base64
+fromHex    = fromBase Base16

--- a/tests/Test/Dscp/Crypto/Encrypt.hs
+++ b/tests/Test/Dscp/Crypto/Encrypt.hs
@@ -1,14 +1,9 @@
 module Test.Dscp.Crypto.Encrypt where
 
-import qualified Data.ByteString as BS
 import Test.Common
+import Test.Dscp.Crypto.Instances ()
 
-import Dscp.Crypto (DecryptionError (..), PassPhrase, decrypt, encrypt, maxPassPhraseLength,
-                    minPassPhraseLength, mkPassPhrase)
-
-instance Arbitrary PassPhrase where
-    arbitrary = either (error . show) identity . mkPassPhrase <$> arbitrary `suchThat`
-        (\bs -> BS.length bs >= minPassPhraseLength && BS.length bs <= maxPassPhraseLength)
+import Dscp.Crypto (DecryptionError (..), decrypt, encrypt)
 
 spec_encryption :: Spec
 spec_encryption = describe "AES encryption functions" $ do

--- a/tests/Test/Dscp/Crypto/Instances.hs
+++ b/tests/Test/Dscp/Crypto/Instances.hs
@@ -1,0 +1,15 @@
+module Test.Dscp.Crypto.Instances () where
+
+import Data.ByteArray (ByteArray)
+import qualified Data.ByteString as BS
+import Test.Common
+
+import Dscp.Crypto (Encrypted, PassPhrase, encrypt, maxPassPhraseLength, minPassPhraseLength,
+                    mkPassPhrase)
+
+instance Arbitrary PassPhrase where
+    arbitrary = either (error . show) identity . mkPassPhrase <$> arbitrary `suchThat`
+        (\bs -> BS.length bs >= minPassPhraseLength && BS.length bs <= maxPassPhraseLength)
+
+instance (Arbitrary ba, ByteArray ba) => Arbitrary (Encrypted ba) where
+    arbitrary = encrypt <$> arbitrary <*> arbitrary

--- a/tests/Test/Dscp/Crypto/Serialise.hs
+++ b/tests/Test/Dscp/Crypto/Serialise.hs
@@ -1,0 +1,12 @@
+module Test.Dscp.Crypto.Serialise where
+
+import Test.Common
+import Test.Dscp.Crypto.Instances ()
+import Test.Dscp.Serialise (serialiseRoundtripProp)
+
+import Dscp.Crypto (Encrypted)
+
+spec_cryptoSerialise :: Spec
+spec_cryptoSerialise = describe "Crypto datatypes binary serialisation" $ do
+    describe "Symmetric encryption" $ do
+        serialiseRoundtripProp @(Encrypted ByteString)

--- a/tests/Test/Dscp/Serialise.hs
+++ b/tests/Test/Dscp/Serialise.hs
@@ -1,0 +1,24 @@
+
+-- | Utils for roundtrip tests for binary serialisation.
+
+module Test.Dscp.Serialise
+    ( serialiseRoundtrip
+    , serialiseRoundtripProp
+    ) where
+
+import Codec.Serialise (Serialise, deserialiseOrFail, serialise)
+import Data.Typeable (typeRep)
+
+import Test.Common
+
+serialiseRoundtrip
+    :: forall a. (Arbitrary a, Serialise a, Eq a, Show a)
+    => Property
+serialiseRoundtrip = property $ \(s :: a) ->
+    first (show @Text) (deserialiseOrFail (serialise s)) === Right s
+
+serialiseRoundtripProp
+    :: forall a. (Arbitrary a, Serialise a, Eq a, Show a, Typeable a)
+    => Spec
+serialiseRoundtripProp =
+    it (show $ typeRep $ Proxy @a) $ serialiseRoundtrip @a


### PR DESCRIPTION
Using fixed initial vectors for authenticated encryption schemes is unsafe (see https://en.wikipedia.org/wiki/Initialization_vector).
This PR introduces random generation of IV on each encryption. Yes, this means that encrypting the same plaintext with the same password will yield different ciphertexts, but that's actually the point.
Also, now encryption key is derived from a passphrase using PBKDF2 and not simply a hash, which is more secure.