### PR TITLE
[AD-310] Handle keys as strings in Knit

### DIFF
--- a/wallet/README.md
+++ b/wallet/README.md
@@ -5,20 +5,20 @@ Ariadne-based wallet for Disciplina.
 Short usage example:
 ```
 knit> gen-key-pair
-L "z1fEXUH5atk6W1VPWkwMMk7rfWIOsK26GMFXIW6hovg="             -- secret key
-  "DpeMraH5KSkJpx79Rmt+w5ouhx8Yp0dxlBgOgg3bPBQ="             -- public key
-  LL4qKtG4mmZF4nC8hMiTpmsG7noszDtWZhiVHuqQsEqtghWdiCFmkkMp   -- address
+L "UDpQX35yW72QVKcL4ufC7YtQMDcPghbX+nKcccrRpHNLZFggwgj8Zo0cbRTepMzHudhyuatPGP5isWJNuNu7vS1ONBs="  -- encrypted secret key
+  "D/nSS++ZrpsxqjV/Pj38iH75FJP73YBqyTyKUbqqfck="                                                  -- public key
+  LL4qKnmSQJJB3hdRKdL1J61HJYFzSwChWjcoZqzHPFdSdzyLZmdSSKiD                                        -- address
 
 knit> gen-key-pair "passphrase"
-L "UFQtH7e81aWSevzLT9pww1JQNZ2o/kaXzrYxV2AaR/oZBFggIj3ohhCpNXFrvPyxLT9R8r76kihL2l3Eu7O0aLswsQI="  -- encrypted secret key
-  "sLug89UoeND+Du7zriv+mBwZkDKYT1w420+k6szs6ZQ="                                                  -- public key
-  LL4qKtG4mmZF4nC8hMiTpmsG7noszDtWZhiVHuqQsEqtghWdiCFmkkMp                                        -- address
+L "UBLf8FurpezJgVIFx6SHJMNQtz9eW8GTQs8y7eR5SzKDYVggFbb449bpHZIimt/H+bhjMyIRLj4aTKdpjFsFJPGS4Rg="  -- encrypted secret key
+  "v6NE7nYvDzJDYGZ5hZnW4oBDmsmWL+l1L2jpFy3s3+M="                                                  -- public key
+  LL4qKtozvcr44DA3rXDDy7kX94aseq5XfnZ2yYbmUNDG316pdEfTo7WD                                        -- address
 
-knit> send-tx "z1fEXUH5atk6W1VPWkwMMk7rfWIOsK26GMFXIW6hovg=" (tx-out LL4qKtG4mmZF4nC8hMiTpmsG7noszDtWZhiVHuqQsEqtghWdiCFmkkMp 10) 
-"b67d7c65adb4310cf548bdc3440dee1c8730ea19b65ad50be4e8a2ef80932db8"  -- transaction id
+knit> send-tx "UDpQX35yW72QVKcL4ufC7YtQMDcPghbX+nKcccrRpHNLZFggwgj8Zo0cbRTepMzHudhyuatPGP5isWJNuNu7vS1ONBs=" (tx-out LL4qKtG4mmZF4nC8hMiTpmsG7noszDtWZhiVHuqQsEqtghWdiCFmkkMp 10)
+"6745d05dcd39a97faa735be93e64a669fc73ac569f301236e87ec85814ff227b"  -- transaction id
 
-knit> send-tx "passphrase" "UFQtH7e81aWSevzLT9pww1JQNZ2o/kaXzrYxV2AaR/oZBFggIj3ohhCpNXFrvPyxLT9R8r76kihL2l3Eu7O0aLswsQI=" (tx-out LL4qKtG4mmZF4nC8hMiTpmsG7noszDtWZhiVHuqQsEqtghWdiCFmkkMp 10)
-"a187f6335885449a5743837c432c541e84fef0a5c2e3c6e044d1396961257e61"  -- transaction id
+knit> send-tx "UBLf8FurpezJgVIFx6SHJMNQtz9eW8GTQs8y7eR5SzKDYVggFbb449bpHZIimt/H+bhjMyIRLj4aTKdpjFsFJPGS4Rg=" "passphrase" (tx-out LL4qKtG4mmZF4nC8hMiTpmsG7noszDtWZhiVHuqQsEqtghWdiCFmkkMp 10)
+"a4355afd95cfde8ea84c42155dfe7018bcd7d41ce5a4fc1bcd3ddb2879f489ce"  -- transaction id
 
 knit> get-balance LL4qKtG4mmZF4nC8hMiTpmsG7noszDtWZhiVHuqQsEqtghWdiCFmkkMp
 1337

--- a/wallet/README.md
+++ b/wallet/README.md
@@ -5,18 +5,19 @@ Ariadne-based wallet for Disciplina.
 Short usage example:
 ```
 knit> gen-key-pair
