### PR TITLE
[DSCP-176] Educator implementation (part 1)

### DIFF
--- a/core/package.yaml
+++ b/core/package.yaml
@@ -22,6 +22,7 @@ library:
     - directory
     - exceptions
     - fmt
+    - generic-arbitrary
     - hashable
     - hspec
     - log-warper

--- a/core/src/Dscp/Core/Arbitrary.hs
+++ b/core/src/Dscp/Core/Arbitrary.hs
@@ -20,6 +20,7 @@ module Dscp.Core.Arbitrary
     , tiList
     , tiInfUnique
     , genCoreTestEnv
+    , cteSubmissions
     , simpleCoreTestParams
     , wildCoreTestParams
 
@@ -38,10 +39,13 @@ module Dscp.Core.Arbitrary
 
 import qualified Data.Foldable
 import Data.List (nub)
+import qualified Data.Text.Buildable
 import Data.Time.Clock (UTCTime, getCurrentTime)
+import Fmt ((+||), (||+))
 import qualified GHC.Exts as Exts
 import GHC.IO.Unsafe (unsafePerformIO)
 import Test.QuickCheck (sized)
+import qualified Text.Show
 
 import Dscp.Core.Foundation
 import Dscp.Crypto
@@ -224,6 +228,20 @@ data CoreTestEnv = CoreTestEnv
     , cteSignedSubmissions :: TestItem SignedSubmission
     , ctePrivateTxs        :: TestItem PrivateTx
     }
+
+cteSubmissions :: CoreTestEnv -> TestItem Submission
+cteSubmissions = fmap _ssSubmission . cteSignedSubmissions
+
+instance Show CoreTestEnv where
+    show = toString . pretty
+
+instance Buildable CoreTestEnv where
+    build env@CoreTestEnv{..} =
+        "Students: "    +|| tiList cteStudents ||+ "\n\
+        \Courses: "     +|| tiList cteCourses ||+ "\n\
+        \Assignments: " +|| tiList cteAssignments ||+ "\n\
+        \Submissions: " +|| tiList (cteSubmissions env) ||+ "\n\
+        \Private txs: " +|| tiList ctePrivateTxs ||+ ""
 
 -- | Generate 'CoreTestEnv'.
 --

--- a/core/src/Dscp/Core/Foundation/Educator.hs
+++ b/core/src/Dscp/Core/Foundation/Educator.hs
@@ -202,7 +202,7 @@ type SubmissionSig = Signature (Id Submission)
 data SubmissionWitness = SubmissionWitness
     { _swKey :: !PublicKey
     , _swSig :: !SubmissionSig
-    } deriving (Show, Eq, Generic)
+    } deriving (Show, Eq, Ord, Generic)
 
 -- | Datatype for verifiable transaction (transaction with a witness)
 data SignedSubmission = SignedSubmission
@@ -210,7 +210,7 @@ data SignedSubmission = SignedSubmission
     -- ^ Student submission
     , _ssWitness    :: !SubmissionWitness
     -- ^ Submission witness
-    } deriving (Eq, Show, Generic)
+    } deriving (Eq, Ord, Show, Generic)
 
 instance HasHash Submission => HasId SignedSubmission where
     type Id SignedSubmission = Hash Submission
@@ -242,7 +242,7 @@ data PrivateTx = PrivateTx
     -- ^ Grade for this submission
     , _ptTime             :: !UTCTime
     -- ^ Timestamp for this transaction
-    } deriving (Show, Eq, Generic)
+    } deriving (Show, Eq, Ord, Generic)
 
 type PrivateTxId = Hash PrivateTx
 

--- a/core/src/Dscp/Core/Genesis.hs
+++ b/core/src/Dscp/Core/Genesis.hs
@@ -74,7 +74,7 @@ distrElemToMap (Just addrs) (GDEqual cTotal) =
             a :| as -> let n = length addrs
                            c = fromIntegral $ unCoin cTotal
                            each' = c `div` n
