### PR TITLE
Set bash in shebang of demo launcher

### DIFF
--- a/scripts/launch/demo.sh
+++ b/scripts/launch/demo.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e -o pipefail
 


### PR DESCRIPTION
For me `sh` does not know what is `set -o pipefail`