### PR TITLE
[DSCP-263] Fix educator secret

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -20,3 +20,23 @@ stack ghci disciplina-educator
 ```
 
 Then execute your `curl` request with appended `-H "Authorization: Bearer eyJhbGciOiJFZERTQSJ9.eyJkYXQiOnsiYWRQYXRoIjoiL2FwaS9lZHVjYXRvci92MS9zdHVkZW50cyIsImFkVGltZSI6IjIwMjUtMDgtMTBUMTM6MTU6NDAuNDYxOTk4MTM2WiJ9fQ.xqn65GQNSlEktlwy0nPlEJRre0BzEVbAeU69U4yn0jozjhmZQpWmWoojnrhrxWO5FENrNzMu0oj1ujuTWyJhCQ"`.
+
+This will generate a pseudo-random secret key and suitable for making requests to Student API. If you are testing Educator API and need to use a specific secret key, then you need to unencrypt key stored in educator key file used by the node. Or consider using the ready key; assuming an `educator.key` file has the following content
+
+
+```json
+{
+  "content": {
+    "secret": "UDmuKdozmYBZNPPBVEuu2xBQ1pXPhKZwDL2OxMlQExkTnFggprngNDUpBF5wSXReXmjDROuiHG5tUbKmmBFJGVAlt0M="
+  },
+  "version": "1.0.0"
+}
+```
+
+corresponding secret key can be acquired as follows
+
+```bash
+stack ghci disciplina-educator
+> import Dscp.Util
+> secret = leftToPanic $ fromBase64 "sB6doD5XUROM3JwUs3oxOVDv3BrWZaFOzjGS1h1MTxc="
+```

--- a/run/educator.key
+++ b/run/educator.key
@@ -1,1 +1,1 @@
-{"content":{"secret":"UCOv0cwGBIGUEd8afhK9lEFQT8GufQRMtZXasofR9aF81FggZBEdkDFA4pbYmKqwpAw8fXbQHEbk1tV8kDCgcG1i5+g="},"version":"1.0.0"}
+{"content":{"secret":"UDmuKdozmYBZNPPBVEuu2xBQ1pXPhKZwDL2OxMlQExkTnFggprngNDUpBF5wSXReXmjDROuiHG5tUbKmmBFJGVAlt0M="},"version":"1.0.0"}

--- a/scripts/launch/node.sh
+++ b/scripts/launch/node.sh
@@ -56,7 +56,7 @@ witness_web_addr="127.0.0.1:8091"
 
 # educator-only params
 educator_params="
---educator-keyfile $tmp_files/educator.key
+--educator-keyfile $files/educator.key
 --educator-gen-key
 --sql-path $tmp_files/educator.db
 --educator-listen 127.0.0.1:8090


### PR DESCRIPTION
1. Keep educator secret key in `run/educator.key` rather than `run/tmp/educator.key` which is deleted upon each launch
2. Keep unencrypted secret in key file (password is long forgotten)
3. Update authentication doc to tell how to deal with Educator API's authentication