### PR TITLE
[OPS-330] [OPS-331] refactor nix to output multiple packages

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,14 @@
 with import <nixpkgs> { overlays = [ (import <serokell-overlay/pkgs>) ]; };
-with lib;
 with haskell.lib;
 let
+  getAttrs = attrs: set: lib.genAttrs attrs (name: set.${name});
+in
+buildStackApplication rec {
+  packages = [
+    "disciplina-core" "disciplina-witness" "disciplina-educator"
+    "disciplina-wallet" "disciplina-tools"
+  ];
+
   # Running hpack manually before the build is required
   # because of the problem in stack2nix -- it builds every
   # subpackage in a separate environment, thus moving
@@ -17,16 +24,7 @@ let
     done
   '';
 
-  srcPath = import (writeText "path.nix" src);
-
   ghc = haskell.compiler.ghc822;
-
-  packages = [
-    "disciplina-core" "disciplina-witness" "disciplina-educator"
-    "disciplina-wallet" "disciplina-tools"
-  ];
-
-  getAttrs = attrs: set: genAttrs attrs (name: set.${name});
 
   overrides = 
     final: previous: 
@@ -39,9 +37,4 @@ let
     in {
       rocksdb-haskell = dependCabal previous.rocksdb-haskell [ rocksdb ];
     } // (mapAttrs (const overrideModule) (getAttrs packages previous));
-
-  closure = stackClosure ghc srcPath overrides;
-
-in
-  getAttrs packages closure
-
+}

--- a/default.nix
+++ b/default.nix
@@ -17,6 +17,8 @@ let
     done
   '';
 
+  srcPath = import (writeText "path.nix" src);
+
   ghc = haskell.compiler.ghc822;
 
   packages = [
@@ -38,7 +40,7 @@ let
       rocksdb-haskell = dependCabal previous.rocksdb-haskell [ rocksdb ];
     } // (mapAttrs (const overrideModule) (getAttrs packages previous));
 
-  closure = stackClosure ghc src overrides;
+  closure = stackClosure ghc srcPath overrides;
 
 in
   getAttrs packages closure

--- a/default.nix
+++ b/default.nix
@@ -36,5 +36,5 @@ buildStackApplication rec {
         overrideModule = prev: overrideCabal prev (overridingSet final);
     in {
       rocksdb-haskell = dependCabal previous.rocksdb-haskell [ rocksdb ];
-    } // (mapAttrs (const overrideModule) (getAttrs packages previous));
+    } // (lib.mapAttrs (lib.const overrideModule) (getAttrs packages previous));
 }


### PR DESCRIPTION
Output an attrset with all the relevant packages.

I could've sworn `getAttrs` exists in nixpkgs already, but couldn't find it.