### PR TITLE
[AD-269] Show account address as a wallet ID

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -51,7 +51,7 @@ extra-deps:
     - code/prelude
 
 - git: https://github.com/serokell/ariadne.git
-  commit: d754b82c1a8c901f4656c6def407d10d5b220178
+  commit: d8760c8c2c25c82aaeca8674bdbff13b0d2fba94
   subdirs:
     - ariadne/core
     - knit

--- a/wallet/app-vty/Glue.hs
+++ b/wallet/app-vty/Glue.hs
@@ -269,6 +269,7 @@ walletEventToUI WalletState{ selection } = \case
       Account{..} <- accounts ^? ix (fromIntegral i)
       Just $ UiSelectionWallet $ UiWalletInfo
         { uwiLabel = Just $ fromMaybe (pretty accountAddress) accountName
+        , uwiId = pretty accountAddress
         , uwiWalletIdx = i
         , uwiBalance = Nothing
         , uwiAccounts = []


### PR DESCRIPTION
Now you can name an account in any way you want and still be able to copy-paste its address.

![image](https://user-images.githubusercontent.com/2828228/44157561-6ba36900-a0bb-11e8-9cdf-f9b0657dcf27.png)
