### PR TITLE
[DSCP-124] Provide logging context into resource allocation

### DIFF
--- a/src/Dscp/DB/SQLite/Functions.hs
+++ b/src/Dscp/DB/SQLite/Functions.hs
@@ -26,12 +26,12 @@ openSQLiteDB SQLiteParams{..} = do
     path <- case sdpLocation of
         SQLiteInMemory ->
             return ":memory:"
-        SQLiteReal path ->
+        SQLiteReal path
             -- some paths produce db in memory, can't use them
-            if any (== path) ["", ":memory:"]
-            then throwM (SQLInvalidPathError path)
-            else return path
-
+            | any (== path) ["", ":memory:"] ->
+                throwM (SQLInvalidPathError path)
+            | otherwise ->
+                return path
     sdConn <-
         wrapRethrowIO @SomeException (SQLConnectionOpenningError . show) $
         Lower.open path

--- a/src/Dscp/DB/SQLite/Schema.hs
+++ b/src/Dscp/DB/SQLite/Schema.hs
@@ -3,14 +3,14 @@
 
 module Dscp.DB.SQLite.Schema (ensureSchemaIsSetUp) where
 
-import Database.SQLite3 (exec)
 import Database.SQLite.Simple.Internal (Connection (..))
+import Database.SQLite3 (exec)
 
 import Dscp.DB.SQLite.FileQuoter (qFile)
 
-ensureSchemaIsSetUp :: Connection -> IO ()
+ensureSchemaIsSetUp :: MonadIO m => Connection -> m ()
 ensureSchemaIsSetUp (Connection db) = do
-    exec db schema
+    liftIO $ exec db schema
 
 schema :: IsString s => s
 schema = [qFile|./database/schema.sql|]

--- a/src/Dscp/Educator/Launcher/Runner.hs
+++ b/src/Dscp/Educator/Launcher/Runner.hs
@@ -6,7 +6,8 @@ import Dscp.Educator.Launcher.Mode (EducatorContext (..), EducatorRealMode)
 import Dscp.Educator.Launcher.Params (EducatorParams (..))
 import Dscp.Educator.Launcher.Resource (EducatorResources (..))
 import Dscp.Launcher.Rio (runRIO)
-import Dscp.Resource (tryRunComponentM, AllocResource (..))
+import Dscp.Resource (AllocResource (..), InitParams (..), runResourceAllocation)
+import Dscp.Witness.Launcher.Params (wpLoggingParams)
 import Dscp.Witness.Launcher.Runner (formWitnessContext)
 
 -- | Make up Educator context from dedicated pack of allocated resources.
@@ -24,8 +25,12 @@ runEducatorRealMode = runRIO
 -- | Given params, allocate resources, construct node context and run
 -- `EducatorWorkMode` monad. Any synchronous exceptions are handled inside.
 launchEducatorRealMode :: EducatorParams -> EducatorRealMode () -> IO ()
-launchEducatorRealMode params action =
-    void . tryRunComponentM "Educator (real mode)" (allocResource params) $
+launchEducatorRealMode params@EducatorParams{..} action =
+    void $
+    runResourceAllocation appDesc initParams (allocResource params) $
       \resources ->
         let ctx = formEducatorContext resources
         in runEducatorRealMode ctx action
+  where
+    appDesc = "Educator (real mode)"
+    initParams = InitParams{ ipLoggingParams = wpLoggingParams epWitnessParams }

--- a/src/Dscp/Educator/Secret/Real/Error.hs
+++ b/src/Dscp/Educator/Secret/Real/Error.hs
@@ -1,7 +1,7 @@
 
 module Dscp.Educator.Secret.Real.Error
     ( EducatorSecretError (..)
-    , rewrapSecretIOError
+    , rewrapSecretIOErrors
     ) where
 
 import qualified Data.Text.Buildable
@@ -9,7 +9,7 @@ import Fmt ((+|), (|+))
 import qualified Text.Show
 
 import Dscp.Crypto (DecryptionError)
