### PR TITLE
[DSCP-221] Support HTTPS in witness client

### DIFF
--- a/faucet/src/Dscp/Faucet/CLI.hs
+++ b/faucet/src/Dscp/Faucet/CLI.hs
@@ -25,7 +25,7 @@ faucetParamsParser = do
     _fpLoggingParams <- logParamsParser "faucet"
     _fpKeyParams <- baseKeyParamsParser "faucet"
     _fpWebParams <- serverParamsParser "faucet"
-    _fpWitnessAddress <- networkAddressParser "witness-backend" witnessBackendHelp
+    _fpWitnessAddress <- clientAddressParser "witness-backend" witnessBackendHelp
     _fpTranslatedAmount <- translatedAmountParser
     _fpDryRun <- dryRunParser
     return FaucetParams{..}

--- a/faucet/src/Dscp/Faucet/Launcher/Params.hs
+++ b/faucet/src/Dscp/Faucet/Launcher/Params.hs
@@ -32,7 +32,7 @@ data FaucetParams = FaucetParams
       -- ^ Corresponds to source of transactions made by faucet.
     , _fpWebParams        :: ServerParams
       -- ^ Parameters of faucet API server.
-    , _fpWitnessAddress   :: NetworkAddress
+    , _fpWitnessAddress   :: BaseUrl
       -- ^ Address of transactions processing backend.
     , _fpTranslatedAmount :: TranslatedAmount
       -- ^ How much money to send on request.

--- a/wallet/README.md
+++ b/wallet/README.md
@@ -8,7 +8,7 @@ Two frontends are provided:
 
 Running the wallet requires specifying a witness node address:
 ```
-dscp-wallet --wallet-server 18.136.123.101:4030
+dscp-wallet --witness witness-1.disciplina.serokell.team
 ```
 
 Some useful Knit commands:

--- a/wallet/exec-cli/Main.hs
+++ b/wallet/exec-cli/Main.hs
@@ -1,15 +1,13 @@
 module Main where
 
 import IiExtras
-import Options.Applicative (execParser, fullDesc, helper, info, progDesc)
 import Text.PrettyPrint.ANSI.Leijen (Doc)
 
 import Ariadne.Knit.Backend
 import Ariadne.TaskManager.Backend
 import Ariadne.UI.Cli
-import Dscp.CommonCLI
 import Dscp.Wallet.Backend
-import Dscp.Web
+import Dscp.Wallet.CLI
 
 import qualified Ariadne.TaskManager.Knit as Knit
 import qualified Dscp.Wallet.Knit as Knit
@@ -40,10 +38,3 @@ main = do
     uiAction = mkUiAction (knitFaceToUI uiFace knitFace)
 
   uiAction
-
-getWalletCLIParams :: IO NetworkAddress
-getWalletCLIParams = do
-    let parser = networkAddressParser "wallet-server" "Address of wallet server"
-    execParser $
-        info (helper <*> versionOption <*> parser) $
-        fullDesc <> progDesc "Client wallet node."

--- a/wallet/exec/Main.hs
+++ b/wallet/exec/Main.hs
@@ -1,16 +1,14 @@
 module Main where
 
 import IiExtras
-import Options.Applicative (execParser, fullDesc, helper, info, progDesc)
 import Text.PrettyPrint.ANSI.Leijen (Doc)
 
 import Ariadne.Knit.Backend
 import Ariadne.TaskManager.Backend
 import Ariadne.UI.Vty
 import Ariadne.UI.Vty.Face
-import Dscp.CommonCLI
 import Dscp.Wallet.Backend
-import Dscp.Web
+import Dscp.Wallet.CLI
 
 import qualified Ariadne.TaskManager.Knit as Knit
 import qualified Ariadne.UI.Vty.Knit as Knit
@@ -54,10 +52,3 @@ main = do
     uiAction = mkUiAction (knitFaceToUI uiWalletState uiFace walletFace knitFace)
 
   uiAction
