### PR TITLE
default.nix: attempt less rebuilds

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -26,7 +26,7 @@ let
 in
 
 disciplinaPackages // rec {
-  disciplina-config = runCommand "config.yaml" {} "mkdir -p $out/etc/disciplina && cp ${./config.yaml} $_";
+  disciplina-config = runCommand "config.yaml" {} "mkdir -p $out/etc/disciplina && cp ${./config.yaml} $_/config.yaml";
   disciplina-static = symlinkJoin {
     name = "disciplina-static";
     paths = [ disciplina-config ] ++ map haskell.lib.justStaticExecutables

--- a/default.nix
+++ b/default.nix
@@ -11,16 +11,17 @@ let
     reMatch = (re: builtins.match re relPath != null);
   in
     (lib.any reMatch whitelist) && !(lib.any reMatch blacklist);
+  composeFilters = a: b: name: type: (a name type) && (b name type);
 
   buildStackProject = import stack4nix { inherit pkgs; };
   disciplinaPackages = buildStackProject (builtins.path rec {
     path = ./.;
     name = "disciplina";
-    filter = filterWhiteBlack {
+    filter = composeFilters (filterWhiteBlack {
       inherit path;
       whitelist = [ "stack\.yaml" ".*/.*" ];
       blacklist = [ ".*node_modules.*" "docs.*" "run.*" "scripts.*" "secrets.*" "specs.*" ];
-    };
+    }) (lib.cleanSourceFilter);
   });
 in
 


### PR DESCRIPTION
This uses a whitelist/blacklist approach along with builtins.path, to remove any dependency on the source folder name and documentation or nix files.