-                       in (a, unsafeMkCoin $ c - (n-1) * each') :
+                       in (a, unsafeMkCoin $ c - (n - 1) * each') :
                           map (, unsafeMkCoin each') as
     in if sum (map (unCoin . snd) mapping) /= unCoin cTotal
        then error "distrToMap: equal summing failed"

--- a/core/src/Dscp/Crypto/Aeson.hs
+++ b/core/src/Dscp/Crypto/Aeson.hs
@@ -6,6 +6,7 @@ module Dscp.Crypto.Aeson () where
 
 import Prelude hiding (toStrict)
 
+import Codec.Serialise (Serialise)
 import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.ByteArray (ByteArrayAccess)
 import Data.Reflection (Reifies (..))
@@ -13,6 +14,7 @@ import Data.Reflection (Reifies (..))
 import Dscp.Crypto.ByteArray (FromByteArray)
 import Dscp.Crypto.Encrypt (Encrypted)
 import Dscp.Crypto.Hash (AbstractHash)
+import Dscp.Crypto.MerkleTree
 import Dscp.Crypto.Signing (AbstractPK, AbstractSig)
 import Dscp.Util.Aeson (AsByteString (..), CustomEncoding (..), HexEncoded, IsEncoding,
                         parseJSONSerialise, toJSONSerialise)
@@ -38,3 +40,17 @@ instance ByteArrayAccess (AbstractSig ss a) => ToJSON (AbstractSig ss a) where
     toJSON = toJSON . AsByteString @HexEncoded
 instance FromByteArray (AbstractSig ss a) => FromJSON (AbstractSig ss a) where
     parseJSON = fmap (getAsByteString @HexEncoded) . parseJSON
+
+instance (IsEncoding enc) =>
+         ToJSON (CustomEncoding enc $ MerkleSignature a) where
+    toJSON = toJSONSerialise (reflect (Proxy @enc)). unCustomEncoding
+instance (IsEncoding enc) =>
+         FromJSON (CustomEncoding enc $ MerkleSignature a) where
+    parseJSON = fmap CustomEncoding . parseJSONSerialise (reflect (Proxy @enc))
+
+instance (Serialise a, IsEncoding enc) =>
+         ToJSON (CustomEncoding enc $ MerkleProof a) where
+    toJSON = toJSONSerialise (reflect (Proxy @enc)). unCustomEncoding
+instance (Serialise a, IsEncoding enc) =>
+         FromJSON (CustomEncoding enc $ MerkleProof a) where
+    parseJSON = fmap CustomEncoding . parseJSONSerialise (reflect (Proxy @enc))

--- a/core/src/Dscp/Crypto/Arbitrary.hs
+++ b/core/src/Dscp/Crypto/Arbitrary.hs
@@ -2,11 +2,14 @@
 
 module Dscp.Crypto.Arbitrary () where
 
+import Test.QuickCheck.Arbitrary.Generic (genericArbitrary, genericShrink)
+
 import Dscp.Util.Test
 
 import Dscp.Crypto.ByteArray
 import Dscp.Crypto.Encrypt
 import Dscp.Crypto.Hash
+import Dscp.Crypto.MerkleTree
 import Dscp.Crypto.Signing
 
 ----------------------------------------------------------------------------
@@ -39,3 +42,15 @@ instance Arbitrary PassPhrase where
 instance (Arbitrary ba, FromByteArray ba) =>
          Arbitrary (Encrypted ba) where
     arbitrary = encrypt <$> arbitrary <*> arbitrary
+
+----------------------------------------------------------------------------
+-- Merkle tree
+----------------------------------------------------------------------------
+
+instance Arbitrary a => Arbitrary (MerkleSignature a) where
+    arbitrary = genericArbitrary
+    shrink = genericShrink
+
+instance Arbitrary a => Arbitrary (MerkleProof a) where
+    arbitrary = genericArbitrary
+    shrink = genericShrink

--- a/core/src/Dscp/Crypto/MerkleTree.hs
+++ b/core/src/Dscp/Crypto/MerkleTree.hs
@@ -171,6 +171,8 @@ data MerkleProof a
         { pnSig :: !(MerkleSignature a) }
     deriving (Eq, Show, Functor, Foldable, Traversable, Generic)
 
+instance Serialise a => Serialise (MerkleProof a)
+
 getMerkleProofRoot :: MerkleProof a -> MerkleSignature a
 getMerkleProofRoot = pnSig
 

--- a/core/src/Dscp/Util.hs
+++ b/core/src/Dscp/Util.hs
@@ -87,7 +87,7 @@ listToMaybeWarn msg = \case
     [] -> pure Nothing
     [x] -> pure (Just x)
     (x:_) -> do
-        logWarning $ "listToMaybeWarn: to many entries ("+|msg|+")"
+        logWarning $ "listToMaybeWarn: too many entries ("+|msg|+")"
         return (Just x)
 
 allUniqueOrd :: Ord a => [a] -> Bool

--- a/core/src/Dscp/Util/Test.hs
+++ b/core/src/Dscp/Util/Test.hs
@@ -30,10 +30,11 @@ import Data.Typeable (typeRep)
 import GHC.Show (Show (show))
 import Test.Hspec as T
 import Test.QuickCheck as T (Arbitrary (..), Fixed (..), Gen, Property, Testable (..), choose,
-                             elements, expectFailure, forAll, frequency, infiniteList, ioProperty,
-                             label, listOf, listOf1, oneof, property, sublistOf, suchThat,
-                             suchThatMap, vectorOf, (.&&.), (===), (==>))
+                             conjoin, cover, elements, expectFailure, forAll, frequency,
+                             infiniteList, ioProperty, label, listOf, listOf1, oneof, property,
+                             sublistOf, suchThat, suchThatMap, vectorOf, (.&&.), (===), (==>))
 import Test.QuickCheck (sized)
+import qualified Test.QuickCheck as Q
 import Test.QuickCheck.Gen (Gen (..))
 import Test.QuickCheck.Instances as T ()
 import Test.QuickCheck.Property as T (rejected)
@@ -139,12 +140,17 @@ throwsPrism
 throwsPrism excL action = do
     catchJust (^? excL) (action $> False) (\_ -> return True)
 
+expectOne :: Text -> [a] -> a
+expectOne _    [x] = x
+expectOne desc xs  =
+    error $ "expectOne: " <> pretty (length xs) <> " entities (" <> desc <> ")"
+
+counterexample :: Testable prop => Text -> prop -> Property
+counterexample desc prop = Q.counterexample (toString desc) prop
+
 ----------------------------------------------------------------------------
 -- Roundtrips
 ----------------------------------------------------------------------------
-
-
-
 
 serialiseRoundtrip
     :: forall a. (Arbitrary a, Serialise a, Eq a, Show a)

--- a/core/src/Dscp/Util/Type.hs
+++ b/core/src/Dscp/Util/Type.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeOperators #-}
+
+-- | Type-level tricks.
+module Dscp.Util.Type
+    ( type (==)
+    ) where
+
+import Data.Type.Bool (type (&&))
+
+-- | A type family to compute Boolean equality.
+-- Poly-kinded version of (Data.Type.Equality.==), till the moment we switch to
+-- lts-12.
+type family (a :: k) == (b :: k) :: Bool where
+  f a == g b = f == g && a == b
+  a == a = 'True
+  _ == _ = 'False

--- a/educator/database/schema.sql
+++ b/educator/database/schema.sql
@@ -9,6 +9,9 @@
 --  non integer or integer desc PK is present, some of tables are created
 --  WITHOUT ROWID.
 
+-- This pragma should be actually executed for each db connection.
+pragma foreign_keys = ON;
+
 begin transaction;
 
 -- Creating 'Courses' table.
@@ -129,10 +132,10 @@ create table if not exists Transactions (
     submission_hash  BLOB     not null,
     grade            INTEGER  not null,
     time             TIME     not null,
-    idx              INTEGER  not null,    -- Index inside a block. Can be 0 or -1 for every mempool transaction.
+    idx              INTEGER  not null,    -- Index inside a block. -1 for every mempool transaction.
 
     primary key (hash),
-    foreign key (submission_hash) references Submissions(hash)
+    foreign key (submission_hash) references Submissions(hash) on delete restrict
 
 ) without rowid;
 

--- a/educator/database/schema.sql
+++ b/educator/database/schema.sql
@@ -19,7 +19,7 @@ create table if not exists Courses (
     --  null with autoincremented key (while sqlite2 won't).
     --
     id    INTEGER,
-    desc  TEXT     null,
+    desc  TEXT     not null,
 
     primary key (id asc)
 );
@@ -29,7 +29,7 @@ create table if not exists Courses (
 create table if not exists Subjects (
     id         INTEGER  not null,
     course_id  INTEGER  not null,
-    desc       TEXT     null,
+    desc       TEXT     not null,
 
     primary key (id, course_id),
     foreign key (course_id) references Courses (id)
@@ -75,7 +75,7 @@ create table if not exists Assignments (
     course_id      INTEGER  not null,
     contents_hash  BLOB     not null,
     type           INTEGER  not null,
-    desc           TEXT     null,
+    desc           TEXT     not null,
 
     primary key (hash),
     foreign key (course_id) references Courses(id)

--- a/educator/package.yaml
+++ b/educator/package.yaml
@@ -56,6 +56,9 @@ tests:
       - disciplina-core
       - disciplina-witness
       - disciplina-educator
+      - data-default
+      - fmt
+      - generic-arbitrary
       - hspec
       - lens
       - loot-log
@@ -63,6 +66,7 @@ tests:
       - sqlite-simple
       - tasty
       - tasty-hspec
+      - text-format
       - time
       - QuickCheck
       - unliftio

--- a/educator/package.yaml
+++ b/educator/package.yaml
@@ -12,6 +12,7 @@ library:
     - autoexporter
     - bytestring
     - containers
+    - data-default
     - directory
     - direct-sqlite
     - disciplina-core
@@ -36,6 +37,7 @@ library:
     - servant-auth-server
     - servant-generic
     - servant-server
+    - singleton-bool
     - sqlite-simple
     - template-haskell
     - text

--- a/educator/src/Dscp/DB/SQLite/Error.hs
+++ b/educator/src/Dscp/DB/SQLite/Error.hs
@@ -7,6 +7,7 @@ module Dscp.DB.SQLite.Error
 
       -- * Common SQL errors
     , asAlreadyExistsError
+    , asReferenceInvalidError
     ) where
 
 import qualified Data.Text as T
@@ -70,5 +71,14 @@ asAlreadyExistsError :: SQLError -> Maybe Text
 asAlreadyExistsError err = do
     SQLError ErrorConstraint details _ <- pure err
     let pat = "UNIQUE constraint failed"
+    guard $ pat `T.isPrefixOf` details
+    return $ T.drop (length pat) details
+
+-- | Matches on errors which declare violation of FOREIGN KEY constraint,
+-- returns descrition of violated constraint.
+asReferenceInvalidError :: SQLError -> Maybe Text
+asReferenceInvalidError err = do
+    SQLError ErrorConstraint details _ <- pure err
+    let pat = "FOREIGN KEY constraint failed"
     guard $ pat `T.isPrefixOf` details
     return $ T.drop (length pat) details

--- a/educator/src/Dscp/DB/SQLite/Queries.hs
+++ b/educator/src/Dscp/DB/SQLite/Queries.hs
@@ -494,7 +494,7 @@ isAssignedToStudent student assignment = do
     |]
 
 
-createCourse :: DBM m => Course -> Maybe Text -> [Id Subject] -> m (Id Course)
+createCourse :: DBM m => Course -> Text -> [Id Subject] -> m (Id Course)
 createCourse course desc subjects = do
     transaction $ do
         execute createCourseRequest (course, desc)

--- a/educator/src/Dscp/DB/SQLite/Util.hs
+++ b/educator/src/Dscp/DB/SQLite/Util.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE ExistentialQuantification #-}
+
+-- | Utilities for writing SQLite queries.
+
+module Dscp.DB.SQLite.Util
+     (
+       -- * Filtering
+       FilterClause (..)
+     , SomeParams (..)
+     , oneParam
+     , mkFilter
+     , filterClauses
+
+       -- * Conditional fields extraction
+     , FetchIf
+     , positiveFetch
+     ) where
+
+import Data.Singletons.Bool (SBoolI, fromSBool, sbool)
+import Database.SQLite.Simple ((:.) (..), FromRow (..), Only (..), Query, ToRow (..))
+import Database.SQLite.Simple.ToField (ToField)
+
+---------------------------------------------------------------------
+-- Filtering
+---------------------------------------------------------------------
+
+-- | One of conditions within conjenction sum after @where@.
+newtype FilterClause = FilterClause { unFilterClause :: String }
+    deriving (IsString)
+
+-- | Contains a list of objects forming a row in SQL table.
+data SomeParams = forall a. ToRow a => SomeParams a
+
+instance Semigroup SomeParams where
+    SomeParams a <> SomeParams b = SomeParams (a :. b)
+
+instance Monoid SomeParams where
+    mempty = SomeParams ()
+    mappend = (<>)
+
+instance ToRow SomeParams where
+    toRow (SomeParams a) = toRow a
+
+-- | Lift a single field to 'SomeParams'.
+oneParam :: ToField a => a -> SomeParams
+oneParam = SomeParams . Only
+
+-- | For SQL table field and optional value, makes a clause to select
+-- only rows with given condition (if corresponding filter is present).
+-- This function helps to deal with sqlite feature of passing parameters
+-- seperately from query itself.
+mkFilter :: ToField a => String -> Maybe a -> (FilterClause, SomeParams)
+mkFilter filterClause mparam = case mparam of
+      Just param -> (FilterClause ("and " <> filterClause),
+                     oneParam param)
+      Nothing    -> ("", mempty)
+
+-- | Attaches filtering @where@ clauses to query.
+-- "where" statement with some condition should go last in the query.
+filterClauses :: Query -> [FilterClause] -> Query
+filterClauses queryText fs =
+    mconcat $ queryText : map (fromString . unFilterClause) fs
+infixl 1 `filterClauses`
+
+---------------------------------------------------------------------
+-- Fields selection
+---------------------------------------------------------------------
+
+-- | Pack of fields which are only parsed if 'required' is set to 'True'.
+newtype FetchIf (required :: Bool) a = FetchIf (Maybe a)
+
+-- | Get the value if it was required.
+positiveFetch :: (required ~ 'True) => FetchIf required a -> a
+positiveFetch (FetchIf a) = a ?: error "positiveFetch: Nothing"
+
+instance (FromRow a, SBoolI required) => FromRow (FetchIf required a) where
+    fromRow
+        | fromSBool (sbool @required) = FetchIf . Just <$> fromRow
+        | otherwise                   = pure (FetchIf Nothing)

--- a/educator/src/Dscp/Educator/Web/Arbitrary.hs
+++ b/educator/src/Dscp/Educator/Web/Arbitrary.hs
@@ -23,6 +23,6 @@ gradeInfoEx =
 blkProofInfoEx :: BlkProofInfo
 blkProofInfoEx =
     BlkProofInfo
-    { bpiMtreeSerialized = AsByteString $ detGen 123 arbitrary
+    { bpiMtreeSerialized = CustomEncoding $ detGen 123 arbitrary
     , bpiTxs = one privateTxEx
     }

--- a/educator/src/Dscp/Educator/Web/Bot/Setting.hs
+++ b/educator/src/Dscp/Educator/Web/Bot/Setting.hs
@@ -18,7 +18,6 @@ module Dscp.Educator.Web.Bot.Setting
      ) where
 
 import Control.Exception.Safe (catchJust)
-import Control.Lens (traversed)
 import qualified Data.Map as M
 import Data.Reflection (Given (..), give)
 import qualified Data.Set as S
@@ -74,7 +73,7 @@ genBotCourseAssignments n _aCourseId =
 data BotSetting = BotSetting
     {
       -- | All courses info
-      bsCourses           :: [(Course, Text, [Id Subject])]
+      bsCourses           :: [CourseDetails]
       -- | We show a small set of courses at the beginning in order not to
       -- confuse user, and disclose all others later to prevent him getting
       -- bored.
@@ -97,6 +96,7 @@ mkBotSetting params =
   botGen = detGenG (ebpSeed params)
 
   bsCourses =
+    map (\(c, d, s) -> CourseDetails c d s)
     -- using 'courseEx' here helps to keep examples in swagger doc working
     [ (Course 0  , "Patakology", [])
     , (Course 1  , "Learning!", [])
@@ -133,12 +133,12 @@ mkBotSetting params =
     ]
 
   (bsBasicCourses, bsAdvancedCourses) =
-    splitAt 3 (bsCourses ^.. traversed . _1)
+    splitAt 3 (map cdCourseId bsCourses)
 
   bsCourseAssignments =
     M.fromList $
     botGen $
-    forM (zip courseSizes bsCourses) $ \(courseSize, (course, _, _)) -> do
+    forM (zip courseSizes bsCourses) $ \(courseSize, CourseDetails course _ _) -> do
         assignments <- genBotCourseAssignments courseSize course
         let assignmentsWithEx =
                 bool identity (assignmentEx :)
@@ -189,8 +189,7 @@ botPrepareInitialData :: (BotWorkMode m, HasBotSetting) => m ()
 botPrepareInitialData = do
     exists <- existsCourse (head . Exts.fromList $ bsBasicCourses botSetting)
     unless exists $ do
-        forM_ (bsCourses botSetting) $
-            \(c, t, s) -> createCourse c t s
+        forM_ (bsCourses botSetting) createCourse
         mapM_ createAssignment (bsAssignments botSetting)
 
 -- REMEMBER that all operations below should be no-throw

--- a/educator/src/Dscp/Educator/Web/Bot/Setting.hs
+++ b/educator/src/Dscp/Educator/Web/Bot/Setting.hs
@@ -190,7 +190,7 @@ botPrepareInitialData = do
     exists <- existsCourse (head . Exts.fromList $ bsBasicCourses botSetting)
     unless exists $ do
         forM_ (bsCourses botSetting) $
-            \(c, t, s) -> createCourse c (Just t) s
+            \(c, t, s) -> createCourse c t s
         mapM_ createAssignment (bsAssignments botSetting)
 
 -- REMEMBER that all operations below should be no-throw

--- a/educator/src/Dscp/Educator/Web/Educator/API.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/API.hs
@@ -36,7 +36,7 @@ educatorAPI = Proxy
 protectedEducatorAPI :: Proxy ProtectedEducatorAPI
 protectedEducatorAPI = Proxy
 
--- TODO: add a way to fetch ALL assignments, even whose which are not assigned to any student
+-- TODO [DSCP-176]: add a way to fetch ALL assignments, even whose which are not assigned to any student
 
 data EducatorApiEndpoints route = EducatorApiEndpoints
     {

--- a/educator/src/Dscp/Educator/Web/Educator/API.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/API.hs
@@ -36,6 +36,8 @@ educatorAPI = Proxy
 protectedEducatorAPI :: Proxy ProtectedEducatorAPI
 protectedEducatorAPI = Proxy
 
+-- TODO: add a way to fetch ALL assignments, even whose which are not assigned to any student
+
 data EducatorApiEndpoints route = EducatorApiEndpoints
     {
       -- * Students

--- a/educator/src/Dscp/Educator/Web/Educator/API.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/API.hs
@@ -60,7 +60,7 @@ data EducatorApiEndpoints route = EducatorApiEndpoints
         :- "students"
         :> Summary "Get a list of all registered students' addresses"
         :> QueryParam "courseId" Course
-        :> Get '[DSON] [Student]
+        :> Get '[DSON] [StudentInfo]
 
       -- * Courses
 
@@ -81,7 +81,7 @@ data EducatorApiEndpoints route = EducatorApiEndpoints
         :> Summary "Enroll a student in a new course"
         :> Description "Given existing student and course, enroll the \
                         \student to the course."
-        :> ReqBody '[DSON] CourseEducatorInfo
+        :> ReqBody '[DSON] EnrollStudentToCourse
         :> Post '[DSON] ()
 
     , eGetStudentCourses :: route
@@ -107,7 +107,7 @@ data EducatorApiEndpoints route = EducatorApiEndpoints
         :> Summary "Get active student's assignments"
         :> Description "Given student address, gets a list of all pending \
                         \assignments student has."
-        :> Get '[DSON] [Assignment]
+        :> Get '[DSON] [AssignmentEducatorInfo]
 
     , eAssignToStudent :: route
         :- "students" :> Capture "studentAddr" Student
@@ -136,7 +136,7 @@ data EducatorApiEndpoints route = EducatorApiEndpoints
                         \all pending assignments student has as a part of a \
                         \course."
         :> QueryParam "isFinal" IsFinal
-        :> Get '[DSON] [Assignment]
+        :> Get '[DSON] [AssignmentEducatorInfo]
 
       -- * Submissions
 
@@ -144,7 +144,7 @@ data EducatorApiEndpoints route = EducatorApiEndpoints
         :- "submissions" :> Capture "submissionHash" (Hash Submission)
         :> Summary "Get info about a submission"
         :> Description "Gets a submission data by given submission hash."
-        :> Get '[DSON] [SubmissionEducatorInfo]
+        :> Get '[DSON] SubmissionEducatorInfo
 
     , eDeleteSubmission :: route
         :- "submissions" :> Capture "submissionHash" (Hash Submission)

--- a/educator/src/Dscp/Educator/Web/Educator/Error.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Error.hs
@@ -18,7 +18,7 @@ import Data.Aeson.TH (deriveToJSON)
 import Data.Reflection (Reifies (..))
 import Data.Typeable (cast)
 import Dscp.DB.SQLite (DomainError)
-import Servant (ServantErr (..), err400, err403, err500)
+import Servant (ServantErr (..), err400, err500)
 
 import Dscp.Educator.Web.Util
 import Dscp.Util.Servant
@@ -27,11 +27,9 @@ import Dscp.Util.Servant
 data APIError
     = SomeDomainError DomainError
       -- ^ Something not found or already exists.
-    | StudentIsActiveError
-      -- ^ Cannot delete a student because he attends some courses.
     | InvalidFormat
       -- ^ Failed to decode something.
-    deriving (Show, Eq, Generic, Typeable)
+    deriving (Show, Eq, Generic)
 
 makePrisms ''APIError
 
@@ -55,7 +53,6 @@ deriveToJSON defaultOptions ''ErrResponse
 
 instance ToJSON APIError where
     toJSON = String . \case
-        StudentIsActiveError -> "StudentIsActive"
         InvalidFormat        -> "InvalidFormat"
         SomeDomainError err  -> domainErrorToShortJSON err
 
@@ -66,7 +63,6 @@ instance ToJSON APIError where
 -- | Get HTTP error code of error.
 toServantErrNoReason :: APIError -> ServantErr
 toServantErrNoReason = \case
-    StudentIsActiveError -> err403
     InvalidFormat        -> err400
     SomeDomainError err  -> domainToServantErrNoReason err
 

--- a/educator/src/Dscp/Educator/Web/Educator/Handlers.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Handlers.hs
@@ -71,8 +71,8 @@ educatorApiHandlers =
 
     , eGetStudentCourseAssignments = \student course afIsFinal ->
         sqlTransaction $
-        commonGetAssignments EducatorCase student
-            def{ afCourse = Just course, afIsFinal }
+          commonGetAssignments EducatorCase student
+              def{ afCourse = Just course, afIsFinal }
 
       -- * Submissions
 

--- a/educator/src/Dscp/Educator/Web/Educator/Handlers.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Handlers.hs
@@ -38,7 +38,11 @@ educatorApiHandlers =
       -- * Courses
 
     , eAddCourse = \(NewCourse cid desc subjects) ->
-        void $ createCourse cid (desc ?: "") (subjects ?: [])
+        void $ createCourse CourseDetails
+            { cdCourseId = cid
+            , cdDesc = desc ?: ""
+            , cdSubjects = subjects ?: []
+            }
 
     , eGetCourses =
         educatorGetCourses Nothing

--- a/educator/src/Dscp/Educator/Web/Educator/Handlers.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Handlers.hs
@@ -15,6 +15,7 @@ import Dscp.Educator.Web.Educator.Error
 import Dscp.Educator.Web.Educator.Logic
 import Dscp.Educator.Web.Educator.Queries
 import Dscp.Educator.Web.Educator.Types
+import Dscp.Educator.Web.Logic
 import Dscp.Educator.Web.Queries
 import Dscp.Educator.Web.Types
 
@@ -57,7 +58,7 @@ educatorApiHandlers =
 
     , eAddCourseAssignment = \_autoAssign na -> do
         void $ createAssignment (requestToAssignment na)
-        error "Auto assign (in transaction!)"
+        -- TODO [DSCP-176]: consider autoassign
 
     , eGetStudentAssignments = \student ->
         sqlTransaction $ commonGetAssignments EducatorCase student def

--- a/educator/src/Dscp/Educator/Web/Educator/Logic.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Logic.hs
@@ -2,6 +2,7 @@ module Dscp.Educator.Web.Educator.Logic
     ( EducatorApiWorkMode
 
     , educatorGetSubmission
+    , educatorGetAllSubmissions
     ) where
 
 import Data.Default (def)
@@ -29,3 +30,8 @@ educatorGetSubmission submissionH = do
     commonGetSubmissions EducatorCase def{ sfSubmissionHash = Just submissionH }
         >>= listToMaybeWarn "submission"
         >>= nothingToThrow (AbsentError $ SubmissionDomain submissionH)
+
+educatorGetAllSubmissions
+    :: EducatorApiWorkMode m
+    => m [SubmissionEducatorInfo]
+educatorGetAllSubmissions = commonGetSubmissions EducatorCase def

--- a/educator/src/Dscp/Educator/Web/Educator/Logic.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Logic.hs
@@ -1,0 +1,31 @@
+module Dscp.Educator.Web.Educator.Logic
+    ( EducatorApiWorkMode
+
+    , educatorGetSubmission
+    ) where
+
+import Data.Default (def)
+
+import Dscp.Core
+import Dscp.Crypto
+import Dscp.DB.SQLite
+import Dscp.Educator.Web.Educator.Queries
+import Dscp.Educator.Web.Educator.Types
+import Dscp.Educator.Web.Queries
+import Dscp.Educator.Web.Types
+import Dscp.Util
+
+type EducatorApiWorkMode m =
+    ( MonadCatch m
+    , MonadSQLiteDB m
+    , MonadEducatorAPIQuery m
+    )
+
+educatorGetSubmission
+    :: EducatorApiWorkMode m
+    => Hash Submission
+    -> m SubmissionEducatorInfo
+educatorGetSubmission submissionH = do
+    commonGetSubmissions EducatorCase def{ sfSubmissionHash = Just submissionH }
+        >>= listToMaybeWarn "submission"
+        >>= nothingToThrow (AbsentError $ SubmissionDomain submissionH)

--- a/educator/src/Dscp/Educator/Web/Educator/Queries.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Queries.hs
@@ -1,0 +1,169 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module Dscp.Educator.Web.Educator.Queries
+    ( module Dscp.Educator.Web.Educator.Queries
+    ) where
+
+import Control.Lens (from, mapping, traversed)
+import Data.List (groupBy)
+import Data.Time.Clock (getCurrentTime)
+import Database.SQLite.Simple (Only (..), Query)
+import Loot.Log (MonadLogging)
+import Servant (err501)
+import Text.InterpolatedString.Perl6 (q)
+
+import Dscp.Core
+import Dscp.Crypto
+import Dscp.DB.SQLite
+import Dscp.Educator.Web.Educator.Types
+import Dscp.Educator.Web.Types
+import Dscp.Educator.Web.Util
+import Dscp.Util
+
+type MonadEducatorAPIQuery m =
+    ( MonadSQLiteDB m
+    , MonadCatch m
+    , MonadLogging m
+    )
+
+educatorRemoveStudent :: MonadEducatorAPIQuery m => Student -> m ()
+educatorRemoveStudent student = do
+    -- TODO Proper implementation of this method may require
+    -- fundemental rethinking of our database scheme and rewriting many code.
+    -- Should be done soon though.
+    _ <- throwM err501
+    execute queryText (Only student)
+  where
+    queryText :: Query
+    queryText = [q|
+        delete
+        from      Students
+        where     addr = ?
+    |]
+
+educatorGetStudents
+    :: MonadEducatorAPIQuery m
+    => Maybe Course -> m [StudentInfo]
+educatorGetStudents courseF = do
+    map (StudentInfo . fromOnly) <$> query queryText paramF
+  where
+    (clauseF, paramF) = mkFilterOn "course_id" courseF
+
+    queryText = [q|
+        select    addr
+        from      Students
+        left join StudentCourses
+               on Students.addr = StudentCourses.student_addr
+        where     course_id = ?
+    |]
+      `filterClauses` [clauseF]
+
+educatorGetCourses :: DBM m => Maybe Student -> m [CourseEducatorInfo]
+educatorGetCourses studentF = do
+    res <- query queryText paramF
+    return $
+        -- group "subject" fields
+        [ CourseEducatorInfo{..}
+        | course@((ciId, ciDesc, _) : _) <- groupBy ((==) `on` view _1) res
+        , let ciSubjects = course ^.. traversed . _3
+        ]
+  where
+    (clauseF, paramF) = mkFilterOn "student_addr" studentF
+
+    queryText = [q|
+        select    Courses.id, Courses.desc, Subjects.id
+        from      Courses
+        left join Subjects
+               on Courses.id = Subjects.course_id
+        left join StudentCourses
+               on StudentCourses.course_id = Courses.id
+        order by  Courses.id asc  -- TODO: is it necessary?
+    |]
+      `filterClauses` [clauseF]
+
+educatorUnassignFromStudent
+    :: MonadEducatorAPIQuery m
+    => Student
+    -> Hash Assignment
+    -> m ()
+educatorUnassignFromStudent student assignH = do
+    -- we are not deleting other info since educator may want it to be preserved
+    -- in case if he wants to assign as assignment again
+    execute queryText (student, assignH)
+  where
+    queryText :: Query
+    queryText = [q|
+        delete
+        from      StudentsAssignments
+        where     student_addr = ?
+              and assignment_hash = ?
+    |]
+
+isGradedSubmission
+    :: MonadEducatorAPIQuery m
+    => Hash Submission -> m Bool
+isGradedSubmission submissionH = do
+    checkExists queryText (Only submissionH)
+  where
+    queryText :: Query
+    queryText = [q|
+        select    count(*)
+        from      Transactions
+        where     submission_hash = ?
+    |]
+
+educatorGetGrades
+    :: MonadEducatorAPIQuery m
+    => Maybe Student
+    -> Maybe Course
+    -> Maybe IsFinal
+    -> m [GradeInfo]
+educatorGetGrades studentF courseIdF isFinalF = do
+    query queryText (mconcat paramsF)
+  where
+    studentFilter = mkFilterOn "S.student_addr" studentF
+    courseFilter = mkFilterOn "course_id" courseIdF
+    assignTypeF = isFinalF ^. mapping (from assignmentTypeRaw)
+    assignTypeFilter = mkFilterOn "A.type" assignTypeF
+    (clausesF, paramsF) =
+        unzip [studentFilter, courseFilter, assignTypeFilter]
+
+    queryText = [q|
+        select    T.grade, T.time, T.submission_hash, T.idx
+        from      Submissions as S
+        left join Assignments as A
+               on A.hash = S.assignment_hash
+        where     1 = 1
+    |]
+      `filterClauses` clausesF
+
+educatorPostGrade
+    :: MonadEducatorAPIQuery m
+    => Hash Submission -> Grade -> m ()
+educatorPostGrade subH grade = do
+    time <- liftIO getCurrentTime
+    transaction $ do
+        sigSub <- getSignedSubmission subH
+            `assertJust` AbsentError (SubmissionDomain subH)
+
+        let ptx = PrivateTx
+                { _ptSignedSubmission = sigSub
+                , _ptTime = time
+                , _ptGrade = grade
+                }
+            txId = getId ptx
+
+        execute queryText
+            ( txId
+            , subH
+            , grade
+            , time
+            , TxInMempool
+            )
+            `ifAlreadyExistsThrow` TransactionDomain txId
+  where
+    queryText :: Query
+    queryText = [q|
+        insert into  Transactions
+        values       (?, ?, ?, ?, ?)
+    |]

--- a/educator/src/Dscp/Educator/Web/Educator/Queries.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Queries.hs
@@ -61,8 +61,8 @@ educatorGetCourses :: DBM m => Maybe Student -> m [CourseEducatorInfo]
 educatorGetCourses studentF = do
     res :: [(Course, Text, Maybe Subject)] <- query queryText paramF
     return $
-        -- group "subject" fields for the same course
-        [ CourseEducatorInfo{..}
+        -- group "subject" fields for the same courses
+        [ CourseEducatorInfo{ ciId, ciDesc, ciSubjects }
         | course@((ciId, ciDesc, _) : _) <- groupBy ((==) `on` view _1) res
         , let ciSubjects = course ^.. traversed . _3 . _Just
         ]

--- a/educator/src/Dscp/Educator/Web/Educator/Types.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Types.hs
@@ -106,7 +106,7 @@ educatorLiftSubmission ss siGrade =
     , siContentsHash = _sContentsHash s
     , siAssignmentHash = _sAssignmentHash s
     , siWitness = _ssWitness ss
-    , ..
+    , siGrade
     }
   where
     s = _ssSubmission ss

--- a/educator/src/Dscp/Educator/Web/Educator/Types.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Types.hs
@@ -18,6 +18,7 @@ module Dscp.Educator.Web.Educator.Types
 
       -- * Conversions
     , educatorLiftAssignment
+    , educatorLiftSubmission
     , requestToAssignment
     ) where
 
@@ -55,7 +56,7 @@ data CourseEducatorInfo = CourseEducatorInfo
     { ciId       :: Course
     , ciDesc     :: Text
     , ciSubjects :: [Subject]
-    } deriving (Show, Eq, Generic)
+    } deriving (Show, Eq, Ord, Generic)
 
 data AssignmentEducatorInfo = AssignmentEducatorInfo
     { aiHash         :: (Hash Assignment)
@@ -97,6 +98,18 @@ educatorLiftAssignment a =
     , aiIsFinal = _aType a ^. assignmentTypeRaw
     , aiDesc = _aDesc a
     }
+
+educatorLiftSubmission :: SignedSubmission -> Maybe GradeInfo -> SubmissionEducatorInfo
+educatorLiftSubmission ss siGrade =
+    SubmissionEducatorInfo
+    { siHash = hash s
+    , siContentsHash = _sContentsHash s
+    , siAssignmentHash = _sAssignmentHash s
+    , siWitness = _ssWitness ss
+    , ..
+    }
+  where
+    s = _ssSubmission ss
 
 requestToAssignment :: NewAssignment -> Assignment
 requestToAssignment NewAssignment{..} =

--- a/educator/src/Dscp/Educator/Web/Logic.hs
+++ b/educator/src/Dscp/Educator/Web/Logic.hs
@@ -1,0 +1,24 @@
+-- | Common logic for educator and student API's.
+
+module Dscp.Educator.Web.Logic
+    ( commonGetProofs
+    ) where
+
+import Dscp.Core
+import Dscp.DB.SQLite.Queries
+import Dscp.Educator.Web.Queries
+import Dscp.Educator.Web.Types
+import Dscp.Util.Aeson
+
+commonGetProofs
+    :: MonadEducatorQuery m
+    => Student
+    -> GetProvenStudentTransactionsFilters
+    -> m [BlkProofInfo]
+commonGetProofs student filters = do
+    rawProofs <- getProvenStudentTransactions student filters
+    return
+        [ BlkProofInfo{ bpiMtreeSerialized = CustomEncoding mtree, bpiTxs }
+        | (mtree, indicedTxs) <- rawProofs
+        , let bpiTxs = map snd indicedTxs
+        ]

--- a/educator/src/Dscp/Educator/Web/Queries.hs
+++ b/educator/src/Dscp/Educator/Web/Queries.hs
@@ -1,0 +1,267 @@
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+-- | Common queries for student and educator APIs.
+
+module Dscp.Educator.Web.Queries
+    ( module Dscp.Educator.Web.Queries
+    ) where
+
+import Control.Lens (from, mapping)
+import Data.Time.Clock (UTCTime)
+import Dscp.Util.Aeson (AsByteString (..))
+import Database.SQLite.Simple (Only (..), (:.) (..))
+import Loot.Log (MonadLogging)
+import Data.Default (Default (..))
+import Text.InterpolatedString.Perl6 (q, qc)
+
+import Dscp.Core
+import Dscp.Crypto
+import Dscp.DB.SQLite
+import Dscp.Educator.Web.Educator.Types
+import Dscp.Educator.Web.Student.Types
+import Dscp.Educator.Web.Student.Queries -- remove
+import Dscp.Educator.Web.Types
+import Dscp.Educator.Web.Util
+import Dscp.Util
+import Dscp.Util.Type (type (==))
+
+type MonadEducatorQuery m =
+    ( MonadSQLiteDB m
+    , MonadCatch m
+    , MonadLogging m
+    )
+
+----------------------------------------------------------------------------
+-- Assignments
+----------------------------------------------------------------------------
+
+data GetAssignmentsFilters = GetAssignmentsFilters
+    { afAssignmentHash :: Maybe $ Hash Assignment
+    , afCourse         :: Maybe Course
+    , afDocType        :: Maybe DocumentType
+    , afIsFinal        :: Maybe IsFinal
+    } deriving (Show, Generic)
+
+instance Default GetAssignmentsFilters where
+    def = GetAssignmentsFilters def def def def
+
+commonGetAssignments
+    :: (MonadEducatorQuery m, DistinctTag apiTag, WithinSQLTransaction)
+    => ApiCase apiTag
+    -> Student
+    -> GetAssignmentsFilters
+    -> m [ResponseCase apiTag Assignment]
+commonGetAssignments apiCase student filters = do
+    assignments <- query queryText (mconcat $ oneParam student : paramsF)
+    forM assignments $
+        \( assignH        :: Hash Assignment
+         , aiCourseId     :: Course
+         , aiContentsHash :: Hash Raw
+         , assignType     :: AssignmentType
+         , aiDesc         :: Text
+         ) -> do
+        let aiIsFinal = assignType ^. assignmentTypeRaw
+        case apiCase of
+            EducatorCase ->
+                return AssignmentEducatorInfo{ aiHash = assignH, .. }
+            StudentCase -> do
+                aiLastSubmission <- studentGetLastAssignmentSubmission student assignH
+                return AssignmentStudentInfo{ aiHash = assignH, .. }
+  where
+    assignFilter = mkFilterOn "Assignments.hash" (afAssignmentHash filters)
+    courseFilter = mkFilterOn "course_id" (afCourse filters)
+    assignTypeF = afIsFinal filters ^. mapping (from assignmentTypeRaw)
+    assignTypeFilter = mkFilterOn "type" assignTypeF
+    docTypeFilter = mkDocTypeFilter "Assignments.hash" (afDocType filters)
+    (clausesF, paramsF) =
+        unzip [assignFilter, courseFilter, assignTypeFilter, docTypeFilter]
+
+    queryText = [q|
+        select    hash, course_id, contents_hash, type, desc
+        from      Assignments
+        left join StudentAssignments
+               on StudentAssignments.assignment_hash = Assignments.hash
+        where     student_addr = ?
+    |]
+      `filterClauses` clausesF
+
+----------------------------------------------------------------------------
+-- Submissions
+----------------------------------------------------------------------------
+
+data GetSubmissionsFilters = GetSubmissionsFilters
+    { sfStudent        :: Maybe Student
+    , sfCourse         :: Maybe Course
+    , sfSubmissionHash :: Maybe $ Hash Submission
+    , sfAssignmentHash :: Maybe $ Hash Assignment
+    , sfDocType        :: Maybe DocumentType
+    } deriving (Show, Generic)
+
+instance Default GetSubmissionsFilters where
+    def = GetSubmissionsFilters def def def def def
+
+commonGetSubmissions
+    :: forall apiTag m.
+       (MonadEducatorQuery m, DistinctTag apiTag)
+    => ApiCase apiTag
+    -> GetSubmissionsFilters
+    -> m [ResponseCase apiTag Submission]
+commonGetSubmissions apiCase filters = do
+    submissions <- query queryText (mconcat paramsF)
+    return $ submissions <&>
+      \(  (submissionH      :: Hash Submission
+       ,   siContentsHash   :: Hash Raw
+       ,   siAssignmentHash :: Hash Assignment
+          )
+       :. (witness          :: FetchIf (apiTag == 'EducatorTag)
+                                       (Only SubmissionWitness))
+       :. (siGrade          :: Maybe GradeInfo)
+       ) ->
+        case apiCase of
+            StudentCase  -> SubmissionStudentInfo
+                            { siHash = submissionH, .. }
+            EducatorCase -> SubmissionEducatorInfo
+                            { siHash = submissionH
+                            , siWitness = fromOnly $ positiveFetch witness, .. }
+  where
+    studentFilter = mkFilterOn "S.student_addr" (sfStudent filters)
+    courseFilter  = mkFilterOn "course_id" (sfCourse filters)
+    assignFilter  = mkFilterOn "A.hash" (sfAssignmentHash filters)
+    subFilter     = mkFilterOn "S.hash" (sfSubmissionHash filters)
+    docTypeFilter = mkDocTypeFilter "A.hash" (sfDocType filters)
+    (clausesF, paramsF) =
+        unzip [studentFilter, courseFilter, assignFilter, subFilter, docTypeFilter]
+
+    extraFields :: Text
+    extraFields = case apiCase of
+        StudentCase  -> ""
+        EducatorCase -> "S.signature,"
+
+    queryText = [qc|
+        select    S.hash, S.contents_hash, assignment_hash, {extraFields}
+                  T.submission_hash, T.grade, T.time, T.idx  -- grade
+        from      Submissions as S
+        left join Assignments as A
+               on A.hash = S.assignment_hash
+        left join Transactions as T
+               on T.submission_hash = S.hash
+        where     1 = 1
+    |]
+      `filterClauses` clausesF
+
+----------------------------------------------------------------------------
+-- Proofs
+----------------------------------------------------------------------------
+
+-- | Given db-internal block index, fetch transactions it contains.
+commonGetBlockTxs
+    :: MonadStudentAPIQuery m
+    => Student
+    -> TxBlockIdx
+    -> m [PrivateTx]
+commonGetBlockTxs student blockIdx = do
+    query queryText (blockIdx, student)
+  where
+    queryText = [q|
+        select     Submissions.student_addr,
+                   Submissions.contents_hash,
+                   Assignments.hash,
+
+                   Submissions.signature,
+                   grade,
+                   time
+
+        from       Transactions
+
+        left join  Submissions
+               on  submission_hash = Submissions.hash
+
+        left join  Assignments
+               on  assignment_hash = Assignments.hash
+
+        where      Transactions.idx = ?
+              and  student_addr = ?
+    |]
+
+data GetProofsFilters = GetProofsFilters
+    { pfCourse :: Maybe Course
+    , pfSince  :: Maybe UTCTime
+    } deriving (Show, Generic)
+
+instance Default GetProofsFilters where
+    def = GetProofsFilters def def
+
+-- | Get proofs of student activity grouped by blocks.
+commonGetProofs
+    :: (MonadStudentAPIQuery m, WithinSQLTransaction)
+    => Student
+    -> GetProofsFilters
+    -> m [BlkProofInfo]
+commonGetProofs student filters = do
+    -- It's questionable whether doing just one request would be optimal here
+    -- since fetching same merkel-tree for each transaction in block can take long.
+    blocks <- query queryText (pfCourse filters, pfCourse filters, pfSince filters, pfSince filters)
+    forM blocks $ \(idx, tree) -> do
+        txs <- commonGetBlockTxs student idx
+        return BlkProofInfo
+            { bpiMtreeSerialized = AsByteString tree
+            , bpiTxs = txs
+            }
+  where
+    queryText = [q|
+        select     Blocks.idx, mtree
+        from       Blocks
+        left join  Transactions
+                on Transactions.idx = Blocks.idx
+        left join  Submissions
+                on Transactions.submission_hash = Submissions.hash
+        left join  Assignments
+                on Submissions.assignment_hash = Assignments.hash
+        where      Transactions.hash is not null  -- nulls arise from join
+               and (? is null or Assignments.course_id = ?)
+               and (? is null or Blocks.time >= ?)
+    |]
+
+----------------------------------------------------------------------------
+-- Predicates
+----------------------------------------------------------------------------
+
+commonExistsSubmission
+    :: (MonadStudentAPIQuery m, WithinSQLTransaction)
+    => Hash Submission
+    -> Maybe Student
+    -> m Bool
+commonExistsSubmission submissionH studentF = do
+    checkExists queryText (oneParam submissionH <> paramF)
+  where
+    (clauseF, paramF) = mkFilterOn "student_addr" studentF
+    queryText = [q|
+       select   count(*)
+       from     Submissions
+       where    hash = ?
+    |]
+      `filterClauses` one clauseF
+
+----------------------------------------------------------------------------
+-- Deletions
+----------------------------------------------------------------------------
+
+commonDeleteSubmission
+    :: (MonadStudentAPIQuery m, WithinSQLTransaction)
+    => Hash Submission
+    -> Maybe Student
+    -> m ()
+commonDeleteSubmission submissionH studentF = do
+    commonExistsSubmission submissionH studentF
+        `assert` AbsentError (SubmissionDomain submissionH)
+    execute queryText (oneParam submissionH <> paramF)
+        `onReferenceInvalidThrow` (SemanticError $ DeletingGradedSubmission submissionH)
+  where
+    (clauseF, paramF) = mkFilterOn "student_addr" studentF
+    queryText = [q|
+       delete
+       from     Submissions
+       where    hash = ?
+    |]
+      `filterClauses` one clauseF

--- a/educator/src/Dscp/Educator/Web/Student/Error.hs
+++ b/educator/src/Dscp/Educator/Web/Student/Error.hs
@@ -3,7 +3,6 @@
 module Dscp.Educator.Web.Student.Error
        ( APIError (..)
        , _BadSubmissionSignature
-       , _DeletingGradedSubmission
        , _SomeDomainError
        , WrongSubmissionSignature (..)
        , _FakeSubmissionSignature
@@ -46,8 +45,6 @@ instance Exception WrongSubmissionSignature
 data APIError
     = BadSubmissionSignature WrongSubmissionSignature
       -- ^ Submission signature doesn't match the student nor has valid format.
-    | DeletingGradedSubmission
-      -- ^ Graded Submission is being deleted.
     | SomeDomainError DomainError
       -- ^ Entity is missing or getting duplicated.
     | InvalidFormat
@@ -81,7 +78,6 @@ instance ToJSON APIError where
         BadSubmissionSignature err -> case err of
             FakeSubmissionSignature{}    -> "FakeSubmissionSignature"
             SubmissionSignatureInvalid{} -> "SubmissionSignatureInvalid"
-        DeletingGradedSubmission{} ->       "DeletingGradedSubmission"
         InvalidFormat ->                    "InvalidFormat"
         SomeDomainError err -> domainErrorToShortJSON err
 
@@ -93,7 +89,6 @@ instance ToJSON APIError where
 toServantErrNoReason :: APIError -> ServantErr
 toServantErrNoReason = \case
     BadSubmissionSignature{}   -> err403
-    DeletingGradedSubmission{} -> err403
     InvalidFormat{}            -> err400
     SomeDomainError err -> domainToServantErrNoReason err
 

--- a/educator/src/Dscp/Educator/Web/Student/Handlers.hs
+++ b/educator/src/Dscp/Educator/Web/Student/Handlers.hs
@@ -37,8 +37,8 @@ studentApiHandlers student =
 
     , sGetAssignments = \afCourse afDocType afIsFinal ->
         sqlTransaction $
-        commonGetAssignments StudentCase student
-            def{ afCourse, afDocType, afIsFinal }
+            commonGetAssignments StudentCase student
+                def{ afCourse, afDocType, afIsFinal }
 
     , sGetAssignment = \assignH ->
         sqlTransaction $ studentGetAssignment student assignH

--- a/educator/src/Dscp/Educator/Web/Student/Handlers.hs
+++ b/educator/src/Dscp/Educator/Web/Student/Handlers.hs
@@ -10,7 +10,9 @@ import Servant (Handler, throwError)
 import UnliftIO (UnliftIO (..))
 
 import Dscp.Core (Student)
+import Dscp.DB.SQLite
 import Dscp.DB.SQLite (sqlTransaction)
+import Dscp.Educator.Web.Logic
 import Dscp.Educator.Web.Queries
 import Dscp.Educator.Web.Student.API
 import Dscp.Educator.Web.Student.Error

--- a/educator/src/Dscp/Educator/Web/Student/Logic.hs
+++ b/educator/src/Dscp/Educator/Web/Student/Logic.hs
@@ -3,17 +3,24 @@
 module Dscp.Educator.Web.Student.Logic
     ( requestToSignedSubmission
     , studentMakeSubmissionVerified
+    , studentGetAssignment
+    , studentGetAllAssignments
+    , studentGetSubmission
+    , studentGetAllSubmissions
     ) where
+
+import Data.Default (def)
 
 import Dscp.Core
 import Dscp.Crypto
-import Dscp.DB.SQLite (sqlTransaction)
-import Dscp.DB.SQLite.Queries
+import Dscp.DB.SQLite
+import Dscp.Educator.Web.Queries
 import Dscp.Educator.Web.Student.Error (APIError (..))
 import Dscp.Educator.Web.Student.Queries
 import Dscp.Educator.Web.Student.Types
 import Dscp.Educator.Web.Student.Util (verifyStudentSubmission)
-import Dscp.Util (assertJust, leftToThrow)
+import Dscp.Educator.Web.Types
+import Dscp.Util
 
 requestToSignedSubmission
     :: MonadStudentAPIQuery m
@@ -42,3 +49,42 @@ studentMakeSubmissionVerified student newSubmission = do
     sqlTransaction $ do
         submissionId <- submitAssignment signedSubmission
         studentGetSubmission student submissionId
+
+-- | Get exactly one assignment.
+studentGetAssignment
+    :: (MonadStudentAPIQuery m, WithinSQLTransaction)
+    => Student
+    -> Hash Assignment
+    -> m AssignmentStudentInfo
+studentGetAssignment student assignH = do
+    commonGetAssignments StudentCase student def
+        { afAssignmentHash = Just assignH }
+        >>= listToMaybeWarn "assignment"
+        >>= nothingToThrow (AbsentError $ AssignmentDomain assignH)
+
+-- | Get all student assignments.
+studentGetAllAssignments
+    :: (MonadStudentAPIQuery m, WithinSQLTransaction)
+    => Student
+    -> m [AssignmentStudentInfo]
+studentGetAllAssignments student = commonGetAssignments StudentCase student def
+
+-- | Get exactly one submission.
+studentGetSubmission
+    :: MonadStudentAPIQuery m
+    => Student
+    -> Hash Submission
+    -> m SubmissionStudentInfo
+studentGetSubmission student submissionH = do
+    commonGetSubmissions StudentCase def
+        { sfStudent = Just student, sfSubmissionHash = Just submissionH }
+        >>= listToMaybeWarn "submission"
+        >>= nothingToThrow (AbsentError $ SubmissionDomain submissionH)
+
+-- | Get all student submissions.
+studentGetAllSubmissions
+    :: MonadStudentAPIQuery m
+    => Student
+    -> m [SubmissionStudentInfo]
+studentGetAllSubmissions student =
+    commonGetSubmissions StudentCase def{ sfStudent = Just student }

--- a/educator/src/Dscp/Educator/Web/Student/Queries.hs
+++ b/educator/src/Dscp/Educator/Web/Student/Queries.hs
@@ -7,68 +7,20 @@ module Dscp.Educator.Web.Student.Queries
     ( module Dscp.Educator.Web.Student.Queries
     ) where
 
-import Control.Lens (from, mapping)
 import Data.Coerce (coerce)
-import Data.Time.Clock (UTCTime)
-import Database.SQLite.Simple ((:.) (..), Only (..), Query, ToRow (..))
-import Database.SQLite.Simple.ToField (ToField)
+import Database.SQLite.Simple (Only (..), Query)
 import Loot.Log (MonadLogging)
 import Text.InterpolatedString.Perl6 (q)
 
 import Dscp.Core
 import Dscp.Crypto (Hash)
-import Dscp.DB.SQLite (DomainError (..), DomainErrorItem (..), MonadSQLiteDB (..),
-                       TxBlockIdx (TxInMempool), WithinSQLTransaction)
+import Dscp.DB.SQLite
 import qualified Dscp.DB.SQLite.Queries as Base
 import Dscp.Util (Id, assertJust, listToMaybeWarn)
-import Dscp.Util.Aeson (AsByteString (..))
 
-import Dscp.Educator.Web.Student.Error (APIError (..))
 import Dscp.Educator.Web.Student.Types
 import Dscp.Educator.Web.Types
-
----------------------------------------------------------------------
--- Helpers
----------------------------------------------------------------------
-
--- | One of conditions within conjenction sum after @where@.
-newtype FilterClause = FilterClause { unFilterClause :: String }
-    deriving (IsString)
-
--- | Contains a list of objects forming a row in SQL table.
-data SomeParams = forall a. ToRow a => SomeParams a
-
-instance Monoid SomeParams where
-    mempty = SomeParams ()
-    SomeParams a `mappend` SomeParams b = SomeParams (a :. b)
-
-instance ToRow SomeParams where
-    toRow (SomeParams a) = toRow a
-
--- | Lift a single field to 'SomeParams'.
-oneParam :: ToField a => a -> SomeParams
-oneParam = SomeParams . Only
-
--- | For SQL table field and optional value, makes a clause to select
--- only rows with field mathing value (if present).
--- This function helps to deal with sqlite feature of passing parameters
--- seperately from query itself.
-mkFilterOn :: ToField a => String -> Maybe a -> (FilterClause, SomeParams)
-mkFilterOn fieldName mparam = case mparam of
-      Just param -> (FilterClause ("and " <> fieldName <> "= ?"),
-                     oneParam param)
-      Nothing    -> ("", mempty)
-
--- | Attaches filtering @where@ clauses to query.
--- "where" statement with some condition should go last in the query.
-filterClauses :: Query -> [FilterClause] -> Query
-filterClauses queryText fs =
-    mconcat $ queryText : map (fromString . unFilterClause) fs
-infixl 1 `filterClauses`
-
----------------------------------------------------------------------
--- Queries
----------------------------------------------------------------------
+import Dscp.Educator.Web.Util
 
 type MonadStudentAPIQuery m =
     ( MonadSQLiteDB m
@@ -153,6 +105,8 @@ studentGetCourses studentId (coerce -> isEnrolledF) = do
         )
     |]
 
+-- TODO: only student's grade!
+-- TODO: detect warnings in tests?
 studentGetGrade :: MonadStudentAPIQuery m => Hash Submission -> m (Maybe GradeInfo)
 studentGetGrade submissionH = do
     mgrade <-
@@ -188,192 +142,4 @@ studentGetLastAssignmentSubmission student assignH = do
               and student_addr = ?
         order by  creation_time desc
         limit     1
-    |]
-
-studentGetAssignment
-    :: (MonadStudentAPIQuery m, WithinSQLTransaction)
-    => Student -> Hash Assignment -> m AssignmentStudentInfo
-studentGetAssignment student assignH = do
-    massign <-
-        query queryText (assignH, student)
-        >>= listToMaybeWarn "assignments"
-    (aiCourseId, aiContentsHash, assignType, aiDesc) <-
-        pure massign `assertJust` AbsentError (AssignmentDomain assignH)
-    let IsFinal aiIsFinal = assignType ^. assignmentTypeRaw
-    aiLastSubmission <- studentGetLastAssignmentSubmission student assignH
-    return AssignmentStudentInfo{ aiHash = assignH, .. }
-  where
-    queryText :: Query
-    queryText = [q|
-        select    course_id, contents_hash, type, desc
-        from      Assignments
-        left join StudentAssignments
-               on StudentAssignments.assignment_hash = Assignments.hash
-        where     hash = ?
-              and student_addr = ?
-    |]
-
-mkDocTypeFilter :: Maybe DocumentType -> (FilterClause, SomeParams)
-mkDocTypeFilter = \case
-    Nothing ->
-        ("", mempty)
-    Just Offline ->
-        ("and Assignments.hash = ?", oneParam offlineHash)
-    Just Online  ->
-        ("and Assignments.hash <> ?", oneParam offlineHash)
-
-studentGetAssignments
-    :: (MonadStudentAPIQuery m, WithinSQLTransaction)
-    => Student
-    -> Maybe Course
-    -> Maybe DocumentType
-    -> Maybe IsFinal
-    -> m [AssignmentStudentInfo]
-studentGetAssignments student courseIdF docTypeF isFinalF = do
-    let courseFilter = mkFilterOn "course_id" courseIdF
-        assignTypeF = isFinalF ^. mapping (from assignmentTypeRaw)
-        assignTypeFilter = mkFilterOn "type" assignTypeF
-        docTypeFilter = mkDocTypeFilter docTypeF
-        (clausesF, paramsF) =
-            unzip [courseFilter, assignTypeFilter, docTypeFilter]
-
-    assignments <- query (queryText clausesF)
-                         (mconcat $ oneParam student : paramsF)
-    forM assignments $
-      \(assignH, aiCourseId, aiContentsHash, assignType, aiDesc) -> do
-        let IsFinal aiIsFinal = assignType ^. assignmentTypeRaw
-        aiLastSubmission <- studentGetLastAssignmentSubmission student assignH
-        return AssignmentStudentInfo{ aiHash = assignH, .. }
-  where
-    queryText clausesF = [q|
-        select    hash, course_id, contents_hash, type, desc
-        from      Assignments
-        left join StudentAssignments
-               on StudentAssignments.assignment_hash = Assignments.hash
-        where     student_addr = ?
-    |]
-      `filterClauses` clausesF
-
-studentGetSubmission
-    :: (MonadStudentAPIQuery m, WithinSQLTransaction)
-    => Student -> Hash Submission -> m SubmissionStudentInfo
-studentGetSubmission student submissionH = do
-    msubmission <-
-        query queryText (submissionH, student)
-        >>= listToMaybeWarn "courses"
-    (siContentsHash, siAssignmentHash) <-
-        pure msubmission `assertJust` AbsentError (SubmissionDomain submissionH)
-    siGrade <- studentGetGrade submissionH
-    return SubmissionStudentInfo{ siHash = submissionH, .. }
-  where
-    queryText :: Query
-    queryText = [q|
-        select    contents_hash, assignment_hash
-        from      Submissions
-        where     hash = ?
-              and student_addr = ?
-    |]
-
-studentGetSubmissions
-    :: (MonadStudentAPIQuery m, WithinSQLTransaction)
-    => Student
-    -> Maybe Course
-    -> Maybe (Hash Assignment)
-    -> Maybe DocumentType
-    -> m [SubmissionStudentInfo]
-studentGetSubmissions student courseIdF assignHF docTypeF = do
-    let courseFilter = mkFilterOn "course_id" courseIdF
-        assignFilter = mkFilterOn "Assignments.hash" assignHF
-        docTypeFilter = mkDocTypeFilter docTypeF
-        (clausesF, paramsF) = unzip [courseFilter, assignFilter, docTypeFilter]
-
-    submissions <- query (queryText clausesF)
-                         (mconcat $ oneParam student : paramsF)
-    forM submissions $
-      \(submissionH, siContentsHash, siAssignmentHash) -> do
-        siGrade <- studentGetGrade submissionH
-        return SubmissionStudentInfo{ siHash = submissionH, .. }
-  where
-    queryText clausesF = [q|
-        select    Submissions.hash, Submissions.contents_hash, assignment_hash
-        from      Submissions
-        left join Assignments
-               on Assignments.hash = Submissions.assignment_hash
-        where     Submissions.student_addr = ?
-    |]
-      `filterClauses` clausesF
-
-studentEnsureSubmissionExists
-    :: (MonadStudentAPIQuery m, WithinSQLTransaction)
-    => Student -> Hash Submission -> m ()
-studentEnsureSubmissionExists = void ... studentGetSubmission
-
-studentDeleteSubmission
-    :: (MonadStudentAPIQuery m, WithinSQLTransaction)
-    => Student
-    -> Hash Submission
-    -> m ()
-studentDeleteSubmission student submissionH = do
-    submission <- studentGetSubmission student submissionH
-    whenJust (siGrade submission) $ \_ ->
-        throwM DeletingGradedSubmission
-
-    execute queryText (submissionH, student)
-  where
-    queryText = [q|
-       delete
-       from     Submissions
-       where    hash = ?
-            and student_addr = ?
-    |]
-
-studentGetBlockTxs
-    :: MonadStudentAPIQuery m
-    => Student
-    -> Word32
-    -> m [PrivateTx]
-studentGetBlockTxs student blockIdx = do
-    query queryText (blockIdx, student)
-  where
-    queryText :: Query
-    queryText = [q|
-        select     Submissions.student_addr,
-                   Submissions.contents_hash,
-                   Assignments.hash,
-
-                   Submissions.signature,
-                   grade,
-                   time
-
-        from       Transactions
-
-        left join  Submissions
-               on  submission_hash = Submissions.hash
-
-        left join  Assignments
-               on  assignment_hash = Assignments.hash
-
-        where      Transactions.idx = ?
-              and  student_addr = ?
-    |]
-
-studentGetProofs
-    :: (MonadStudentAPIQuery m, WithinSQLTransaction)
-    => Student
-    -> Maybe UTCTime
-    -> m [BlkProofInfo]
-studentGetProofs student sinceF = do
-    blocks <- query queryText (Only sinceF)
-    forM blocks $ \(idx, tree) -> do
-        txs <- studentGetBlockTxs student idx
-        return BlkProofInfo
-            { bpiMtreeSerialized = AsByteString tree
-            , bpiTxs = txs
-            }
-  where
-    queryText :: Query
-    queryText = [q|
-        select     idx, mtree
-        from       Blocks
-        where      time >= ?
     |]

--- a/educator/src/Dscp/Educator/Web/Student/Queries.hs
+++ b/educator/src/Dscp/Educator/Web/Student/Queries.hs
@@ -20,7 +20,6 @@ import Dscp.Util (Id, assertJust, listToMaybeWarn)
 
 import Dscp.Educator.Web.Student.Types
 import Dscp.Educator.Web.Types
-import Dscp.Educator.Web.Util
 
 type MonadStudentAPIQuery m =
     ( MonadSQLiteDB m
@@ -105,8 +104,6 @@ studentGetCourses studentId (coerce -> isEnrolledF) = do
         )
     |]
 
--- TODO: only student's grade!
--- TODO: detect warnings in tests?
 studentGetGrade :: MonadStudentAPIQuery m => Hash Submission -> m (Maybe GradeInfo)
 studentGetGrade submissionH = do
     mgrade <-

--- a/educator/src/Dscp/Educator/Web/Student/Types.hs
+++ b/educator/src/Dscp/Educator/Web/Student/Types.hs
@@ -57,7 +57,7 @@ data AssignmentStudentInfo = AssignmentStudentInfo
     { aiHash           :: (Hash Assignment)
     , aiCourseId       :: Course
     , aiContentsHash   :: (Hash Raw)
-    , aiIsFinal        :: Bool
+    , aiIsFinal        :: IsFinal
     , aiDesc           :: Text
     , aiLastSubmission :: (Maybe SubmissionStudentInfo)
     } deriving (Show, Eq, Generic)
@@ -73,6 +73,14 @@ saDocumentType :: AssignmentStudentInfo -> DocumentType
 saDocumentType = documentType . aiContentsHash
 
 ---------------------------------------------------------------------------
+-- ResponseCase instances
+---------------------------------------------------------------------------
+
+type instance ResponseCase 'StudentTag Course     = CourseStudentInfo
+type instance ResponseCase 'StudentTag Assignment = AssignmentStudentInfo
+type instance ResponseCase 'StudentTag Submission = SubmissionStudentInfo
+
+---------------------------------------------------------------------------
 -- Simple conversions
 ---------------------------------------------------------------------------
 
@@ -83,7 +91,7 @@ studentLiftAssignment a lastSubmission =
     { aiHash = hash a
     , aiCourseId = _aCourseId a
     , aiContentsHash = _aContentsHash a
-    , aiIsFinal = _aType a ^. assignmentTypeRaw . _IsFinal
+    , aiIsFinal = _aType a ^. assignmentTypeRaw
     , aiDesc = _aDesc a
     , aiLastSubmission = lastSubmission
     }

--- a/educator/src/Dscp/Educator/Web/Types.hs
+++ b/educator/src/Dscp/Educator/Web/Types.hs
@@ -1,15 +1,25 @@
+{-# LANGUAGE GADTs      #-}
 {-# LANGUAGE StrictData #-}
+{-# LANGUAGE TypeOperators #-}
 
 -- | Common datatypes for educator and student HTTP APIs
 
 module Dscp.Educator.Web.Types
        (
+         -- * Multi API types
+
+         ApiTag (..)
+       , ApiCase (..)
+       , ResponseCase
+       , DistinctTag
+
          -- * Flags
-         IsFinal (..)
+       , IsFinal (..)
        , _IsFinal
        , HasProof (..)
 
          -- * Responses
+       , StudentInfo (..)
        , GradeInfo (..)
        , BlkProofInfo (..)
 
@@ -21,11 +31,39 @@ import Control.Lens (Iso', from, iso, makePrisms)
 import Data.Aeson.Options (defaultOptions)
 import Data.Aeson.TH (deriveJSON)
 import Data.Time.Clock (UTCTime)
+import Database.SQLite.Simple (FromRow (..), field)
 import Servant (FromHttpApiData (..))
+import Data.Singletons.Bool (SBoolI)
 
+import Dscp.DB.SQLite.Types
+import Dscp.Util.Type (type (==))
 import Dscp.Core
 import Dscp.Crypto
+import Dscp.DB.SQLite.Instances ()
 import Dscp.Util.Aeson (AsByteString, HexEncoded)
+
+-- | Tag indicating an API.
+data ApiTag = StudentTag | EducatorTag
+
+-- | Various functions are going to serve student and educator cases
+-- simultaniously thus returning slightly different types.
+type family ResponseCase (apiTag :: ApiTag) baseType
+
+-- | Defines which case (student or educator) a function should handle,
+-- returning appropriate 'ResponseCase'.
+data ApiCase a where
+    StudentCase  :: ApiCase 'StudentTag
+    EducatorCase :: ApiCase 'EducatorTag
+
+-- | Declares that we can compare this tag against other 'ApiTag's.
+type DistinctTag tag =
+    ( SBoolI (tag == 'StudentTag)
+    , SBoolI (tag == 'EducatorTag)
+    )
+
+---------------------------------------------------------------------------
+-- Types
+---------------------------------------------------------------------------
 
 -- | Whether assignment is final in course.
 newtype IsFinal = IsFinal { unIsFinal :: Bool }
@@ -36,6 +74,10 @@ makePrisms ''IsFinal
 -- | Whether transaction has been published into public chain.
 newtype HasProof = HasProof { unHasProof :: Bool }
     deriving (Eq, Show)
+
+data StudentInfo = StudentInfo
+    { siAddr :: Student
+    } deriving (Show, Eq, Generic)
 
 data GradeInfo = GradeInfo
     { giSubmissionHash :: (Hash Submission)
@@ -72,6 +114,7 @@ deriveJSON defaultOptions ''PrivateTx
 deriveJSON defaultOptions ''IsFinal
 deriveJSON defaultOptions ''HasProof
 deriveJSON defaultOptions ''GradeInfo
+deriveJSON defaultOptions ''StudentInfo
 deriveJSON defaultOptions ''BlkProofInfo
 
 ---------------------------------------------------------------------------
@@ -79,3 +122,15 @@ deriveJSON defaultOptions ''BlkProofInfo
 ---------------------------------------------------------------------------
 
 deriving instance FromHttpApiData IsFinal
+
+---------------------------------------------------------------------------
+-- SQLite instances
+---------------------------------------------------------------------------
+
+instance FromRow GradeInfo where
+    fromRow = GradeInfo <$> field <*> field <*> field
+                        <*> ((/= TxInMempool) <$> field)
+instance FromRow (Maybe GradeInfo) where
+    fromRow =
+        liftM4 GradeInfo <$> field <*> field <*> field
+                         <*> (fmap (/= TxInMempool) <$> field)

--- a/educator/src/Dscp/Educator/Web/Types.hs
+++ b/educator/src/Dscp/Educator/Web/Types.hs
@@ -77,14 +77,14 @@ newtype HasProof = HasProof { unHasProof :: Bool }
 
 data StudentInfo = StudentInfo
     { siAddr :: Student
-    } deriving (Show, Eq, Generic)
+    } deriving (Show, Eq, Ord, Generic)
 
 data GradeInfo = GradeInfo
     { giSubmissionHash :: (Hash Submission)
     , giGrade          :: Grade
     , giTimestamp      :: UTCTime
     , giHasProof       :: Bool
-    } deriving (Show, Eq, Generic)
+    } deriving (Show, Eq, Ord, Generic)
 
 data BlkProofInfo = BlkProofInfo
     { bpiMtreeSerialized :: (AsByteString HexEncoded ByteString)

--- a/educator/src/Dscp/Educator/Web/Types.hs
+++ b/educator/src/Dscp/Educator/Web/Types.hs
@@ -40,7 +40,7 @@ import Dscp.Util.Type (type (==))
 import Dscp.Core
 import Dscp.Crypto
 import Dscp.DB.SQLite.Instances ()
-import Dscp.Util.Aeson (AsByteString, HexEncoded)
+import Dscp.Util.Aeson (CustomEncoding, HexEncoded)
 
 -- | Tag indicating an API.
 data ApiTag = StudentTag | EducatorTag
@@ -87,7 +87,7 @@ data GradeInfo = GradeInfo
     } deriving (Show, Eq, Ord, Generic)
 
 data BlkProofInfo = BlkProofInfo
-    { bpiMtreeSerialized :: (AsByteString HexEncoded ByteString)
+    { bpiMtreeSerialized :: (CustomEncoding HexEncoded (MerkleProof PrivateTx))
     , bpiTxs             :: [PrivateTx]
     } deriving (Show, Eq, Generic)
 

--- a/educator/src/Dscp/Educator/Web/Util.hs
+++ b/educator/src/Dscp/Educator/Web/Util.hs
@@ -3,33 +3,13 @@
 -- | Utils for educator servers.
 
 module Dscp.Educator.Web.Util
-     ( -- * Errors
-       domainErrorToShortJSON
+     ( domainErrorToShortJSON
      , domainToServantErrNoReason
-
-       -- * SQLite helpers
-     , FilterClause
-     , SomeParams (..)
-     , oneParam
-     , mkFilterOn
-     , filterClauses
-     , mkDocTypeFilter
-
-     , FetchIf
-     , positiveFetch
      ) where
 
-import Data.Singletons.Bool (SBoolI, fromSBool, sbool)
-import Database.SQLite.Simple ((:.) (..), FromRow (..), Only (..), Query, ToRow (..))
-import Database.SQLite.Simple.ToField (ToField)
 import Servant (ServantErr, err400, err403, err404, err409, err500)
 
-import Dscp.Core
 import Dscp.DB.SQLite (DatabaseSemanticError (..), DomainError (..), DomainErrorItem (..))
-
----------------------------------------------------------------------
--- Errors
----------------------------------------------------------------------
 
 -- | Mention only constructor name on JSON, used in errors representation.
 domainErrorToShortJSON :: DomainError -> Text
@@ -69,71 +49,3 @@ domainToServantErrNoReason = \case
         BlockWithIndexDomain{}                -> err500
     AlreadyPresentError _ -> err409
     SemanticError{} -> err403
-
----------------------------------------------------------------------
--- SQLite helpers: filtering
----------------------------------------------------------------------
-
--- | One of conditions within conjenction sum after @where@.
-newtype FilterClause = FilterClause { unFilterClause :: String }
-    deriving (IsString)
-
--- | Contains a list of objects forming a row in SQL table.
-data SomeParams = forall a. ToRow a => SomeParams a
-
-instance Semigroup SomeParams where
-    SomeParams a <> SomeParams b = SomeParams (a :. b)
-
-instance Monoid SomeParams where
-    mempty = SomeParams ()
-    mappend = (<>)
-
-instance ToRow SomeParams where
-    toRow (SomeParams a) = toRow a
-
--- | Lift a single field to 'SomeParams'.
-oneParam :: ToField a => a -> SomeParams
-oneParam = SomeParams . Only
-
--- | For SQL table field and optional value, makes a clause to select
--- only rows with field mathing value (if present).
--- This function helps to deal with sqlite feature of passing parameters
--- seperately from query itself.
-mkFilterOn :: ToField a => String -> Maybe a -> (FilterClause, SomeParams)
-mkFilterOn fieldName mparam = case mparam of
-      Just param -> (FilterClause ("and " <> fieldName <> "= ?"),
-                     oneParam param)
-      Nothing    -> ("", mempty)
-
--- | Attaches filtering @where@ clauses to query.
--- "where" statement with some condition should go last in the query.
-filterClauses :: Query -> [FilterClause] -> Query
-filterClauses queryText fs =
-    mconcat $ queryText : map (fromString . unFilterClause) fs
-infixl 1 `filterClauses`
-
--- | Create filter for 'DocumentType'.
-mkDocTypeFilter :: String -> Maybe DocumentType -> (FilterClause, SomeParams)
-mkDocTypeFilter fieldName = \case
-    Nothing ->
-        ("", mempty)
-    Just Offline ->
-        (FilterClause $ "and " <> fieldName <> " = ?", oneParam offlineHash)
-    Just Online  ->
-        (FilterClause $ "and " <> fieldName <> " <> ?", oneParam offlineHash)
-
----------------------------------------------------------------------
--- SQLite helpers: fields selection
----------------------------------------------------------------------
-
--- | Pack of fields which are only parsed if 'required' is set to 'True'.
-newtype FetchIf (required :: Bool) a = FetchIf (Maybe a)
-
--- | Get the value if it was required.
-positiveFetch :: (required ~ 'True) => FetchIf required a -> a
-positiveFetch (FetchIf a) = a ?: error "positiveFetch: Nothing"
-
-instance (FromRow a, SBoolI required) => FromRow (FetchIf required a) where
-    fromRow
-        | fromSBool (sbool @required) = FetchIf . Just <$> fromRow
-        | otherwise                   = pure (FetchIf Nothing)

--- a/educator/src/Dscp/Educator/Web/Util.hs
+++ b/educator/src/Dscp/Educator/Web/Util.hs
@@ -1,13 +1,35 @@
+{-# LANGUAGE ExistentialQuantification #-}
+
 -- | Utils for educator servers.
 
 module Dscp.Educator.Web.Util
-     ( domainErrorToShortJSON
+     ( -- * Errors
+       domainErrorToShortJSON
      , domainToServantErrNoReason
+
+       -- * SQLite helpers
+     , FilterClause
+     , SomeParams (..)
+     , oneParam
+     , mkFilterOn
+     , filterClauses
+     , mkDocTypeFilter
+
+     , FetchIf
+     , positiveFetch
      ) where
 
-import Servant (ServantErr, err400, err404, err409, err500)
+import Data.Singletons.Bool (SBoolI, fromSBool, sbool)
+import Database.SQLite.Simple ((:.) (..), FromRow (..), Only (..), Query, ToRow (..))
+import Database.SQLite.Simple.ToField (ToField)
+import Servant (ServantErr, err400, err403, err404, err409, err500)
 
-import Dscp.DB.SQLite (DomainError (..), DomainErrorItem (..))
+import Dscp.Core
+import Dscp.DB.SQLite (DatabaseSemanticError (..), DomainError (..), DomainErrorItem (..))
+
+---------------------------------------------------------------------
+-- Errors
+---------------------------------------------------------------------
 
 -- | Mention only constructor name on JSON, used in errors representation.
 domainErrorToShortJSON :: DomainError -> Text
@@ -30,6 +52,9 @@ domainErrorToShortJSON = \case
         SubmissionDomain{}                    -> "SubmissionAlreadyExists"
         TransactionDomain{}                   -> "TransactionAlreadyExists"
         BlockWithIndexDomain{}                -> "BlockWithIndexAlreadyExists"
+    SemanticError err -> case err of
+        StudentIsActiveError{}     -> "StudentIsActive"
+        DeletingGradedSubmission{} -> "DeletingGradedSubmission"
 
 domainToServantErrNoReason :: DomainError -> ServantErr
 domainToServantErrNoReason = \case
@@ -43,3 +68,72 @@ domainToServantErrNoReason = \case
         TransactionDomain{}                   -> err404
         BlockWithIndexDomain{}                -> err500
     AlreadyPresentError _ -> err409
+    SemanticError{} -> err403
+
+---------------------------------------------------------------------
+-- SQLite helpers: filtering
+---------------------------------------------------------------------
+
+-- | One of conditions within conjenction sum after @where@.
+newtype FilterClause = FilterClause { unFilterClause :: String }
+    deriving (IsString)
+
+-- | Contains a list of objects forming a row in SQL table.
+data SomeParams = forall a. ToRow a => SomeParams a
+
+instance Semigroup SomeParams where
+    SomeParams a <> SomeParams b = SomeParams (a :. b)
+
+instance Monoid SomeParams where
+    mempty = SomeParams ()
+    mappend = (<>)
+
+instance ToRow SomeParams where
+    toRow (SomeParams a) = toRow a
+
+-- | Lift a single field to 'SomeParams'.
+oneParam :: ToField a => a -> SomeParams
+oneParam = SomeParams . Only
+
+-- | For SQL table field and optional value, makes a clause to select
+-- only rows with field mathing value (if present).
+-- This function helps to deal with sqlite feature of passing parameters
+-- seperately from query itself.
+mkFilterOn :: ToField a => String -> Maybe a -> (FilterClause, SomeParams)
+mkFilterOn fieldName mparam = case mparam of
+      Just param -> (FilterClause ("and " <> fieldName <> "= ?"),
+                     oneParam param)
+      Nothing    -> ("", mempty)
+
+-- | Attaches filtering @where@ clauses to query.
+-- "where" statement with some condition should go last in the query.
+filterClauses :: Query -> [FilterClause] -> Query
+filterClauses queryText fs =
+    mconcat $ queryText : map (fromString . unFilterClause) fs
+infixl 1 `filterClauses`
+
+-- | Create filter for 'DocumentType'.
+mkDocTypeFilter :: String -> Maybe DocumentType -> (FilterClause, SomeParams)
+mkDocTypeFilter fieldName = \case
+    Nothing ->
+        ("", mempty)
+    Just Offline ->
+        (FilterClause $ "and " <> fieldName <> " = ?", oneParam offlineHash)
+    Just Online  ->
+        (FilterClause $ "and " <> fieldName <> " <> ?", oneParam offlineHash)
+
+---------------------------------------------------------------------
+-- SQLite helpers: fields selection
+---------------------------------------------------------------------
+
+-- | Pack of fields which are only parsed if 'required' is set to 'True'.
+newtype FetchIf (required :: Bool) a = FetchIf (Maybe a)
+
+-- | Get the value if it was required.
+positiveFetch :: (required ~ 'True) => FetchIf required a -> a
+positiveFetch (FetchIf a) = a ?: error "positiveFetch: Nothing"
+
+instance (FromRow a, SBoolI required) => FromRow (FetchIf required a) where
+    fromRow
+        | fromSBool (sbool @required) = FetchIf . Just <$> fromRow
+        | otherwise                   = pure (FetchIf Nothing)

--- a/educator/tests/Test/Dscp/DB/SQLite/Common.hs
+++ b/educator/tests/Test/Dscp/DB/SQLite/Common.hs
@@ -104,7 +104,7 @@ instance Buildable TestLoggedError where
 
 instance Log.MonadLogging TestSQLiteM where
   log lvl _ msg =
-      when (lvl == Log.Warning || lvl == Log.Error) $
+      when (lvl >= Log.Warning) $
           throwM $ TestLoggedError lvl msg
   logName = return $ error "Logger name requested in test"
 

--- a/educator/tests/Test/Dscp/DB/SQLite/Common.hs
+++ b/educator/tests/Test/Dscp/DB/SQLite/Common.hs
@@ -15,6 +15,8 @@ import Database.SQLite.Simple (Connection, execute, fold, query, setTrace, withC
 import Fmt ((+|), (+||), (|+), (||+))
 import qualified Loot.Log as Log
 import Test.Hspec
+import Test.QuickCheck (ioProperty)
+import Test.QuickCheck.Monadic (PropertyM, monadic, stop)
 import qualified Text.Show
 import UnliftIO (MonadUnliftIO)
 
@@ -60,6 +62,10 @@ sqliteProperty ::
        (a -> TestSQLiteM prop) -> Property
 sqliteProperty action =
   property $ \input -> ioProperty $ do runTestSQLiteM (action input)
+
+sqlitePropertyM :: Testable prop => PropertyM TestSQLiteM prop -> Property
+sqlitePropertyM action =
+    monadic (ioProperty . runTestSQLiteM) (void $ action >>= stop)
 
 instance Adapter.MonadSQLiteDB TestSQLiteM where
   query theQuery args =

--- a/educator/tests/Test/Dscp/DB/SQLite/Queries.hs
+++ b/educator/tests/Test/Dscp/DB/SQLite/Queries.hs
@@ -24,7 +24,7 @@ spec_Instances = do
 
             it "Course does exist after it is created" $
                 sqliteProperty $ \courseId -> do
-                    _       <- DB.createCourse courseId (Just "foo") []
+                    _       <- DB.createCourse courseId "foo" []
                     isThere <- DB.existsCourse courseId
 
                     return isThere
@@ -46,7 +46,7 @@ spec_Instances = do
             it "Assignment is created and retrieved by hash" $
                 sqliteProperty $ \assignment -> do
 
-                    _              <- DB.createCourse    (assignment^.aCourseId) Nothing []
+                    _              <- DB.createCourse    (assignment^.aCourseId) "" []
                     assignmentHash <- DB.createAssignment assignment
                     assignment'    <- DB.getAssignment    assignmentHash
 
@@ -74,7 +74,7 @@ spec_Instances = do
 
                     let course     = assignment   ^.aCourseId
 
-                    _ <- DB.createCourse           course Nothing []
+                    _ <- DB.createCourse           course "" []
                     _ <- DB.createAssignment       assignment
 
                     throws @DomainError $ do
@@ -93,7 +93,7 @@ spec_Instances = do
                             course     = assignment^.aCourseId
                             student    = submission^.sStudentId
 
-                        _ <- DB.createCourse           course Nothing []
+                        _ <- DB.createCourse           course "" []
                         _ <- DB.createStudent          student
                         _ <- DB.createAssignment       assignment
                         _ <- sqlTransaction $
@@ -114,7 +114,7 @@ spec_Instances = do
                         course        = assignment   ^.aCourseId
                         student       = submission   ^.sStudentId
 
-                    courseId  <- DB.createCourse           course Nothing []
+                    courseId  <- DB.createCourse           course "" []
                     studentId <- DB.createStudent          student
                     _         <- DB.enrollStudentToCourse  studentId courseId
                     aHash     <- DB.createAssignment       assignment
@@ -143,7 +143,7 @@ spec_Instances = do
                     "Student should be enrolled to no courses initially"
 
                 for_ courses $ \course -> do
-                    courseId <- DB.createCourse course (Just "foo") []
+                    courseId <- DB.createCourse course "foo" []
                     DB.enrollStudentToCourse studentId courseId
 
                 courseIds' <- DB.getStudentCourses student
@@ -162,8 +162,8 @@ spec_Instances = do
 
                     studentId <- DB.createStudent student
 
-                    courseId1 <- DB.createCourse course1 Nothing []
-                    courseId2 <- DB.createCourse course2 Nothing []
+                    courseId1 <- DB.createCourse course1 "" []
+                    courseId2 <- DB.createCourse course2 "" []
 
                     DB.enrollStudentToCourse studentId courseId1
                     DB.enrollStudentToCourse studentId courseId2
@@ -210,7 +210,7 @@ spec_Instances = do
                     course     = assignment   ^.aCourseId
                     student    = submission   ^.sStudentId
 
-                courseId  <- DB.createCourse           course Nothing []
+                courseId  <- DB.createCourse           course "" []
                 studentId <- DB.createStudent          student
                 _         <- DB.enrollStudentToCourse  studentId courseId
                 aHash     <- DB.createAssignment       assignment
@@ -244,8 +244,8 @@ spec_Instances = do
                 then do
                     _studentId <- DB.createStudent          student
 
-                    courseId   <- DB.createCourse           course Nothing []
-                    courseId2  <- DB.createCourse           course2 Nothing []
+                    courseId   <- DB.createCourse           course "" []
+                    courseId2  <- DB.createCourse           course2 "" []
 
                     _          <- DB.enrollStudentToCourse  student courseId
                     _          <- DB.enrollStudentToCourse  student courseId2
@@ -290,7 +290,7 @@ spec_Instances = do
                         let sigSubmission = trans        ^.ptSignedSubmission
                             course        = assignment   ^.aCourseId
 
-                        cId <- DB.createCourse           course Nothing [] `orIfItFails` getId course
+                        cId <- DB.createCourse           course "" [] `orIfItFails` getId course
                         _   <- DB.enrollStudentToCourse  studentId cId     `orIfItFails` ()
                         aId <- DB.createAssignment       assignment        `orIfItFails` getId assignment
                         _   <- DB.setStudentAssignment   studentId aId     `orIfItFails` ()

--- a/educator/tests/Test/Dscp/DB/SQLite/Queries.hs
+++ b/educator/tests/Test/Dscp/DB/SQLite/Queries.hs
@@ -24,7 +24,7 @@ spec_Instances = do
 
             it "Course does exist after it is created" $
                 sqliteProperty $ \courseId -> do
-                    _       <- DB.createCourse courseId "foo" []
+                    _       <- DB.createCourse (simpleCourse courseId)
                     isThere <- DB.existsCourse courseId
 
                     return isThere
@@ -46,7 +46,7 @@ spec_Instances = do
             it "Assignment is created and retrieved by hash" $
                 sqliteProperty $ \assignment -> do
 
-                    _              <- DB.createCourse    (assignment^.aCourseId) "" []
+                    _              <- DB.createCourse    (simpleCourse $ assignment^.aCourseId)
                     assignmentHash <- DB.createAssignment assignment
                     assignment'    <- DB.getAssignment    assignmentHash
 
@@ -74,7 +74,7 @@ spec_Instances = do
 
                     let course     = assignment   ^.aCourseId
 
-                    _ <- DB.createCourse           course "" []
+                    _ <- DB.createCourse           (simpleCourse course)
                     _ <- DB.createAssignment       assignment
 
                     throws @DomainError $ do
@@ -93,7 +93,7 @@ spec_Instances = do
                             course     = assignment^.aCourseId
                             student    = submission^.sStudentId
 
-                        _ <- DB.createCourse           course "" []
+                        _ <- DB.createCourse           (simpleCourse course)
                         _ <- DB.createStudent          student
                         _ <- DB.createAssignment       assignment
                         _ <- sqlTransaction $
@@ -114,7 +114,7 @@ spec_Instances = do
                         course        = assignment   ^.aCourseId
                         student       = submission   ^.sStudentId
 
-                    courseId  <- DB.createCourse           course "" []
+                    courseId  <- DB.createCourse           (simpleCourse course)
                     studentId <- DB.createStudent          student
                     _         <- DB.enrollStudentToCourse  studentId courseId
                     aHash     <- DB.createAssignment       assignment
@@ -143,7 +143,7 @@ spec_Instances = do
                     "Student should be enrolled to no courses initially"
 
                 for_ courses $ \course -> do
-                    courseId <- DB.createCourse course "foo" []
+                    courseId <- DB.createCourse (simpleCourse course)
                     DB.enrollStudentToCourse studentId courseId
 
                 courseIds' <- DB.getStudentCourses student
@@ -162,8 +162,8 @@ spec_Instances = do
 
                     studentId <- DB.createStudent student
 
-                    courseId1 <- DB.createCourse course1 "" []
-                    courseId2 <- DB.createCourse course2 "" []
+                    courseId1 <- DB.createCourse $ CourseDetails course1 "" []
+                    courseId2 <- DB.createCourse $ CourseDetails course2 "" []
 
                     DB.enrollStudentToCourse studentId courseId1
                     DB.enrollStudentToCourse studentId courseId2
@@ -210,7 +210,7 @@ spec_Instances = do
                     course     = assignment   ^.aCourseId
                     student    = submission   ^.sStudentId
 
-                courseId  <- DB.createCourse           course "" []
+                courseId  <- DB.createCourse           (simpleCourse course)
                 studentId <- DB.createStudent          student
                 _         <- DB.enrollStudentToCourse  studentId courseId
                 aHash     <- DB.createAssignment       assignment
@@ -244,8 +244,8 @@ spec_Instances = do
                 then do
                     _studentId <- DB.createStudent          student
 
-                    courseId   <- DB.createCourse           course "" []
-                    courseId2  <- DB.createCourse           course2 "" []
+                    courseId   <- DB.createCourse           (simpleCourse course)
+                    courseId2  <- DB.createCourse           (simpleCourse course2)
 
                     _          <- DB.enrollStudentToCourse  student courseId
                     _          <- DB.enrollStudentToCourse  student courseId2
@@ -290,7 +290,7 @@ spec_Instances = do
                         let sigSubmission = trans        ^.ptSignedSubmission
                             course        = assignment   ^.aCourseId
 
-                        cId <- DB.createCourse           course "" [] `orIfItFails` getId course
+                        cId <- DB.createCourse           (simpleCourse course) `orIfItFails` getId course
                         _   <- DB.enrollStudentToCourse  studentId cId     `orIfItFails` ()
                         aId <- DB.createAssignment       assignment        `orIfItFails` getId assignment
                         _   <- DB.setStudentAssignment   studentId aId     `orIfItFails` ()

--- a/educator/tests/Test/Dscp/Educator/Web/Educator/Queries.hs
+++ b/educator/tests/Test/Dscp/Educator/Web/Educator/Queries.hs
@@ -1,0 +1,212 @@
+module Test.Dscp.Educator.Web.Educator.Queries where
+
+import Control.Lens (to)
+import Data.Default (def)
+import Data.List (nub, nubBy)
+import Dscp.DB.SQLite
+import Dscp.Util.Test
+import Test.QuickCheck (cover)
+import Test.QuickCheck.Monadic (pick, pre)
+
+import Dscp.Educator.Web.Educator
+import Dscp.Educator.Web.Queries
+import Dscp.Educator.Web.Types
+import Dscp.Util
+import Test.Dscp.DB.SQLite.Common
+import Test.Dscp.Educator.Web.Instances ()
+import Test.Dscp.Educator.Web.Scenarios
+
+applyFilterOn :: Eq f => (a -> f) -> (Maybe f) -> [a] -> [a]
+applyFilterOn field (Just match) = filter (\a -> field a == match)
+applyFilterOn _ _                = id
+
+sqlTx :: MonadSQLiteDB m => (WithinSQLTransaction => m a) -> m a
+sqlTx = sqlTransaction
+
+spec_EducatorApiQueries :: Spec
+spec_EducatorApiQueries = describe "Basic database operations" $ do
+  describe "Students" $ do
+    describe "getStudents" $ do
+        it "Returns previously added students" $ sqlitePropertyM $ do
+            students <- pick listUnique
+            lift $ forM_ students createStudent
+
+            students' <- lift $ educatorGetStudents Nothing
+            return $ sort students' === sort (map StudentInfo students)
+
+        it "Filtering works" $ sqlitePropertyM $ do
+            students@[student1, student2] <- pick $ vectorUnique 2
+            courses@[course1, course2] <- pick $ vectorUnique 2
+            lift $ do
+                forM_ students createStudent
+                forM_ courses $ createCourse . simpleCourse
+                enrollStudentToCourse student1 course1
+                enrollStudentToCourse student2 course1
+                enrollStudentToCourse student1 course2
+
+            res1 <- lift $ educatorGetStudents (Just course1)
+            res2 <- lift $ educatorGetStudents (Just course2)
+            return $ sort res1 === sort (map StudentInfo students)
+                .&&. res2 === one (StudentInfo student1)
+
+  describe "Courses" $ do
+    describe "getCourses" $ do
+        it "Returns previously added courses" $ sqlitePropertyM $ do
+            coursesDetails <- nubBy ((==) `on` cdCourseId) <$> pick arbitrary
+            lift $ forM_ coursesDetails createCourse
+
+            courses' <- lift $ educatorGetCourses Nothing
+            let coursesBone = coursesDetails <&>
+                              \(CourseDetails courseId desc subjs) ->
+                                  (courseId, desc, subjs)
+            let coursesBone' = courses' <&>
+                              \(CourseEducatorInfo courseId desc subjs) ->
+                                  (courseId, desc, subjs)
+            return $
+                cover (length coursesDetails > 1) 50 "enough courses" $
+                sort coursesBone === sort coursesBone'
+
+    describe "getCourses" $ do
+        it "Filtering works" $ sqlitePropertyM $ do
+            students@[student1, student2] <- pick $ vectorUnique 2
+            courses@[course1, course2] <- pick $ vectorUnique 2
+            lift $ do
+                forM_ students createStudent
+                forM_ courses $ createCourse . simpleCourse
+                enrollStudentToCourse student1 course1
+                enrollStudentToCourse student2 course1
+                enrollStudentToCourse student1 course2
+
+            res1 <- lift $ educatorGetCourses (Just student1)
+            res2 <- lift $ educatorGetCourses (Just student2)
+            return $ sort (map ciId res1) === sort courses
+                .&&. map ciId res2 === one (course1)
+
+    describe "getAssignments" $ do
+        -- This endpoint is fully covered by tests for Student API,
+        -- so just checking it at least works.
+
+        it "Returns existing assignment properly" $ sqlitePropertyM $ do
+            env <- pick $ genCoreTestEnv simpleCoreTestParams
+            let assignment = tiOne $ cteAssignments env
+            let student = tiOne $ cteStudents env
+
+            lift $ do
+                prepareForAssignments env
+                void $ createAssignment assignment
+                setStudentAssignment student (hash assignment)
+
+            res <- lift $ sqlTx $ commonGetAssignments EducatorCase student def
+            return $ res === one AssignmentEducatorInfo
+                { aiHash = hash assignment
+                , aiCourseId = _aCourseId assignment
+                , aiContentsHash = _aContentsHash assignment
+                , aiIsFinal =
+                    _aType assignment ^. assignmentTypeRaw
+                , aiDesc = _aDesc assignment
+                }
+
+  describe "Submissions" $ do
+    describe "getSubmission" $ do
+        it "Fails on request of non-existent submission" $ sqlitePropertyM $ do
+            env <- pick $ genCoreTestEnv simpleCoreTestParams
+            let submission = tiOne $ cteSubmissions env
+            let student = _sStudentId submission
+
+            _ <- lift $ createStudent student
+
+            lift . throwsPrism (_AbsentError . _SubmissionDomain) $
+                sqlTx $ educatorGetSubmission (getId submission)
+
+        it "Returns existing submission properly" $ sqlitePropertyM $ do
+            env <- pick $ genCoreTestEnv simpleCoreTestParams
+            let assignment = tiOne $ cteAssignments env
+                submission = tiOne $ cteSubmissions env
+                signedSubmission = tiOne $ cteSignedSubmissions env
+
+            lift $ prepareAndCreateSubmission env
+
+            res <- lift $ sqlTx $ educatorGetSubmission (getId submission)
+            return $ res === SubmissionEducatorInfo
+                { siHash = hash submission
+                , siContentsHash = _sContentsHash submission
+                , siAssignmentHash = hash assignment
+                , siGrade = Nothing
+                , siWitness = _ssWitness signedSubmission
+                }
+
+    describe "getSubmissions" $ do
+        it "Student has no last submissions initially" $ sqlitePropertyM $ do
+            env <- pick $ genCoreTestEnv simpleCoreTestParams
+            lift $ prepareForAssignments env
+            -- even after this ^ there should be no submissions
+
+            submissions <- lift educatorGetAllSubmissions
+            return $ submissions === []
+
+        it "Returns existing submission properly" $
+          sqlitePropertyM $ do
+            env <- pick $ genCoreTestEnv wildCoreTestParams
+            let submission = tiOne $ cteSubmissions env
+                signedSubmission = tiOne $ cteSignedSubmissions env
+
+            lift $ prepareAndCreateSubmission env
+
+            res <- lift educatorGetAllSubmissions
+            return $ res === one SubmissionEducatorInfo
+                { siHash = hash submission
+                , siContentsHash = _sContentsHash submission
+                , siAssignmentHash = _sAssignmentHash submission
+                , siGrade = Nothing
+                , siWitness = _ssWitness signedSubmission
+                }
+
+        it "Returns grade when present" $ sqlitePropertyM $ do
+            env <- pick $ genCoreTestEnv simpleCoreTestParams
+            let txs     = tiList $ ctePrivateTxs env
+                sigSubs = tiList $ cteSignedSubmissions env
+
+            pre (length sigSubs == length (nub sigSubs))
+
+            lift $ do
+                prepareForSubmissions env
+                sqlTx $ mapM_ createSignedSubmission sigSubs
+                mapM_ createTransaction txs
+
+            submissions' <- lift educatorGetAllSubmissions
+            let submissionsAndGrades' =
+                    map (siHash &&& fmap giGrade . siGrade) submissions'
+            let submissionsAndGrades = txs <&> \tx ->
+                        ( tx ^. ptSignedSubmission . ssSubmission . to hash
+                        , Just (_ptGrade tx))
+            return $
+                sortOn fst submissionsAndGrades
+                ===
+                sortOn fst submissionsAndGrades'
+
+        it "Filtering works" $ sqlitePropertyM $ do
+            env <- pick $ genCoreTestEnv simpleCoreTestParams
+                                         { ctpAssignment = AllRandomItems }
+            courseIdF <- pick arbitrary
+            assignHF <- pick arbitrary
+            docTypeF <- pick arbitrary
+
+            let student = tiOne $ cteStudents env
+                sigSubs = nub . tiList $ cteSignedSubmissions env
+                courses = map _aCourseId . tiList $ cteAssignments env
+
+            lift $ prepareForSubmissions env
+            lift $ sqlTx $ mapM_ createSignedSubmission sigSubs
+
+            submissions <- lift $ commonGetSubmissions EducatorCase
+                def{ sfStudent = Just student, sfCourse = courseIdF
+                    , sfAssignmentHash = assignHF, sfDocType = docTypeF }
+
+            let submissions' =
+                  map (\(s, _) -> educatorLiftSubmission s Nothing) $
+                  applyFilterOn snd courseIdF $
+                  applyFilterOn (_sAssignmentHash . _ssSubmission . fst) assignHF $
+                  applyFilterOn (_sDocumentType . _ssSubmission . fst) docTypeF $
+                  sigSubs `zip` cycle courses
+
+            return $ sortOn siHash submissions === sortOn siHash submissions'

--- a/educator/tests/Test/Dscp/Educator/Web/Instances.hs
+++ b/educator/tests/Test/Dscp/Educator/Web/Instances.hs
@@ -1,10 +1,15 @@
 module Test.Dscp.Educator.Web.Instances () where
 
+import Test.QuickCheck (resize)
 import Test.QuickCheck.Arbitrary.Generic (genericArbitrary, genericShrink)
 
+import Dscp.DB.SQLite
 import Dscp.Educator.Web.Queries
 import Dscp.Educator.Web.Types (IsFinal (..))
 import Dscp.Util.Test
+
+instance Arbitrary CourseDetails where
+    arbitrary = CourseDetails <$> arbitrary <*> arbitrary <*> resize 10 listUnique
 
 deriving instance Arbitrary IsFinal
 

--- a/educator/tests/Test/Dscp/Educator/Web/Instances.hs
+++ b/educator/tests/Test/Dscp/Educator/Web/Instances.hs
@@ -1,7 +1,21 @@
 module Test.Dscp.Educator.Web.Instances () where
 
+import Test.QuickCheck.Arbitrary.Generic (genericArbitrary, genericShrink)
+
+import Dscp.Educator.Web.Queries
+import Dscp.Educator.Web.Types (IsFinal (..))
 import Dscp.Util.Test
 
-import Dscp.Educator.Web.Types (IsFinal (..))
-
 deriving instance Arbitrary IsFinal
+
+instance Arbitrary GetAssignmentsFilters where
+    arbitrary = genericArbitrary
+    shrink = genericShrink
+
+instance Arbitrary GetSubmissionsFilters where
+    arbitrary = genericArbitrary
+    shrink = genericShrink
+
+instance Arbitrary GetProofsFilters where
+    arbitrary = genericArbitrary
+    shrink = genericShrink

--- a/educator/tests/Test/Dscp/Educator/Web/Instances.hs
+++ b/educator/tests/Test/Dscp/Educator/Web/Instances.hs
@@ -21,6 +21,6 @@ instance Arbitrary GetSubmissionsFilters where
     arbitrary = genericArbitrary
     shrink = genericShrink
 
-instance Arbitrary GetProofsFilters where
+instance Arbitrary GetProvenStudentTransactionsFilters where
     arbitrary = genericArbitrary
     shrink = genericShrink

--- a/educator/tests/Test/Dscp/Educator/Web/Scenarios.hs
+++ b/educator/tests/Test/Dscp/Educator/Web/Scenarios.hs
@@ -1,0 +1,51 @@
+-- | Scenarious for advanced test cases.
+
+module Test.Dscp.Educator.Web.Scenarios
+     ( prepareForAssignments
+     , prepareForSubmissions
+     , prepareAndCreateSubmission
+     ) where
+
+import qualified Data.Foldable as F
+
+import Dscp.Core
+import Dscp.Crypto
+import Dscp.DB.SQLite
+
+-- | Puts in db all needed to put 'SignedSubmission's
+-- later, tolerates repeated entities.
+prepareForAssignments
+    :: (MonadSQLiteDB m, MonadCatch m)
+    => CoreTestEnv -> m ()
+prepareForAssignments CoreTestEnv{..} = do
+    let assignments = F.toList cteAssignments
+        courses = map _aCourseId assignments
+        owners = F.toList cteStudents
+    mapM_ createStudent (ordNub owners)
+    forM_ (ordNub courses) $ \course -> do
+          void $ createCourse (simpleCourse course)
+          forM_ (ordNub owners) $ \owner ->
+              enrollStudentToCourse owner course
+
+-- | Puts in db all needed to put 'SignedSubmission's
+-- later, tolerates repeated entities.
+prepareForSubmissions
+    :: (MonadSQLiteDB m, MonadCatch m)
+    => CoreTestEnv -> m ()
+prepareForSubmissions env@CoreTestEnv{..} = do
+    let assignments = F.toList cteAssignments
+        owners = F.toList cteStudents
+    prepareForAssignments env
+    forM_ (ordNub assignments) $ \assignment -> do
+          void $ createAssignment assignment
+          forM_ (ordNub owners) $ \owner ->
+              setStudentAssignment owner (hash assignment)
+
+-- | Prepare all needed to put 'SignedSubmission's, and puts the first one.
+prepareAndCreateSubmission
+    :: (MonadSQLiteDB m, MonadCatch m)
+    => CoreTestEnv -> m ()
+prepareAndCreateSubmission env = do
+    prepareForSubmissions env
+    let sigSub = tiOne $ cteSignedSubmissions env
+    void $ sqlTransaction $ submitAssignment sigSub

--- a/educator/tests/Test/Dscp/Educator/Web/Student/Queries.hs
+++ b/educator/tests/Test/Dscp/Educator/Web/Student/Queries.hs
@@ -57,7 +57,7 @@ createCourseSimple :: CoreDB.DBM m => Int -> m Course
 createCourseSimple i =
     CoreDB.createCourse
         (allCourses !! (i - 1))
-        (Just $ "course " <> pretty i)
+        ("course " <> pretty i)
         []
 
 getAllSubmissions
@@ -77,7 +77,7 @@ prepareForSubmissions CoreTestEnv{..} = do
         owners = F.toList cteStudents
     mapM_ CoreDB.createStudent (ordNub owners)
     forM_ (ordNub courses) $ \course -> do
-          void $ CoreDB.createCourse course Nothing []
+          void $ CoreDB.createCourse course "" []
           forM_ (ordNub owners) $ \owner ->
               CoreDB.enrollStudentToCourse owner course
     forM_ (ordNub assignments) $ \assignment -> do
@@ -149,7 +149,7 @@ spec_StudentApiQueries = describe "Basic database operations" $ do
                 course <- studentGetCourse student1 courseId
                 return $ course === CourseStudentInfo
                     { ciId = courseId
-                    , ciDesc = fromMaybe "" desc
+                    , ciDesc = desc
                     , ciSubjects = subjects
                     , ciIsEnrolled = False
                     , ciIsFinished = False
@@ -224,7 +224,7 @@ spec_StudentApiQueries = describe "Basic database operations" $ do
                 courses <- sqlTx $ studentGetCourses student1 Nothing
                 return $ courses === one CourseStudentInfo
                     { ciId = courseId
-                    , ciDesc = fromMaybe "" desc
+                    , ciDesc = desc
                     , ciSubjects = subjects
                     , ciIsEnrolled = False
                     , ciIsFinished = False
@@ -307,7 +307,7 @@ spec_StudentApiQueries = describe "Basic database operations" $ do
             sqliteProperty $ \assignment -> do
                 let course = _aCourseId assignment
                 _ <- CoreDB.createStudent student1
-                _ <- CoreDB.createCourse course Nothing []
+                _ <- CoreDB.createCourse course "" []
                 _ <- CoreDB.createAssignment assignment
                 throwsPrism (_AbsentError . _AssignmentDomain) $
                     sqlTx $ studentGetAssignment student1 (hash assignment1)
@@ -317,7 +317,7 @@ spec_StudentApiQueries = describe "Basic database operations" $ do
                 let assignmentH = hash assignment
                 let course = _aCourseId assignment
                 _ <- CoreDB.createStudent student1
-                _ <- CoreDB.createCourse course Nothing []
+                _ <- CoreDB.createCourse course "" []
                 _ <- CoreDB.createAssignment assignment
                 _ <- CoreDB.enrollStudentToCourse student1 course
                 _ <- CoreDB.setStudentAssignment student1 assignmentH
@@ -338,7 +338,7 @@ spec_StudentApiQueries = describe "Basic database operations" $ do
               ) -> do
                 let course = _aCourseId assignment
                 _ <- CoreDB.createStudent student1
-                _ <- CoreDB.createCourse course Nothing []
+                _ <- CoreDB.createCourse course "" []
                 _ <- CoreDB.createAssignment assignment
                 _ <- CoreDB.enrollStudentToCourse student1 course
                 _ <- CoreDB.setStudentAssignment student1 (hash assignment)
@@ -353,7 +353,7 @@ spec_StudentApiQueries = describe "Basic database operations" $ do
             sqliteProperty $ \() -> do
                 let course = _aCourseId assignment1
                 _ <- CoreDB.createStudent student1
-                _ <- CoreDB.createCourse course Nothing []
+                _ <- CoreDB.createCourse course "" []
                 _ <- CoreDB.createAssignment assignment1
                 _ <- CoreDB.enrollStudentToCourse student1 course
                 _ <- CoreDB.setStudentAssignment student1 (hash assignment1)
@@ -367,7 +367,7 @@ spec_StudentApiQueries = describe "Basic database operations" $ do
                 let assignmentH = hash assignment
                 _ <- CoreDB.createStudent student1
                 forM_ (ordNub $ map _aCourseId assignments) $ \course -> do
-                    void $ CoreDB.createCourse course Nothing []
+                    void $ CoreDB.createCourse course "" []
                     void $ CoreDB.enrollStudentToCourse student1 course
                 _ <- CoreDB.createAssignment assignment
                 _ <- CoreDB.createAssignment needlessAssignment
@@ -394,7 +394,7 @@ spec_StudentApiQueries = describe "Basic database operations" $ do
                 let courseIds = ordNub $ map _aCourseId preAssignments
                 _ <- CoreDB.createStudent student1
                 forM_ courseIds $ \courseId -> do
-                    void $ CoreDB.createCourse courseId Nothing []
+                    void $ CoreDB.createCourse courseId "" []
                     void $ CoreDB.enrollStudentToCourse student1 courseId
                 forM_ preAssignments $ \assignment -> do
                     void $ CoreDB.createAssignment assignment
@@ -464,7 +464,7 @@ spec_StudentApiQueries = describe "Basic database operations" $ do
                     submission = _ssSubmission sigSub
                     course = _aCourseId assignment
                 _ <- CoreDB.createStudent owner
-                _ <- CoreDB.createCourse course Nothing []
+                _ <- CoreDB.createCourse course "" []
                 _ <- CoreDB.createAssignment assignment
                 _ <- CoreDB.enrollStudentToCourse owner course
                 _ <- CoreDB.setStudentAssignment owner (hash assignment)
@@ -494,7 +494,7 @@ spec_StudentApiQueries = describe "Basic database operations" $ do
                 else do
                     _ <- CoreDB.createStudent owner
                     _ <- CoreDB.createStudent user
-                    _ <- CoreDB.createCourse course Nothing []
+                    _ <- CoreDB.createCourse course "" []
                     _ <- CoreDB.createAssignment assignment
                     _ <- CoreDB.enrollStudentToCourse owner course
                     _ <- CoreDB.setStudentAssignment owner (hash assignment)
@@ -527,7 +527,7 @@ spec_StudentApiQueries = describe "Basic database operations" $ do
             sqliteProperty $ \() -> do
                 let course = _aCourseId assignment1
                 _ <- CoreDB.createStudent student1
-                _ <- CoreDB.createCourse course Nothing []
+                _ <- CoreDB.createCourse course "" []
                 _ <- CoreDB.createAssignment assignment1
                 _ <- CoreDB.enrollStudentToCourse student1 course
                 _ <- CoreDB.setStudentAssignment student1 (hash assignment1)

--- a/hpack/definitions.yaml
+++ b/hpack/definitions.yaml
@@ -48,6 +48,7 @@ _definitions:
     - &ghc-options
         - -Wall
         - -fno-warn-orphans
+        - -Werror
 
   _utils:
     - &lib-common

--- a/hpack/definitions.yaml
+++ b/hpack/definitions.yaml
@@ -48,7 +48,6 @@ _definitions:
     - &ghc-options
         - -Wall
         - -fno-warn-orphans
-        - -Werror
 
   _utils:
     - &lib-common

--- a/specs/disciplina/educator/api/educator.yaml
+++ b/specs/disciplina/educator/api/educator.yaml
@@ -644,6 +644,10 @@ paths:
           description: Submission hash value is invalid
           schema:
             $ref: "#/definitions/ErrResponse"
+        403:
+          description: Submission has already been graded.
+          schema:
+            $ref: "#/definitions/ErrResponse"
         404:
           description: Submission with given hash not found
           schema:
@@ -956,11 +960,13 @@ definitions:
             * `CourseAlreadyExists` - Course with such id already exists.
             * `AssignmentAlreadyExists` - Exactly the same assignment already exists.
             * `StudentDoesNotAttendCourse` - Student does not attend the course.
-            * `StudentIsActive` - Can not delete a student because he is attending a course.
 
             * `StudentAlreadyAttendsCourse` - Student already attends given course.
             * `StudentAlreadyHasAssignment` - Student is already subscribed on given assignment.
             * `StudentHasNoAssignment` - Given student didn't have given assignment.
+
+            * `StudentIsActive` - Can not delete a student because he is attending a course.
+            * `DeletingGradedSubmission` - Attempt to delete an already graded submission.
 parameters:
   StudentAddr:
     in: path

--- a/stack.yaml
+++ b/stack.yaml
@@ -43,7 +43,7 @@ extra-deps:
   commit: 2dd6b4ffdc4edb86b477273ee3c8416a1520f4e1
 
 - git: https://github.com/serokell/lootbox.git
-  commit: 885e41ce6f410597265823ca640267b69b1727e6
+  commit: f07f615884efc2419140137e4b450b2e100ac309
   subdirs:
     - code/base
     - code/config


### PR DESCRIPTION
I would really appreciate if this is reviewed and merged before substantial progress is done on DSCP-245, otherwise potential conflicts may make me :crying_cat_face:.

Contains:
* [x] Educator endpoints implementation - mostly
  * Some endpoints now serve both for student API and educator API
  * Fixed `getProofs` endpoint of Student API
  * Missing logic is marked with `TODO`
* [x] Educator tests - except a couple of endpoints
  * Moved some Students' tests to Educator's module - where was suitable
  * Missing tests are marked with `TODO`
* [x] Make "description" field in every SQL table mandatory (to prevent bugs)