-import Dscp.Util (wrapRethrowIO)
+import Dscp.Util (wrapRethrow)
 
 -- | Exception during secret key extraction from storage.
 data EducatorSecretError
@@ -39,5 +39,5 @@ instance Buildable EducatorSecretError where
 
 instance Exception EducatorSecretError
 
-rewrapSecretIOError :: (MonadIO m, MonadCatch m) => IO a -> m a
-rewrapSecretIOError = wrapRethrowIO @SomeException (SecretIOError . show)
+rewrapSecretIOErrors :: MonadCatch m => m a -> m a
+rewrapSecretIOErrors = wrapRethrow @SomeException (SecretIOError . show)

--- a/src/Dscp/Resource/AppDir.hs
+++ b/src/Dscp/Resource/AppDir.hs
@@ -7,10 +7,11 @@ module Dscp.Resource.AppDir
     , AppDirectory (..)
     ) where
 
-import Control.Monad.Component (buildComponent)
+import Fmt ((+|), (|+))
+import Loot.Log (MonadLogging, logInfo)
 import System.Directory (XdgDirectory (XdgData), createDirectoryIfMissing, getXdgDirectory)
 
-import Dscp.Resource.Class (AllocResource (..))
+import Dscp.Resource.Class (AllocResource (..), buildComponentR)
 import Dscp.System (appName)
 
 -- | Which application directory to use.
@@ -28,15 +29,16 @@ getOSAppDir = liftIO $ getXdgDirectory XdgData appName
 
 -- | Create application directory if absent.
 ensureDirExists
-    :: (MonadIO m, MonadThrow m)
+    :: (MonadIO m, MonadLogging m)
     => AppDirectoryParam -> m AppDirectory
 ensureDirExists AppDirectoryOS = do
     appDir <- getOSAppDir
+    logInfo $ "Application home directory will be at "+|appDir|+""
     liftIO $ createDirectoryIfMissing False appDir
     return $ AppDirectory appDir
 
 instance AllocResource AppDirectoryParam AppDirectory where
     allocResource p =
-        buildComponent "Application directory"
+        buildComponentR "Application directory"
             (ensureDirExists p)
             (\_ -> pass)

--- a/src/Dscp/Resource/Class.hs
+++ b/src/Dscp/Resource/Class.hs
@@ -1,26 +1,52 @@
 -- | Class for resource allocation.
+--
+-- Note that we split allocation into 2 phases:
+-- 1. Logging is allocated separatelly as it needs for other resources
+-- initialization.
+-- 2. All other resources.
 
 module Dscp.Resource.Class
        ( AllocResource(..)
-       , tryRunComponentM
+       , InitParams (..)
+       , InitContext (..)
+       , buildComponentR
        ) where
 
-import Control.Monad.Component (ComponentM, ComponentError, runComponentM)
-import qualified Data.Text.Prettyprint.Doc as Doc (pretty)
+import Control.Lens (makeLenses)
+import Control.Monad.Component (ComponentM, buildComponent)
+import Loot.Base.HasLens (HasLens (..))
+import Loot.Log.Rio (LoggingIO)
+
+import Dscp.Launcher.Rio (RIO, runRIO)
+import Dscp.Resource.Logging (LoggingParams)
+
+-- | Contains parameters required for most of resources allocation.
+data InitParams = InitParams
+    { ipLoggingParams :: LoggingParams
+    }
+
+-- | Context used in most of resource allocations.
+data InitContext = InitContext
+    { _icLogging :: LoggingIO
+    }
+
+makeLenses ''InitContext
+
+instance HasLens LoggingIO InitContext LoggingIO where
+    lensOf = icLogging
 
 -- | Resources safe allocation.
 class AllocResource param resource | param -> resource, resource -> param where
     -- | Construct a resource using given parameters. Automatic cleanup.
-    -- Use 'buildComponent' to construct function of this type.
-    allocResource :: param -> ComponentM resource
+    -- Use 'buildComponentR' to construct function of this type.
+    allocResource :: param -> ReaderT InitContext ComponentM resource
 