-
-getWalletCLIParams :: IO NetworkAddress
-getWalletCLIParams = do
-    let parser = networkAddressParser "wallet-server" "Address of wallet server"
-    execParser $
-        info (helper <*> versionOption <*> parser) $
-        fullDesc <> progDesc "Client wallet node."

--- a/wallet/package.yaml
+++ b/wallet/package.yaml
@@ -25,6 +25,7 @@ library:
     - knit
     - lens
     - memory
+    - optparse-applicative
     - scientific
     - serialise
     - serokell-util
@@ -49,11 +50,9 @@ executables:
       - double-conversion
       - disciplina-core
       - disciplina-wallet
-      - disciplina-witness
       - ii-extras
       - knit
       - lens
-      - optparse-applicative
       - serokell-util
       - text
       - vector
@@ -69,8 +68,6 @@ executables:
       - ariadne-core
       - disciplina-core
       - disciplina-wallet
-      - disciplina-witness
       - ii-extras
       - knit
-      - optparse-applicative
       - text

--- a/wallet/src/Dscp/Wallet/Backend.hs
+++ b/wallet/src/Dscp/Wallet/Backend.hs
@@ -13,7 +13,7 @@ import Dscp.Web
 import Dscp.Witness.Web.Client
 import Dscp.Witness.Web.Types
 
-createWalletFace :: NetworkAddress -> (WalletEvent -> IO ()) -> IO WalletFace
+createWalletFace :: BaseUrl -> (WalletEvent -> IO ()) -> IO WalletFace
 createWalletFace serverAddress sendEvent = do
     sendStateUpdateEvent sendEvent
     wc <- createWitnessClient serverAddress

--- a/wallet/src/Dscp/Wallet/CLI.hs
+++ b/wallet/src/Dscp/Wallet/CLI.hs
@@ -1,0 +1,15 @@
+module Dscp.Wallet.CLI
+       ( getWalletCLIParams
+       ) where
+
+import Options.Applicative (execParser, fullDesc, helper, info, progDesc)
+
+import Dscp.CommonCLI
+import Dscp.Web
+
+getWalletCLIParams :: IO BaseUrl
+getWalletCLIParams = do
+    let parser = clientAddressParser "witness" "Address of a witness node to communicate with"
+    execParser $
+        info (helper <*> versionOption <*> parser) $
+        fullDesc <> progDesc "Ariadne wallet for Disciplina"

--- a/witness/package.yaml
+++ b/witness/package.yaml
@@ -25,7 +25,7 @@ library:
     - free
     - hashable
     - http-types
-    - http-client
+    - http-client-tls
     - interpolatedstring-perl6
     - lens
     - loot-base

--- a/witness/src/Dscp/CommonCLI.hs
+++ b/witness/src/Dscp/CommonCLI.hs
@@ -10,6 +10,7 @@ module Dscp.CommonCLI
        , timeReadM
        , coinReadM
        , networkAddressParser
+       , clientAddressParser
        , serverParamsParser
        ) where
 
@@ -18,6 +19,7 @@ import Data.Version (showVersion)
 import qualified Loot.Log as Log
 import Options.Applicative (Parser, ReadM, auto, eitherReader, help, infoOption, long, metavar,
                             option, str, strOption, switch)
+import Servant.Client (BaseUrl (..), parseBaseUrl)
 import Text.InterpolatedString.Perl6 (qc)
 import Text.Parsec (eof, many1, parse, sepBy)
 import Text.Parsec.Char (char, digit)
@@ -116,6 +118,13 @@ networkAddressParser pName helpTxt =
     option (eitherReader parseNetAddr) $
     long pName <>
     metavar "HOST:PORT" <>
+    help helpTxt
+
+clientAddressParser :: String -> String -> Parser BaseUrl
+clientAddressParser pName helpTxt =
+    option (eitherReader $ first displayException . parseBaseUrl) $
+    long pName <>
+    metavar "URL" <>
     help helpTxt
 
 serverParamsParser :: String -> Parser ServerParams

