### PR TITLE
[DSCP-176] Fix tests

### DIFF
--- a/educator/tests/Test/Dscp/DB/SQLite/Queries.hs
+++ b/educator/tests/Test/Dscp/DB/SQLite/Queries.hs
@@ -275,11 +275,13 @@ spec_Instances = do
     describe "Retrieval of proven transactions" $ do
         it "getProvenStudentTransactions" $
             sqliteProperty $ \
-                ( delayedGen (genCoreTestEnv simpleCoreTestParams) -> env
+                ( delayedGen (genCoreTestEnv simpleCoreTestParams
+                              `suchThat` ((>= 3) . tiNum . ctePrivateTxs)
+                             ) -> env
                 ) -> do
                     let student      = tiOne $ cteStudents env
                         assignment   = tiOne $ cteAssignments env
-                        transactions = take 3 $ tiInfUnique $ ctePrivateTxs env
+                        transactions = take 3 $ tiList $ ctePrivateTxs env
 
                     studentId <- DB.createStudent student
 

--- a/educator/tests/Test/Dscp/Educator/Web/Educator/Queries.hs
+++ b/educator/tests/Test/Dscp/Educator/Web/Educator/Queries.hs
@@ -187,7 +187,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
 
         it "Filtering works" $ sqlitePropertyM $ do
             env <- pick $ genCoreTestEnv simpleCoreTestParams
-                                         { ctpAssignment = AllRandomItems }
+                                         { ctpAssignment = variousItems }
             courseIdF <- pick arbitrary
             assignHF <- pick arbitrary
             docTypeF <- pick arbitrary

--- a/educator/tests/Test/Dscp/Educator/Web/Student/Queries.hs
+++ b/educator/tests/Test/Dscp/Educator/Web/Student/Queries.hs
@@ -240,8 +240,8 @@ spec_StudentApiQueries = describe "Basic database operations" $ do
                 let student = tiOne $ cteStudents env
                     sigSubs = nub . tiList $ cteSignedSubmissions env
                     gradedSigSubs = [(ss, g) | (ss, Just g) <- zip sigSubs mgrades]
-                prepareForSubmissions env
-                forM_ sigSubs $ \sigSub -> sqlTx $ submitAssignment sigSub
+
+                prepareAndCreateSubmissions env
                 forM_ gradedSigSubs $ \(sigSub, grade) ->
                     createTransaction PrivateTx
                     { _ptSignedSubmission = sigSub
@@ -562,8 +562,7 @@ spec_StudentApiQueries = describe "Basic database operations" $ do
         it "Pretending to be another student is bad" $
             sqliteProperty $
               \( delayedGen
-                 (genCoreTestEnv simpleCoreTestParams
-                                 { ctpSecretKey = AllRandomItems }) -> env
+                 (genCoreTestEnv simpleCoreTestParams) -> env
                , badStudent
                ) -> do
                 let student = tiOne $ cteStudents env


### PR DESCRIPTION
Previously I introduced generation of whole test environments which would
produce interconnected courses, assignments, submissions e.t.c.

One of invariants is one can zip produced list of courses/submissions/whatever
and get a list of tuples containing entities corresponding to each other.
Although I did a mistake while satisfying that invariant.

Now I reworked generation a bit a made it more concise.

100 runs of tests passed ok.