--- | Runs a component, handling and printing possible synchronous exceptions.
-tryRunComponentM
+-- | 'buildComponent' for 'ReaderT'.
+buildComponentR
     :: Text
-    -> ComponentM a
-    -> (a -> IO b)
-    -> IO (Either ComponentError b)
-tryRunComponentM appName component main = do
-    res <- try $ runComponentM appName component main
-    whenLeft res $ print . Doc.pretty
-    return res
+    -> RIO r a
+    -> (a -> RIO r ())
+    -> ReaderT r ComponentM a
+buildComponentR desc allocate release =
+    ReaderT $
+      \r -> buildComponent desc (runRIO r allocate) (runRIO r . release)

--- a/src/Dscp/Resource/Functions.hs
+++ b/src/Dscp/Resource/Functions.hs
@@ -1,0 +1,67 @@
+
+module Dscp.Resource.Functions
+       ( handleComponentErrors
+       , runComponentR
+       , runResourceAllocation
+       ) where
+
+import Control.Monad.Component (ComponentError (..), ComponentM, runComponentM)
+import qualified Data.Text.Prettyprint.Doc as Doc (pretty)
+import Fmt ((+||), (||+))
+import Loot.Log (logError)
+
+import Dscp.Launcher.Rio (runRIO)
+import Dscp.Resource.Class (InitContext (..), InitParams (..))
+import Dscp.Resource.Logging (allocLogging)
+
+-- | Catches and prints possible synchronous exceptions thrown
+-- in 'runComponentM'. This includes both resource allocation errors and
+-- application errors.
+handleComponentErrors :: IO a -> IO (Either ComponentError a)
+handleComponentErrors action = do
+    res <- try action
+    whenLeft res $ print . Doc.pretty
+    return res
+
+allocInitResources :: InitParams -> ComponentM InitContext
+allocInitResources InitParams{..} = do
+    _icLogging <- allocLogging ipLoggingParams
+    return InitContext{..}
+
+-- | Similar to 'runComponentM', but allows to pass context.
+runComponentR
+    :: Text
+    -> r
+    -> ReaderT r ComponentM a
+    -> (a -> IO b)
+    -> IO b
+runComponentR appName ctx component main =
+    runComponentM appName (runReaderT component ctx) main
+
+-- | Allocates initial context, runs 'ComponentM' with it and handles possible
+-- exceptions.
+runResourceAllocation
+    :: Text
+    -> InitParams
+    -> ReaderT InitContext ComponentM a
+    -> (a -> IO b)
+    -> IO (Either ComponentError b)
+runResourceAllocation desc params component main = do
+    eres <- try $ runComponentM initDesc (allocInitResources params) $
+      \initCtx -> do
+         eres <- try $ runComponentR desc initCtx component main
+         whenLeft eres $ \(err :: ComponentError) -> do
+             runRIO initCtx $ logError (""+||Doc.pretty err||+"")
+         either throwM pure eres
+    whenLeft eres $ \case
+        ComponentRuntimeFailed{ componentErrorOriginalException = cause }
+            | isJust (fromException @ComponentError cause) ->
+            -- already printed error above
+            pass
+
+        err ->
+            -- have no logging context here, so printing as is
+            print $ Doc.pretty err
+    return eres
+  where
+    initDesc = "Preliminary resource allocation"

--- a/src/Dscp/Resource/Network.hs
+++ b/src/Dscp/Resource/Network.hs
@@ -15,7 +15,6 @@ module Dscp.Resource.Network
     ) where
 
 import Control.Lens (makeLenses)
-import Control.Monad.Component (buildComponent)
 import Data.Reflection (Given (given), give)
 import Loot.Base.HasLens (HasLens (..))
 import Loot.Log (Logging)
@@ -24,7 +23,7 @@ import Loot.Network.ZMQ (ZTGlobalEnv, ZTNetCliEnv, ZTNetServEnv, ZTNodeId (..), 
                          ztGlobalEnvRelease)
 import qualified Text.Show
 
