### PR TITLE
[DSCP-159] Integrated validators and changed them a bit

### DIFF
--- a/lib/src/Dscp/Core/Types.hs
+++ b/lib/src/Dscp/Core/Types.hs
@@ -327,10 +327,10 @@ type TxId = Hash Tx
 txId :: (Serialise Tx) => Tx -> TxId
 txId = hash
 
--- | Transaction witness. We sign a pair of transaction hash and input
--- account. The second element of the pair is redundand, and only
--- included to speed up and simplify transaction validation
--- (@volhovm). Public key should correspond to the input address.
+-- | Transaction witness. We sign a pair of transaction hash and private
+-- key. The second element is there to authenticate proposed changes
+-- (@kirill.andreev). Public key hash should be equal to the input address.
+-- Also, public key should be the same which used to validate signature.
 data TxWitness = TxWitness
     { txwSig :: Signature (TxId, PublicKey)
     , txwPk  :: PublicKey

--- a/lib/src/Dscp/Core/Types.hs
+++ b/lib/src/Dscp/Core/Types.hs
@@ -332,7 +332,7 @@ txId = hash
 -- included to speed up and simplify transaction validation
 -- (@volhovm). Public key should correspond to the input address.
 data TxWitness = TxWitness
-    { txwSig :: Signature (TxId, TxInAcc)
+    { txwSig :: Signature (TxId, PublicKey)
     , txwPk  :: PublicKey
     } deriving (Eq, Show, Generic)
 

--- a/lib/src/Dscp/Snowdrop/AccountValidation.hs
+++ b/lib/src/Dscp/Snowdrop/AccountValidation.hs
@@ -88,7 +88,7 @@ infix 1 `check`
 check :: (Monoid a, HasException e e1) => Bool -> e1 -> ERoComp e id value ctx a
 check = flip validateIff
 
-type VatidatorCtx e pk addr id proof value ctx sig hash stTxId
+type ValidatorCtx e pk addr id proof value ctx sig hash stTxId
     =   ( HasExceptions e
            [ AccountValidationException
            , TxValidationException
@@ -110,7 +110,7 @@ type VatidatorCtx e pk addr id proof value ctx sig hash stTxId
 
 validateSimpleMoneyTransfer
     :: forall       e pk addr id proof value ctx sig hash stTxId
-    .  VatidatorCtx e pk addr id proof value ctx sig hash stTxId
+    .  ValidatorCtx e pk addr id proof value ctx sig hash stTxId
     => Validator    e         id proof value ctx
 
 validateSimpleMoneyTransfer = mkValidator ty
@@ -120,7 +120,7 @@ validateSimpleMoneyTransfer = mkValidator ty
 
 authenticate
     :: forall       e pk addr id proof value ctx sig hash stTxId
-    .  VatidatorCtx e pk addr id proof value ctx sig hash stTxId
+    .  ValidatorCtx e pk addr id proof value ctx sig hash stTxId
     => Eq             pk
     => proof
     -> ERoComp      e         id       value ctx (AccountId addr, Account)
@@ -143,7 +143,7 @@ authenticate proof = do
 
 preValidateSimpleMoneyTransfer
     :: forall       e pk addr id proof value ctx sig hash stTxId
-    .  VatidatorCtx e pk addr id proof value ctx sig hash stTxId
+    .  ValidatorCtx e pk addr id proof value ctx sig hash stTxId
     => PreValidator e         id proof value ctx
 preValidateSimpleMoneyTransfer =
     PreValidator $ \_trans@StateTx {..} -> do

--- a/lib/src/Dscp/Snowdrop/Configuration.hs
+++ b/lib/src/Dscp/Snowdrop/Configuration.hs
@@ -81,8 +81,8 @@ deriving instance (Show pk, Show sig, Show a) => Show (WithSignature pk sig a)
 
 type AddrTxProof =
     WithSignature PublicKey
-                  (Signature (T.TxId, T.TxInAcc))
-                  (T.TxId, T.TxInAcc)
+                  (Signature (T.TxId, PublicKey))
+                  (T.TxId, PublicKey)
 
 data Proofs =
     AddressTxWitness AddrTxProof
@@ -137,8 +137,6 @@ deriveIdView withInjProj ''Ids
 
 deriveView withInjProj ''Values
 deriveIdView withInjProj ''Values
-
-deriveView withInjProj ''Proofs
 
 deriveView withInjProj ''TxIds
 deriveView withInj ''Exceptions

--- a/lib/src/Dscp/Snowdrop/Expanders.hs
+++ b/lib/src/Dscp/Snowdrop/Expanders.hs
@@ -67,7 +67,7 @@ toProofBalanceTx (TxWitnessed tx (TxWitness {..})) =
     txType = StateTxType $ getId (Proxy @TxIds) AccountTxId
     wsSignature = txwSig
     wsPublicKey = txwPk
-    wsBody = (txId tx, txInAcc tx)
+    wsBody = (txId tx, wsPublicKey)
 
 seqExpandersBalanceTx :: SeqExpanders Exceptions Ids Proofs Values ctx TxWitnessed
 seqExpandersBalanceTx =
@@ -101,10 +101,15 @@ seqExpandersBalanceTx =
 
         outs <- forM outOther $ \TxOut{..} -> do
             prevAcc <- getCurAcc txOutAddr
-            let outVal = coinToInteger txOutValue
-            let newAcc = Account { aBalance = outVal , aNonce = 0 }
+
+            let outVal    = coinToInteger txOutValue
+            let newAcc    = Account { aBalance = outVal,               aNonce = 0 }
             let updAcc a0 = Account { aBalance = aBalance a0 + outVal, aNonce = aNonce a0 }
-            let ch = maybe (New $ AccountOutVal newAcc) (Upd . AccountOutVal . updAcc) prevAcc
+            let ch        = maybe
+                    (New $ AccountOutVal   newAcc)
+                    (Upd . AccountOutVal . updAcc)
+                    prevAcc
+
             pure (AccountInIds (AccountId txOutAddr), ch)
 
         pure $ mkDiffCS $ M.fromList $ inp : outs


### PR DESCRIPTION
- Changed `HasPrism` to `HasGetter` for all the validator properties because we don't need to reconstruct `proof` from anything. I blindly copied `HasPrism` constraints back then. Thats what reading SD code does to people.
- Implemented all validatior requirements on `Proofs`.
- Changed requirements to `Expander` to signed `(TxId, PublicKey)`, since `Address` is wrapper around `Hash PublicKey` and `AuthorId` can be retrieved from that.
- Pulled authentication in validator into separate method.