### PR TITLE
[AD-311] Remove Coin token, make tyCoin accept both ValueCoin and ValueNumber

### DIFF
--- a/wallet/package.yaml
+++ b/wallet/package.yaml
@@ -23,6 +23,7 @@ library:
     - lens
     - loc
     - megaparsec
+    - scientific
     - serialise
     - serokell-util
     - text


### PR DESCRIPTION
Coin parsing no longer interfers with number parsing.
Both number literals and `get-balance` return values can be used as input to `tx-out`.
Still, numbers are properly validated on input.