### PR TITLE
witness: add hspec-discover to build tools

### DIFF
--- a/witness/package.yaml
+++ b/witness/package.yaml
@@ -71,6 +71,7 @@ tests:
     <<: *test-common
 
     build-tools:
+      - hspec-discover
       - tasty-discover
     dependencies:
       - hspec


### PR DESCRIPTION
Fixes: https://ci-gate.serokell.io/buildkite_public_log?https://buildkite.com/serokell/disciplina/builds/920#nix-build