### PR TITLE
[DSCP-252] Generalised fee policy

### DIFF
--- a/config-full-sample.yaml
+++ b/config-full-sample.yaml
@@ -6,19 +6,27 @@ sample:
     # in a slot
     slotDuration: 10000
     
-    # Transaction fee parameters.
+    # Transaction fee parameters
     fee:
-      # Minimal fee for money transactions
-      minimal: 10
-      # How many DSCP tokens one byte of money transaction costs.
-      # Total fee is (minimal + size_in_bytes * multiplier)
-      multiplier: 0.1
-
-      # Minimal fee for private header publication.
-      minimalPub: 10
-      # How many DSCP tokens one transaction in a private block costs.
-      # Total fee is (minimalPub + private_tx_num * multiplierPub)
-      multiplierPub: 0.1
+      # Fee parameters for money transactions
+      money:
+        # How the fees are calculated?
+        # `linear` - fee = minimal + S * multiplier, where S
+        # is size of transaction in bytes (for money transactions)
+        type: linear
+        coeffs:
+          minimal: 10
+          multiplier: 0.1
+      # Fee parameters for private header publications
+      publication:
+        type: linear
+        # How the fees are calculated?
+        # `linear` - fee = minimal + N * multiplier, where N
+        # is number of private transactions in corresponding block
+        # (for private header publications)
+        coeffs:
+          minimal: 10
+          multiplier: 1
 
     # Parameters of genesis block
     # See more info in [./docs/config.md](documentation)

--- a/config.yaml
+++ b/config.yaml
@@ -2,10 +2,16 @@ demo: &demo
   core: &demo-core
     slotDuration: 10000 # 10 s
     fee:
-      minimal: 10
-      multiplier: 0.1
-      minimalPub: 10
-      multiplierPub: 0.1
+      money:
+        type: linear
+        coeffs:
+          minimal: 10
+          multiplier: 0.1
+      publication:
+        type: linear
+        coeffs:
+          minimal: 10
+          multiplier: 1
     genesis: &demo-genesis
       genesisSeed: "GromakNaRechke"
       governance:

--- a/core/src/Dscp/Core/Config.hs
+++ b/core/src/Dscp/Core/Config.hs
@@ -23,7 +23,7 @@ module Dscp.Core.Config
     , genesisHeader
     , genesisHash
 
-    , feeCoefficients
+    , feeConfig
 
     , giveL
     , giveLC
@@ -55,7 +55,7 @@ type CoreConfig =
    '[ "core" ::<
        '[ "genesis" ::: GenesisConfig
         , "slotDuration" ::: SlotDuration
-        , "fee" ::: FeeCoefficients
+        , "fee" ::: FeeConfig
 
         , "generated" ::<
             '[ "genesisInfo" ::: GenesisInfo
@@ -106,5 +106,5 @@ genesisHeader = bHeader genesisBlock
 genesisHash :: HasCoreConfig => HeaderHash
 genesisHash = hash genesisHeader
 
-feeCoefficients :: HasCoreConfig => FeeCoefficients
-feeCoefficients = giveL @CoreConfig @FeeCoefficients
+feeConfig :: HasCoreConfig => FeeConfig
+feeConfig = giveL @CoreConfig @FeeConfig

--- a/core/src/Dscp/Util.hs
+++ b/core/src/Dscp/Util.hs
@@ -166,7 +166,7 @@ assertJust action message = whenNothingM action $ throwM message
 nothingToThrow :: (MonadThrow m, Exception e) => e -> Maybe a -> m a
 nothingToThrow e = maybe (throwM e) pure
 
-nothingToFail :: (MonadFail m, ToString t) => t -> Maybe a -> m a
+nothingToFail :: MonadFail m => Text -> Maybe a -> m a
 nothingToFail e = maybe (fail $ toString e) pure
 
 nothingToPanic :: Text -> Maybe a -> a

--- a/wallet/src/Dscp/Wallet/Backend.hs
+++ b/wallet/src/Dscp/Wallet/Backend.hs
@@ -82,7 +82,7 @@ sendTx wc sendEvent eSecretKey mPassPhrase (toList -> outs) = do
     nonce <- fromIntegral . unNonce . aiCurrentNonce <$>
              wGetAccount wc address False
 
-    txWitnessed <- pure . fixFees feeCoefficients $ \fees ->
+    txWitnessed <- pure . fixFees (fcMoney feeConfig) $ \fees ->
         let inAcc   = TxInAcc { tiaNonce = nonce, tiaAddr = address }
             inValue = Coin (sum $ map (unCoin . txOutValue) outs) `unsafeAddCoin` unFees fees
             tx      = Tx { txInAcc = inAcc, txInValue = inValue, txOuts = outs }

