### PR TITLE
[DSCP-231] Allow specifying a knit command as dscp-wallet-cli argument

### DIFF
--- a/wallet/exec-cli/Main.hs
+++ b/wallet/exec-cli/Main.hs
@@ -1,11 +1,14 @@
 module Main where
 
+import Control.Concurrent.Async (wait)
 import Control.Monad.Component (ComponentM, runComponentM)
 import IiExtras
 import Text.PrettyPrint.ANSI.Leijen (Doc)
 
 import Ariadne.Knit.Backend
+import Ariadne.Knit.Face
 import Ariadne.TaskManager.Backend
+import Ariadne.TaskManager.Face
 import Ariadne.UI.Cli
 import Dscp.Wallet.Backend
 import Dscp.Wallet.CLI
@@ -20,13 +23,13 @@ type UiComponents = '[Knit.Core, Knit.TaskManager, Knit.Wallet]
 
 main :: IO ()
 main = do
-    serverAddress <- getWalletCLIParams
-    runComponentM "ariadne" (initializeEverything serverAddress) id
+    params <- getWalletCLIParams
+    runComponentM "ariadne" (initializeEverything params) id
 
-initializeEverything :: BaseUrl -> ComponentM (IO ())
-initializeEverything serverAddress = do
+initializeEverything :: WalletCLIParams -> ComponentM (IO ())
+initializeEverything WalletCLIParams{..} = do
     taskManagerFace <- createTaskManagerFace
-    walletFace <- createWalletFace serverAddress (void . return)
+    walletFace <- createWalletFace wpWitness (void . return)
     (uiFace, mkUiAction) <- createAriadneUI
 
     let knitExecContext :: (Doc -> IO ()) -> Knit.ExecContext IO UiComponents
@@ -39,6 +42,23 @@ initializeEverything serverAddress = do
         knitFace = createKnitBackend knitExecContext taskManagerFace
 
         uiAction :: IO ()
-        uiAction = mkUiAction (knitFaceToUI uiFace knitFace)
+        uiAction = case wpKnitCommand of
+            Nothing -> mkUiAction (knitFaceToUI uiFace knitFace)
+            Just cmd -> case Knit.parse @UiComponents cmd of
+                Right expr -> do
+                    whenJustM (putKnitCommand knitFace handle expr) $ \tid -> do
+                        whenJustM (lookupTask taskManagerFace tid) $ void . wait
+                Left err -> print $ Knit.ppParseError err
+              where
+                handle = KnitCommandHandle
+                    { putCommandResult = \_ -> handleResult
+                    , putCommandOutput = \_ doc -> print doc
+                    }
+                handleResult = \case
+                    KnitCommandSuccess v -> print $ Knit.ppValue v
+                    KnitCommandEvalError e -> print $ Knit.ppEvalError e
+                    KnitCommandProcError e -> print $ Knit.ppResolveErrors e
+                    KnitCommandException e -> print $ displayException e
+
 
     return uiAction

--- a/wallet/exec/Main.hs
+++ b/wallet/exec/Main.hs
@@ -25,11 +25,11 @@ type UiComponents = '[Knit.Core, Knit.Wallet, Knit.TaskManager, Knit.UI]
 
 main :: IO ()
 main = do
-    serverAddress <- getWalletCLIParams
-    runComponentM "ariadne" (initializeEverything serverAddress) id
+    params <- getWalletCLIParams
+    runComponentM "ariadne" (initializeEverything params) id
 
-initializeEverything :: BaseUrl -> ComponentM (IO ())
-initializeEverything serverAddress = do
+initializeEverything :: WalletCLIParams -> ComponentM (IO ())
+initializeEverything WalletCLIParams{..} = do
     uiWalletState <- createWalletState
 
     let features = UiFeatures
@@ -42,7 +42,7 @@ initializeEverything serverAddress = do
             }
     (uiFace, mkUiAction) <- createAriadneUI features historyToUI
     taskManagerFace <- createTaskManagerFace
-    walletFace <- createWalletFace serverAddress (putWalletEventToUI uiWalletState uiFace)
+    walletFace <- createWalletFace wpWitness (putWalletEventToUI uiWalletState uiFace)
 
     let knitExecContext :: (Doc -> IO ()) -> Knit.ExecContext IO UiComponents
         knitExecContext putCommandOutput =

--- a/wallet/package.yaml
+++ b/wallet/package.yaml
@@ -70,6 +70,7 @@ executables:
       - ansi-wl-pprint
       - ariadne-cli-lib
       - ariadne-core
+      - async
       - componentm
       - disciplina-core
       - disciplina-wallet

--- a/wallet/src/Dscp/Wallet/CLI.hs
+++ b/wallet/src/Dscp/Wallet/CLI.hs
@@ -1,16 +1,28 @@
 module Dscp.Wallet.CLI
-       ( BaseUrl
+       ( WalletCLIParams (..)
        , getWalletCLIParams
        ) where
 
-import Options.Applicative (execParser, fullDesc, helper, info, progDesc)
+import Options.Applicative (execParser, fullDesc, help, helper, info, long,
+                            metavar, optional, progDesc, strOption)
 
 import Dscp.CommonCLI
 import Dscp.Web
 
-getWalletCLIParams :: IO BaseUrl
+data WalletCLIParams = WalletCLIParams
+    { wpWitness :: BaseUrl
+    , wpKnitCommand :: Maybe Text
+    }
+
+getWalletCLIParams :: IO WalletCLIParams
 getWalletCLIParams = do
-    let parser = clientAddressParser "witness" "Address of a witness node to communicate with"
+    let parser = do
+            wpWitness <- clientAddressParser "witness" "Address of a witness node to communicate with"
+            wpKnitCommand <- optional $ strOption $
+                long "knit" <>
+                metavar "COMMAND" <>
+                help "Execute provided knit command and exit."
+            return WalletCLIParams{..}
     execParser $
         info (helper <*> versionOption <*> parser) $
         fullDesc <> progDesc "Ariadne wallet for Disciplina"


### PR DESCRIPTION
Example: `dscp-wallet-cli --witness <witness> --knit "get-balance <address>"`