### PR TITLE
[DSCP-263] Provide manual `instance Serialise Submission`

### DIFF
--- a/core/src/Dscp/Core/Foundation/Instances.hs
+++ b/core/src/Dscp/Core/Foundation/Instances.hs
@@ -3,6 +3,8 @@
 module Dscp.Core.Foundation.Instances where
 
 import Codec.Serialise (Serialise (..))
+import Codec.Serialise.Decoding (decodeListLen, decodeWord)
+import Codec.Serialise.Encoding (encodeListLen, encodeWord)
 
 import Dscp.Core.Foundation.Educator
 import Dscp.Core.Foundation.Witness
@@ -49,10 +51,25 @@ deriving instance Serialise ATG
 
 instance Serialise Assignment
 instance Serialise AssignmentType
-instance Serialise Submission
 instance Serialise SubmissionWitness
 instance Serialise SignedSubmission
 instance Serialise DocumentType
+
+instance Serialise Submission where
+    encode (Submission s c a) = mconcat
+        [ encodeListLen 4
+        , encodeWord 0
+        , encode s
+        , encode c
+        , encode a
+        ]
+
+    decode = do
+        len <- decodeListLen
+        tag <- decodeWord
+        case (len, tag) of
+            (4, 0) -> Submission <$> decode <*> decode <*> decode
+            _      -> fail "Invalid Submission encoding"
 
 ----------------------------------------------------------------------------
 -- Witness


### PR DESCRIPTION
Automatically generated instance is not even valid if I check with
`validFlatTerm`.
Now it follows the tutorial on CBOR.

Testing:
* Sanity of new representation is tested in ghci
* `deserialise (serialise sub) === sub` is tested manually in ghci