-L z1fEXUH5atk6W1VPWkwMMk7rfWIOsK26GMFXIW6hovg=               -- secret key
-  DpeMraH5KSkJpx79Rmt+w5ouhx8Yp0dxlBgOgg3bPBQ=               -- public key
+L "z1fEXUH5atk6W1VPWkwMMk7rfWIOsK26GMFXIW6hovg="             -- secret key
+  "DpeMraH5KSkJpx79Rmt+w5ouhx8Yp0dxlBgOgg3bPBQ="             -- public key
   LL4qKtG4mmZF4nC8hMiTpmsG7noszDtWZhiVHuqQsEqtghWdiCFmkkMp   -- address
 
 knit> gen-key-pair "passphrase"
-L UFQtH7e81aWSevzLT9pww1JQNZ2o/kaXzrYxV2AaR/oZBFggIj3ohhCpNXFrvPyxLT9R8r76kihL2l3Eu7O0aLswsQI=  -- encrypted secret key
-  sLug89UoeND+Du7zriv+mBwZkDKYT1w420+k6szs6ZQ=                                                  -- public key
+L "UFQtH7e81aWSevzLT9pww1JQNZ2o/kaXzrYxV2AaR/oZBFggIj3ohhCpNXFrvPyxLT9R8r76kihL2l3Eu7O0aLswsQI="  -- encrypted secret key
+  "sLug89UoeND+Du7zriv+mBwZkDKYT1w420+k6szs6ZQ="                                                  -- public key
+  LL4qKtG4mmZF4nC8hMiTpmsG7noszDtWZhiVHuqQsEqtghWdiCFmkkMp                                        -- address
 
-knit> send-tx z1fEXUH5atk6W1VPWkwMMk7rfWIOsK26GMFXIW6hovg= (tx-out LL4qKtG4mmZF4nC8hMiTpmsG7noszDtWZhiVHuqQsEqtghWdiCFmkkMp 10) 
+knit> send-tx "z1fEXUH5atk6W1VPWkwMMk7rfWIOsK26GMFXIW6hovg=" (tx-out LL4qKtG4mmZF4nC8hMiTpmsG7noszDtWZhiVHuqQsEqtghWdiCFmkkMp 10) 
 "b67d7c65adb4310cf548bdc3440dee1c8730ea19b65ad50be4e8a2ef80932db8"  -- transaction id
 
-knit> send-tx "passphrase" UFQtH7e81aWSevzLT9pww1JQNZ2o/kaXzrYxV2AaR/oZBFggIj3ohhCpNXFrvPyxLT9R8r76kihL2l3Eu7O0aLswsQI= (tx-out LL4qKtG4mmZF4nC8hMiTpmsG7noszDtWZhiVHuqQsEqtghWdiCFmkkMp 10)
+knit> send-tx "passphrase" "UFQtH7e81aWSevzLT9pww1JQNZ2o/kaXzrYxV2AaR/oZBFggIj3ohhCpNXFrvPyxLT9R8r76kihL2l3Eu7O0aLswsQI=" (tx-out LL4qKtG4mmZF4nC8hMiTpmsG7noszDtWZhiVHuqQsEqtghWdiCFmkkMp 10)
 "a187f6335885449a5743837c432c541e84fef0a5c2e3c6e044d1396961257e61"  -- transaction id
 
 knit> get-balance LL4qKtG4mmZF4nC8hMiTpmsG7noszDtWZhiVHuqQsEqtghWdiCFmkkMp


### PR DESCRIPTION
Parsing bare unquoted strings without strictly defined length as public/secret key broke some other Knit commands.
Thus, we require quotes around keys now.

Also, secret keys are always encrypted now. Empty passphrase is used if no passphrase is supplied.