--- a/witness/src/Dscp/Web/Server.hs
+++ b/witness/src/Dscp/Web/Server.hs
@@ -1,7 +1,8 @@
 -- | Utils for serving HTTP APIs
 
 module Dscp.Web.Server
-       ( Scheme (..)
+       ( BaseUrl (..)
+       , Scheme (..)
        , serveWeb
        , buildServantLogConfig
        , buildClientEnv
@@ -11,7 +12,7 @@ import Control.Lens (views)
 import Loot.Base.HasLens (HasLens', lensOf)
 import Loot.Log (Logging, MonadLogging, Name, NameSelector (..))
 import qualified Loot.Log.Internal as Log
-import Network.HTTP.Client (defaultManagerSettings, newManager)
+import Network.HTTP.Client.TLS (newTlsManager)
 import qualified Network.Wai.Handler.Warp as Warp
 import Servant (Application)
 import Servant.Client (BaseUrl (..), ClientEnv, Scheme (..), mkClientEnv)
@@ -53,13 +54,7 @@ buildServantLogConfig modifyName = do
 ----------------------------------------------------------------------------
 
 -- | Construct common client networking environment.
-buildClientEnv :: MonadIO m => Scheme -> NetworkAddress -> m ClientEnv
-buildClientEnv scheme netAddr = do
-    let baseUrl = BaseUrl
-            { baseUrlScheme = scheme
-            , baseUrlHost = toString $ naHost netAddr
-            , baseUrlPort = fromIntegral $ naPort netAddr
-            , baseUrlPath = ""
-            }
-    manager <- liftIO $ newManager defaultManagerSettings
+buildClientEnv :: MonadIO m => BaseUrl -> m ClientEnv
+buildClientEnv baseUrl = do
+    manager <- liftIO $ newTlsManager
     return $ mkClientEnv manager baseUrl

--- a/witness/src/Dscp/Witness/Web/Client/Logic.hs
+++ b/witness/src/Dscp/Witness/Web/Client/Logic.hs
@@ -5,7 +5,7 @@ module Dscp.Witness.Web.Client.Logic
        , hoistWitnessClient
        ) where
 
-import Servant.Client (Client, ClientM, Scheme (..), client, runClientM)
+import Servant.Client (Client, ClientM, client, runClientM)
 import Servant.Generic ((:-), fromServant)
 
 import Dscp.Resource.Class
@@ -39,9 +39,9 @@ hoistWitnessClient nat es =
     , wGetHashType = nat ... wGetHashType es
     }
 
-createWitnessClient :: MonadIO m => NetworkAddress -> m WitnessClient
+createWitnessClient :: MonadIO m => BaseUrl -> m WitnessClient
 createWitnessClient netAddr = do
-    cliEnv <- buildClientEnv Http netAddr
+    cliEnv <- buildClientEnv netAddr
     let nat :: ClientM a -> IO a
         nat act = runClientM act cliEnv >>= leftToThrow servantToWitnessError
 
@@ -53,7 +53,7 @@ createWitnessClient netAddr = do
 -- Instances
 ----------------------------------------------------------------------------
 
-instance AllocResource NetworkAddress WitnessClient where
+instance AllocResource BaseUrl WitnessClient where
     allocResource params =
         buildComponentR "witness client"
             (createWitnessClient params)


### PR DESCRIPTION
Using `Servant.Client.BaseUrl` instead of `NetworkAddress` for flexible URL parsing.
Also, using `http-client-tls` instead of `http-client` for SSL/TLS support.
`--wallet-server` is renamed to `--witness` for less typing.

Both wallet and faucet can now connect to witness using hostname or even full-fledged URL.
Example: `dscp-wallet --witness witness-1.disciplina.serokell.team`
HTTP is used by default if no protocol is provided (didn't bother monkey-patching `servant-client`), but it should be fine, as the requests will be redirected to HTTPS by nginx anyway.

Next step would be making `--witness` parameter optional for the wallet and hard-coding some sensible default list of witness nodes.