### PR TITLE
[DSCP-232] Fix transaction paging in BE API

### DIFF
--- a/witness/src/Dscp/Witness/Logic/Traversals.hs
+++ b/witness/src/Dscp/Witness/Logic/Traversals.hs
@@ -187,5 +187,6 @@ getTxs depth = \case
             Nothing -> return $ txs ++ res
             Just nextBlock -> loadTxs (txs ++ res) (depthLeft - limit) Nothing nextBlock
       where
-        limit = fromMaybe (length txs) mLimit
-        txs = map (GTxInBlock (Just block)) . bbTxs . bBody $ block
+        blockTxs = bbTxs . bBody $ block
+        limit = fromMaybe (length blockTxs) mLimit
+        txs = GTxInBlock (Just block) <$> take limit blockTxs


### PR DESCRIPTION
When we list transactions starting from a particular transaction in the middle of a block,
we have to drop transactions which happened _after_ specified one, which we didn't.