--- a/witness/src/Dscp/Snowdrop/Expanders.hs
+++ b/witness/src/Dscp/Snowdrop/Expanders.hs
@@ -80,7 +80,7 @@ getByGTx
        , SeqExpanders Exceptions Ids Proofs Values ctx GTxWitnessed
        )
 getByGTx applyFees pk t =
-    let fee  = calcFeeG (if applyFees then feeCoefficients else noFees) t
+    let fee  = calcFeeG (if applyFees then feeConfig else noFeesConfig) t
         addr = mkAddr pk
         (a, b) = case t of
                    GMoneyTxWitnessed tx        -> toProofBalanceTx fee tx

--- a/witness/tests/Test/Dscp/Witness/FeeSpec.hs
+++ b/witness/tests/Test/Dscp/Witness/FeeSpec.hs
@@ -9,13 +9,13 @@ import Dscp.Util.Test
 -- TODO: get from config ([DSCP-90])?
 testFeeCoefficients :: FeeCoefficients
 testFeeCoefficients =
-    FeeCoefficients
-        {fcMinimal = Coin 10, fcMultiplier = 0.1, fcMinimalPub = Coin 10, fcMultiplierPub = 0.1}
+    FeeCoefficients{fcMinimal = Coin 10, fcMultiplier = 0.1}
 
 spec :: Spec
 spec = describe "Transaction fees" $ do
-    it "fixFees always converges for money tx" . property $ \txTemplate sk ->
-        let tw = fixFees testFeeCoefficients $ \fees ->
+    it "fixFees always converges for money tx and linear coefs" . property $
+      \txTemplate sk ->
+        let tw = fixFees (LinearFeePolicy testFeeCoefficients) $ \fees ->
                 let outs = txOuts txTemplate
                     inValue = Coin (sum $ map (unCoin . txOutValue) outs)
                               `unsafeAddCoin` unFees fees

--- a/witness/tests/Test/Dscp/Witness/Mode.hs
+++ b/witness/tests/Test/Dscp/Witness/Mode.hs
@@ -105,11 +105,17 @@ testWitnessConfig =
         , gcDistribution = GenesisDistribution . one $ GDSpecific genesisAddressMap
         }
     feeCoefs =
-        FeeCoefficients
-        { fcMinimal       = Coin 10
-        , fcMultiplier    = 0.1
-        , fcMinimalPub    = Coin 10
-        , fcMultiplierPub = 0.0001
+        FeeConfig
+        { fcMoney = LinearFeePolicy
+            FeeCoefficients
+            { fcMinimal       = Coin 10
+            , fcMultiplier    = 0.1
+            }
+        , fcPublication = LinearFeePolicy
+            FeeCoefficients
+            { fcMinimal       = Coin 10
+            , fcMultiplier    = 0.1
+            }
         }
 
 ----------------------------------------------------------------------------

--- a/witness/tests/Test/Dscp/Witness/Tx/MoneyTxSpec.hs
+++ b/witness/tests/Test/Dscp/Witness/Tx/MoneyTxSpec.hs
@@ -38,7 +38,7 @@ properSteps = TxCreationSteps
     , _tcsTx = \txInAcc txInValue txOuts' ->
         Tx{ txInAcc, txInValue, txOuts = txOuts' }
     , _tcsWitness = TxWitness
-    , _tcsFixFees = fixFees feeCoefficients
+    , _tcsFixFees = fixFees (fcMoney feeConfig)
     }
 
 -- | Exact values for transaction.
@@ -78,7 +78,7 @@ genSafeTxData = do
 
 -- | Given creation steps, build a transaction.
 makeTx :: HasWitnessConfig => TxCreationSteps -> TxData -> TxWitnessed
-makeTx steps dat = fixFees feeCoefficients $ \fee ->
+makeTx steps dat = _tcsFixFees steps $ \fee ->
     let sourcePk = toPublic (tdSecret dat)
         inAcc = _tcsInAcc steps (mkAddr sourcePk)
         spent = leftToPanic $ sumCoins $

--- a/witness/tests/Test/Dscp/Witness/Tx/PublicationTxSpec.hs
+++ b/witness/tests/Test/Dscp/Witness/Tx/PublicationTxSpec.hs
@@ -37,7 +37,7 @@ genPublicationChain (Positive n) secret
                         }
                 in PublicationTx
                 { ptAuthor = addr
-                , ptFeesAmount = unFees $ calcFeePub feeCoefficients (mrSize sig)
+                , ptFeesAmount = unFees $ calcFeePub (fcPublication feeConfig) ptHeader
                 , ptHeader
                 }
 


### PR DESCRIPTION
Allow not only linear policies.
Since we have several kinds of transactions, I used GADTs to make it possible to apply some policies only to specific kind of transactions, maybe I overengeneered.

todo:
- [x] Wait for #225 to be merged (to avoid conflicts)
- [x] Wait for #229 to be merged (to avoid conflicts)
- [ ] Update configuration file