### PR TITLE
[DSCP-241] Fix one block application issue

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -32,7 +32,7 @@ extra-deps:
   commit: f9a0cd66f443d7b0e04a3c8ae8d475f8344b823b
 
 - git: https://github.com/serokell/blockchain-util.git
-  commit: 496f064199abaf810599acdab985a1db41f315b3 # master
+  commit: 0252789e6b3d562fd189cbc66e4bfa76d363138f # dscp/release-alpha
   subdirs:
     - snowdrop-core
     - snowdrop-util

--- a/witness/src/Dscp/Snowdrop/Configuration.hs
+++ b/witness/src/Dscp/Snowdrop/Configuration.hs
@@ -34,10 +34,13 @@ module Dscp.Snowdrop.Configuration
     , _AccountValidationError
 
     , TxIds (..)
+
+    , BlockPlusAVLComposition
     ) where
 
 
 import Control.Lens (makePrisms)
+import Data.Reflection (Reifies (..))
 import qualified Data.Set as S
 import qualified Data.Text.Buildable as B
 import Fmt (build, (+|))
@@ -312,6 +315,14 @@ instance Enum TxIds where
 
 instance IdStorage TxIds AccountTxTypeId
 instance IdStorage TxIds PublicationTxTypeId
+
+----------------------------------------------------------------------------
+-- Misc
+----------------------------------------------------------------------------
+
+data BlockPlusAVLComposition
+instance Reifies BlockPlusAVLComposition (Set Prefix) where
+    reflect _ = blockPrefixes
 
 ----------------------------------------------------------------------------
 -- HasReview and lenses

--- a/witness/src/Dscp/Witness/Logic/Processing.hs
+++ b/witness/src/Dscp/Witness/Logic/Processing.hs
@@ -9,7 +9,6 @@ module Dscp.Witness.Logic.Processing
 
 import Data.Default (def)
 import qualified Data.Map as M
-import Data.Reflection (reify)
 import Data.Time.Clock (UTCTime (..))
 import Loot.Base.HasLens (lensOf)
 import Serokell.Util (enumerate)
@@ -61,9 +60,10 @@ applyBlockRaw toVerify block = do
     let blockDBM = nsBlockDBActions sdActions
     let stateDBM = nsStateDBActions sdActions (SD.RememberForProof True)
 
-    (blockCS, stateCS) <- reify blockPrefixes $ \(_ :: Proxy ps) ->
-        let actions = SD.constructCompositeActions @ps (SD.dmaAccessActions blockDBM)
-                                                       (SD.dmaAccessActions stateDBM)
+    (blockCS, stateCS) <-
+        let actions = SD.constructCompositeActions @BlockPlusAVLComposition
+                                                   (SD.dmaAccessActions blockDBM)
+                                                   (SD.dmaAccessActions stateDBM)
             rwComp = do
               sblock <- SD.liftERoComp $ expandBlock block
               -- getCurrentTime requires MonadIO

--- a/witness/src/Dscp/Witness/Mempool/Logic.hs
+++ b/witness/src/Dscp/Witness/Mempool/Logic.hs
@@ -17,7 +17,6 @@ import qualified Data.Set as S
 import Loot.Base.HasLens (HasLens', lensOf)
 
 import qualified Snowdrop.Core as SD
-import qualified Snowdrop.Execution as SD (dmaAccessActions)
 import qualified Snowdrop.Execution as Pool
 import qualified Snowdrop.Execution as AVLP
 import qualified Snowdrop.Util as SD
@@ -25,6 +24,7 @@ import qualified Snowdrop.Util as SD
 import Dscp.Core.Foundation (GTxWitnessed)
 import Dscp.Core.Foundation.Witness
 import qualified Dscp.Snowdrop as SD
+import Dscp.Snowdrop.Actions (sdActionsComposition)
 import Dscp.Snowdrop.Configuration (Exceptions, Ids, Values)
 import Dscp.Witness.Mempool.Type
 import Dscp.Witness.SDLock
@@ -100,7 +100,7 @@ readFromMempool
 readFromMempool pool action = do
     actions <- view (lensOf @SD.SDVars)
     logger  <- view (lensOf @SD.LoggingIO)
-    let dbActions = SD.dmaAccessActions $ SD.nsStateDBActions actions (AVLP.RememberForProof False)
+    let dbActions = sdActionsComposition (AVLP.RememberForProof False) actions
     SD.runRIO logger $
         SD.unwrapSDBaseRethrow $
         Pool.actionWithMempool pool dbActions action
@@ -125,7 +125,7 @@ writeToMempool
 writeToMempool pool action = do
     actions <- view (lensOf @SD.SDVars)
     logger  <- view (lensOf @SD.LoggingIO)
-    let dbActions = SD.dmaAccessActions $ SD.nsStateDBActions actions (AVLP.RememberForProof False)
+    let dbActions = sdActionsComposition (AVLP.RememberForProof False) actions
     SD.runRIO logger $
         SD.unwrapSDBaseRethrow $
         Pool.actionWithMempool pool dbActions action

--- a/witness/src/Dscp/Witness/Mempool/Type.hs
+++ b/witness/src/Dscp/Witness/Mempool/Type.hs
@@ -18,7 +18,11 @@ import Dscp.Witness.AVL (AvlHash)
 import qualified Snowdrop.Execution as AVLP
 import qualified Snowdrop.Execution as Pool
 
-type ChgAccum = AVLP.AVLChgAccum AvlHash Ids Values
+type ChgAccum =
+    Pool.CompositeChgAccum
+        (Pool.SumChangeSet Ids Values)
+        (AVLP.AVLChgAccum AvlHash Ids Values)
+        BlockPlusAVLComposition
 
 type MempoolVar = Mempool (SD.IOCtx ChgAccum)
 


### PR DESCRIPTION
1. Fixes an issue related to nonces, mentioned in ticket https://issues.serokell.io/issue/DSCP-241 as error #3, which could be deterministically reproduced when creating transactions with same destination address within a single slot. Original issue yet remains.

Fix is in snowdrop, related commit: https://github.com/serokell/blockchain-util/commit/0252789e6b3d562fd189cbc66e4bfa76d363138f.
Approved by @pva701.

2. Fixes problem with `TxOf`s mentioned in issue as well, by making mempool consider block storage.
