### PR TITLE
Bump cryptonite-openssl version to 0.7

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -13,6 +13,7 @@ nix:
 extra-deps:
 - aeson-options-0.0.0
 - base58-bytestring-0.1.0
+- cryptonite-openssl-0.7
 - pretty-tree-0.1.0.0
 - time-units-1.0.0
 - componentm-0.0.0.2


### PR DESCRIPTION
LTS has cryptonite-openssl-0.6, which causes the following build error:
```
    <command line>: can't load .so/.DLL for: /home/goodsoft/.stack/snapshots/x86_64-linux-tinfo6/lts-11.17/8.2.2/lib/x86_64-linux-ghc-8.2.2/libHScryptonite-openssl-0.6-8ex6yYmKYbJFQoAbbvgmKg-ghc8.2.2.so (/home/goodsoft/.stack/snapshots/x86_64-linux-tinfo6/lts-11.17/8.2.2/lib/x86_64-linux-ghc-8.2.2/libHScryptonite-openssl-0.6-8ex6yYmKYbJFQoAbbvgmKg-ghc8.2.2.so: undefined symbol: EVP_CIPHER_CTX_init)
```

See also https://serokell.slack.com/archives/C9B1DAMDJ/p1532533676000094