-import Dscp.Resource.Class (AllocResource (..))
+import Dscp.Resource.Class (AllocResource (..), buildComponentR)
 
 ----------------------------------------------------------------------------
 -- Common
@@ -81,7 +80,7 @@ instance HasLens ZTNetCliEnv NetCliResources ZTNetCliEnv where lensOf = ncClient
 
 instance WithNetLogging => AllocResource NetCliParams NetCliResources where
     allocResource NetCliParams {..} =
-        buildComponent "netcli" allocate release
+        buildComponentR "netcli" allocate release
       where
         allocate = do
             global <- ztGlobalEnv (unNetLogging netLogging)
@@ -118,7 +117,7 @@ instance HasLens ZTNetServEnv NetServResources ZTNetServEnv where lensOf = nsSer
 
 instance WithNetLogging => AllocResource NetServParams NetServResources where
     allocResource NetServParams {..} =
-        buildComponent "netcli" allocate release
+        buildComponentR "netcli" allocate release
       where
         allocate = do
             global <- ztGlobalEnv (unNetLogging netLogging)

--- a/src/Dscp/Resource/Other.hs
+++ b/src/Dscp/Resource/Other.hs
@@ -3,24 +3,23 @@
 
 module Dscp.Resource.Other () where
 
-import Control.Monad.Component (buildComponent)
 
 import Dscp.DB.Rocks.Real (RocksDB, RocksDBParams, closeNodeDB, openNodeDB)
 import Dscp.DB.SQLite (ensureSchemaIsSetUp)
 import Dscp.DB.SQLite (SQLiteDB (..), SQLiteParams, closeSQLiteDB, openSQLiteDB)
 import Dscp.Educator.Secret (EducatorSecret, EducatorSecretParams, linkStore)
 import Dscp.Resource.AppDir (AppDirectory)
-import Dscp.Resource.Class (AllocResource (..))
+import Dscp.Resource.Class (AllocResource (..), buildComponentR)
 
 ----------------------------------------------------------------------------
 -- Instances
 ----------------------------------------------------------------------------
 
 instance AllocResource RocksDBParams RocksDB where
-    allocResource p = buildComponent "RocksDB" (openNodeDB p) closeNodeDB
+    allocResource p = buildComponentR "RocksDB" (openNodeDB p) closeNodeDB
 
 instance AllocResource SQLiteParams SQLiteDB where
-    allocResource p = buildComponent "SQLite DB" (openSQLiteDB' p) closeSQLiteDB
+    allocResource p = buildComponentR "SQLite DB" (openSQLiteDB' p) closeSQLiteDB
       where
         openSQLiteDB' p' = do
             db@ (SQLiteDB conn) <- openSQLiteDB p'
@@ -29,6 +28,6 @@ instance AllocResource SQLiteParams SQLiteDB where
 
 instance AllocResource (EducatorSecretParams, AppDirectory) EducatorSecret where
     allocResource (params, appDir) =
-        buildComponent "Educator secret key storage"
+        buildComponentR "Educator secret key storage"
             (linkStore params appDir)
             (\_ -> pass)

--- a/src/Dscp/Witness/Launcher/Resource.hs
+++ b/src/Dscp/Witness/Launcher/Resource.hs
@@ -38,7 +38,7 @@ instance HasLens ZTNetServEnv WitnessResources ZTNetServEnv where
 
 instance AllocResource WitnessParams WitnessResources where
     allocResource WitnessParams{..} = do
-        _wrLogging <- allocResource wpLoggingParams
+        _wrLogging <- view (lensOf @LoggingIO)
         _wrDB <- allocResource wpDBParams
         _wrNetwork <-
             withNetLogging (NetLogging $ _wrLogging & logNameSelL . _GivenName %~ (<> "network")) $


### PR DESCRIPTION
Split resource allocation into two phases, first prepares logging so that in second phase we can use it for other resources allocation and reporting possible errors.