### PR TITLE
[DSCP-167] Proper JSON instances for configuration types

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -6,10 +6,9 @@ demo:
     genesis: 
       genesisSeed: "GromakNaRechke"
       governance: 
-        govCommittee: 
-          committeeOpen: 
-            secret: "opencomittee"
-            n: 2
+        type: committeeOpen
+        secret: "opencommittee"
+        n: 2
       distribution: 
         - equal: 1000
         - specific:

--- a/core/src/Dscp/Core/Aeson.hs
+++ b/core/src/Dscp/Core/Aeson.hs
@@ -67,7 +67,7 @@ instance FromJSON Governance where
             commParticipants <- o .: "participants"
             return $ GovCommittee (CommitteeClosed {..})
         "governanceOpen" -> return GovOpen
-        _ -> fail "Governance type is invalid: "
+        _ -> fail "Governance type is invalid"
 
 ---------------------------------------------------------------------------
 -- Standalone derivations for newtypes

--- a/core/src/Dscp/Core/Aeson.hs
+++ b/core/src/Dscp/Core/Aeson.hs
@@ -3,7 +3,7 @@
 module Dscp.Core.Aeson () where
 
 import Data.Aeson (FromJSON (..), FromJSONKey (..), ToJSON (..), ToJSONKey, Value (..),
-                   withScientific, withText)
+                   withScientific, withText, withObject, (.:))
 import Data.Aeson.Options (defaultOptions)
 import Data.Aeson.TH (deriveFromJSON, deriveJSON)
 
@@ -55,6 +55,20 @@ instance ToJSON SubmissionWitness where
 instance FromJSON SubmissionWitness where
     parseJSON = parseJSONSerialise Base16
 
+instance FromJSON Governance where
+  parseJSON = withObject "governance" $ \o -> do
+    (governanceType :: Text) <- o .: "type"
+    case governanceType of
+        "committeeOpen" -> do
+            commSecret <- o .: "secret"
+            commN <- o .: "n"
+            return $ GovCommittee (CommitteeOpen {..})
+        "committeeClosed" -> do
+            commParticipants <- o .: "participants"
+            return $ GovCommittee (CommitteeClosed {..})
+        "governanceOpen" -> return GovOpen
+        _ -> fail "Governance type is invalid: "
+
 ---------------------------------------------------------------------------
 -- Standalone derivations for newtypes
 ---------------------------------------------------------------------------
@@ -105,7 +119,6 @@ deriveJSON defaultOptions ''PublicationHead
 deriveJSON defaultOptions ''PublicationNext
 
 deriveFromJSON defaultOptions ''Committee
-deriveFromJSON defaultOptions ''Governance
 deriveJSON defaultOptions ''GenesisDistributionElem
 deriveFromJSON defaultOptions ''GenesisConfig
 


### PR DESCRIPTION
This would introduce new configuration format for _governance_ param in configuration.yaml file.
```
governance:
       type: governanceOpen

OR

governance:
       type: committeeOpen
       secret: "secret"
       n: N

OR

governance:
       type: committeeClosed
       participants: [p_1, 
                      p_2,
                      ...
                      p_n]
```
