### PR TITLE
[DSCP-242] Throw exception if transaction queue is overflown instead of blocking

### DIFF
--- a/core/src/Dscp/Core/Foundation/Witness.hs
+++ b/core/src/Dscp/Core/Foundation/Witness.hs
@@ -304,7 +304,14 @@ data BlockBody = BlockBody
     } deriving (Eq, Show, Generic)
 
 instance Buildable BlockBody where
-    build (BlockBody txs) = listF txs
+    build (BlockBody txs) =
+        listF displayedTxs +|
+        whenF (n > displayed) (" + "+|left|+" more transactions.")
+      where
+        n = length txs
+        displayed = 10
+        displayedTxs = take displayed txs
+        left = n - displayed
 
 -- | Block.
 data Block = Block

--- a/tools/src/txperf/Dscp/TxPerf/Tx.hs
+++ b/tools/src/txperf/Dscp/TxPerf/Tx.hs
@@ -33,7 +33,10 @@ genTx wc async = do
     let toCount = length accounts `min` balance accFrom
     accsTo <- liftIO . generate . resize toCount . listOf1 $ elements $ delete accFrom accounts
 
-    void . liftIO $ sendTx wc async accFrom (map (, Coin 1) . ordNub $ accsTo)
+    liftIO $
+        void (sendTx wc async accFrom (map (, Coin 1) . ordNub $ accsTo))
+        `catch` \(e :: WitnessClientError) ->
+                    putStrLn $ "Tx sending error: " ++ show e
 
     let upd =
             (\acc -> if acc == accFrom

--- a/tools/src/txperf/Dscp/TxPerf/Tx.hs
+++ b/tools/src/txperf/Dscp/TxPerf/Tx.hs
@@ -36,7 +36,7 @@ genTx wc async = do
     liftIO $
         void (sendTx wc async accFrom (map (, Coin 1) . ordNub $ accsTo))
         `catch` \(e :: WitnessClientError) ->
-                    putStrLn $ "Tx sending error: " ++ show e
+                    putStrLn $ "Tx sending error: " <> pretty e
 
     let upd =
             (\acc -> if acc == accFrom

--- a/tools/txperf-demo.json
+++ b/tools/txperf-demo.json
@@ -1,0 +1,10 @@
+{
+  "witness": "127.0.0.1:8003",
+  "accKeys": [
+    "ffRB5uhVEV24NXsYUuw1irt9HF5i5IRWJXHJzagXU8Y=",
+    "fOhZOFr6SSnYv1/xfKPPMHdWLdQDboysJ4Q794Gezmw="
+  ],
+  "genAccs": 2,
+  "txCount": 300,
+  "txAsync": true
+}

--- a/witness/src/Dscp/Witness/Relay.hs
+++ b/witness/src/Dscp/Witness/Relay.hs
@@ -3,6 +3,7 @@ module Dscp.Witness.Relay
     ( relayTx
     , newRelayState
     , RelayState (RelayState)
+    , RelayException (..)
     , rsInput
     , rsPipe
     , rsFailed

--- a/witness/src/Dscp/Witness/Relay.hs
+++ b/witness/src/Dscp/Witness/Relay.hs
@@ -42,8 +42,8 @@ instance Show RelayException where
 
 -- these sized do not really matter for now
 relayInputSize, relayPipeSize :: Int
-relayInputSize = 500
-relayPipeSize = 500
+relayInputSize = 100
+relayPipeSize = 100
 
 newRelayState :: MonadIO m => m RelayState
 newRelayState = atomically $

--- a/witness/src/Dscp/Witness/Web/Error.hs
+++ b/witness/src/Dscp/Witness/Web/Error.hs
@@ -18,6 +18,7 @@ import Servant (ServantErr (..), err400, err404, err500, err503)
 
 import Dscp.Snowdrop
 import Dscp.Util.Servant
+import Dscp.Witness.Relay (RelayException)
 import Dscp.Witness.Web.Util
 
 data WitnessAPIError
@@ -43,6 +44,7 @@ instance Exception WitnessAPIError where
         asum
         [ cast e'
         , fmap TxError . (^? _AccountValidationError) =<< fromException e
+        , ServiceUnavailable . show @Text @RelayException <$> fromException e
         ]
 
 -- | Contains info about error in client-convenient form.

--- a/witness/src/Dscp/Witness/Web/Error.hs
+++ b/witness/src/Dscp/Witness/Web/Error.hs
@@ -11,9 +11,10 @@ import Data.Aeson (FromJSON (..), ToJSON (..), Value (..), encode, withText)
 import Data.Aeson.Options (defaultOptions)
 import Data.Aeson.TH (deriveJSON)
 import Data.Reflection (Reifies (..))
+import qualified Data.Text as T
 import qualified Data.Text.Buildable as B
 import Data.Typeable (cast)
-import Servant (ServantErr (..), err400, err404, err500)
+import Servant (ServantErr (..), err400, err404, err500, err503)
 
 import Dscp.Snowdrop
 import Dscp.Util.Servant
@@ -24,6 +25,7 @@ data WitnessAPIError
     | TransactionNotFound
     | TxError AccountValidationException
     | InternalError Text
+    | ServiceUnavailable Text
     | InvalidFormat
     deriving (Show, Generic, Typeable)
 
@@ -33,6 +35,7 @@ instance Buildable WitnessAPIError where
         TransactionNotFound -> "Specified transaction does not exist."
         TxError err -> B.build err
         InternalError msg -> "Internal error: " <> B.build msg
+        ServiceUnavailable msg -> "Service unavailable: " <> B.build msg
         InvalidFormat -> "Failed to deserialise one of parameters."
 
 instance Exception WitnessAPIError where
@@ -53,12 +56,27 @@ data ErrResponse = ErrResponse
 
 deriveJSON defaultOptions ''ErrResponse
 
+uaPrefix :: Text
+uaPrefix = "<unavailable>"
+
+prefixUnavailable :: Text -> Text
+prefixUnavailable = (<>) uaPrefix
+
+unprefixUnavailable :: Text -> Maybe Text
+unprefixUnavailable txt =
+    if T.take l txt == uaPrefix
+    then Just $ T.drop l txt
+    else Nothing
+  where
+    l = length uaPrefix
+
 instance ToJSON WitnessAPIError where
     toJSON = String . \case
         BlockNotFound -> "BlockNotFound"
         TransactionNotFound -> "TransactionNotFound"
         TxError err -> snowdropErrorToShortJSON err
         InternalError msg -> msg
+        ServiceUnavailable msg -> prefixUnavailable msg
         InvalidFormat -> "InvalidFormat"
 
 instance FromJSON WitnessAPIError where
@@ -66,9 +84,9 @@ instance FromJSON WitnessAPIError where
         "BlockNotFound" -> BlockNotFound
         "TransactionNotFound" -> TransactionNotFound
         "InvalidFormat" -> InvalidFormat
-        msg | Just err <- parseShortJSONToSnowdropError msg
-            -> TxError err
-        msg -> InternalError msg
+        msg | Just err <- parseShortJSONToSnowdropError msg -> TxError err
+            | Just err <- unprefixUnavailable msg -> ServiceUnavailable err
+            | otherwise -> InternalError msg
 
 ---------------------------------------------------------------------------
 -- Functions
@@ -77,11 +95,12 @@ instance FromJSON WitnessAPIError where
 -- | Get HTTP error code of error.
 toServantErrNoReason :: WitnessAPIError -> ServantErr
 toServantErrNoReason = \case
-    BlockNotFound       -> err404
-    TransactionNotFound -> err404
-    TxError err         -> snowdropToServantErrNoReason err
-    InternalError{}     -> err500
-    InvalidFormat       -> err400
+    BlockNotFound        -> err404
+    TransactionNotFound  -> err404
+    TxError err          -> snowdropToServantErrNoReason err
+    InternalError{}      -> err500
+    ServiceUnavailable{} -> err503
+    InvalidFormat        -> err400
 
 -- | Make up error which will be returned to client.
 witnessToServantErr :: WitnessAPIError -> ServantErr

--- a/witness/src/Dscp/Witness/Web/Server.hs
+++ b/witness/src/Dscp/Witness/Web/Server.hs
@@ -17,7 +17,6 @@ import UnliftIO (UnliftIO (..), askUnliftIO)
 import Dscp.Util.Servant (LoggingApi, ServantLogConfig (..))
 import Dscp.Web (ServerParams (..), buildServantLogConfig, serveWeb)
 import Dscp.Witness.Launcher.Mode (WitnessWorkMode)
-import Dscp.Witness.Relay (RelayException)
 import Dscp.Witness.Web.API (WitnessAPI, witnessAPI)
 import Dscp.Witness.Web.Error
 import Dscp.Witness.Web.Handlers (witnessServantHandlers)
@@ -36,7 +35,6 @@ convertWitnessHandler
 convertWitnessHandler (UnliftIO unliftIO) handler =
     liftIO (unliftIO handler)
         `catch` throwServant
-        `catch` (throwServant . ServiceUnavailable . show @Text @RelayException)
         `catchAny` (throwServant . InternalError . show)
   where
     throwServant = throwError . witnessToServantErr


### PR DESCRIPTION
This avoids the situation when during high transactions load Servant handlers block on `writeTBQueue` and do not return any response until the queue isn't cleared.