### PR TITLE
[DSCP-208] Prevented application/validation exns from leaking out

### DIFF
--- a/witness/src/Dscp/Witness/Workers/Worker.hs
+++ b/witness/src/Dscp/Witness/Workers/Worker.hs
@@ -144,5 +144,9 @@ makeRelay (RelayState input pipe failedTxs) =
             isThere <- isInMempool @ctx pool tx
 
             unless isThere $ do
-                addTxToMempool @ctx pool tx
+                good <- addTxToMempool @ctx pool tx
+
+                unless good $ do
+                    atomically $ STM.modifyTVar failedTxs $ HashMap.insert (hash tx) tx
+
                 atomically $ STM.writeTQueue pipe tx

--- a/witness/src/Dscp/Witness/Workers/Worker.hs
+++ b/witness/src/Dscp/Witness/Workers/Worker.hs
@@ -146,7 +146,8 @@ makeRelay (RelayState input pipe failedTxs) =
             unless isThere $ do
                 good <- addTxToMempool @ctx pool tx
 
-                unless good $ do
-                    atomically $ STM.modifyTVar failedTxs $ HashMap.insert (hash tx) tx
+                unless good $
+                    atomically $
+                        STM.modifyTVar failedTxs $ HashMap.insert (hash tx) tx
 
                 atomically $ STM.writeTQueue pipe tx


### PR DESCRIPTION
- Also `failedTxs` `TVar` is now filled with txs.
- But is never cleaned.