### PR TITLE
[DSCP-275] [DSCP-282] Make Educator and Student APIs authentication optional

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -225,6 +225,7 @@ language_extensions:
   - DefaultSignatures
   - DeriveDataTypeable
   - DeriveGeneric
+  - ExplicitNamespaces
   - FlexibleContexts
   - FlexibleInstances
   - FunctionalDependencies

--- a/config-full-sample.yaml
+++ b/config-full-sample.yaml
@@ -5,7 +5,7 @@ sample:
     # Slot duration in milliseconds. A block is issued once
     # in a slot
     slotDuration: 10000
-    
+
     # Transaction fee parameters
     fee:
       # Fee parameters for money transactions
@@ -40,13 +40,13 @@ sample:
         - equal: 1000
         - specific:
           - # Faucet
-            - LL4qKn62hrdLh1vkyiidEFLfCaAngaVmtu3ipGVSubhackXS4pXNbeDC
+            - 3BAyX5pNrN2UzxPZhrFAocCti3nVRUZRk7CZtudT2iLhGH6T1eq5FzqEuk
             - 1000
           - # Test key #1, secret: ffRB5uhVEV24NXsYUuw1irt9HF5i5IRWJXHJzagXU8Y=
-            - LL4qKoASaEwZGfvoQCPa2xGv3LKJQVCxaRw73p61Bj6tD8CSDcgkANf6
+            - 3BAyX5pPvmtsKAyDhtfeUZ1beJdFZzHLTHt6nHrzdGcpfagpgeysRNPyMe
             - 1000
           - # Test key #2, secret: fOhZOFr6SSnYv1/xfKPPMHdWLdQDboysJ4Q794Gezmw=
-            - LL4qKqwvLDw4eKXTt5tpCZytoyaMVVbRmVRCo1HL8zwPaNWDxBnLpKoJ
+            - 3BAyX5pSiFerJgLsJZ9XyoBDMHPtq3NLqm5AGPcBpba6W644zSiSWy3vVr
             - 1000
 
   # Witness node configuration
@@ -93,7 +93,7 @@ sample:
         # Keyfile passphrase (optional). If not given, key is encrypted with an
         # empty passphrase.
         passphrase: "qwerty123"
-        
+
       # Committee params. Used together with committee governance params
       # in order to generate committee keys from seed. Optional.
       committee:
@@ -186,7 +186,7 @@ sample:
 
     # Backend Witness address
     witnessBackend: witness.disciplina.io:8001
-    
+
     # Amount of money to be transferred with a single transaction
     transferredAmount: 20
 

--- a/config-full-sample.yaml
+++ b/config-full-sample.yaml
@@ -163,6 +163,16 @@ sample:
         # Delay between action trigger and action (e. g. time
         # between receiving student's submission and posting a grade)
         operationsDelay: "3s"
+      # Whether authentication in Student API should be optional
+      studentAPINoAuth:
+        # If enabled, primary JWT-based authentication becomes optional
+        enabled: true
+        # Address of student pretending to be author of requests to server.
+        data: 3BAyX5pUsPCFfK45adsJpj7X6waKEB1kxdvMn1Tj2VYsrJuHApTviPEpK3
+      # Whether authentication in Educator API should be optional
+      educatorAPINoAuth:
+        enabled: true
+        data: []
 
   # Faucet config
   faucet:

--- a/educator/src/Dscp/Educator/Web/Educator/API.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/API.hs
@@ -26,7 +26,8 @@ import Dscp.Educator.Web.Types
 type EducatorAPI =
     "api" :> "educator" :> "v1" :> ToServant (EducatorApiEndpoints AsApi)
 
-type ProtectedEducatorAPI = Auth' EducatorAuth () :> EducatorAPI
+type ProtectedEducatorAPI =
+    Auth' [EducatorAuth, NoAuth "educator"] () :> EducatorAPI
 
 type EducatorApiHandlers m = EducatorApiEndpoints (AsServerT m)
 

--- a/educator/src/Dscp/Educator/Web/Params.hs
+++ b/educator/src/Dscp/Educator/Web/Params.hs
@@ -5,12 +5,17 @@ module Dscp.Educator.Web.Params
 import Data.Aeson.Options (defaultOptions)
 import Data.Aeson.TH (deriveFromJSON)
 
+import Dscp.Educator.Web.Auth
 import Dscp.Educator.Web.Bot.Params
+import Dscp.Educator.Web.Educator.Auth ()
+import Dscp.Educator.Web.Student.Auth ()
 import Dscp.Web
 
 data EducatorWebParams = EducatorWebParams
-    { ewpServerParams :: ServerParams
-    , ewpBotParams    :: EducatorBotSwitch
+    { ewpServerParams      :: ServerParams
+    , ewpBotParams         :: EducatorBotSwitch
+    , ewpEducatorAPINoAuth :: NoAuthContext "educator"
+    , ewpStudentAPINoAuth  :: NoAuthContext "student"
     }
 
 deriveFromJSON defaultOptions ''EducatorWebParams

--- a/educator/src/Dscp/Educator/Web/Student/API.hs
+++ b/educator/src/Dscp/Educator/Web/Student/API.hs
@@ -39,7 +39,8 @@ data StudentApiEndpoints route = StudentApiEndpoints
 type StudentAPI =
     "api" :> "student" :> "v1" :> ToServant (StudentApiEndpoints AsApi)
 
-type ProtectedStudentAPI = Auth' StudentAuth Core.Student :> StudentAPI
+type ProtectedStudentAPI =
+    Auth' [StudentAuth, NoAuth "student"] Core.Student :> StudentAPI
 
 type StudentApiHandlers m = StudentApiEndpoints (AsServerT m)
 

--- a/scripts/launch/node.sh
+++ b/scripts/launch/node.sh
@@ -60,6 +60,8 @@ educator_params="
 --educator-gen-key
 --sql-path $tmp_files/educator.db
 --educator-listen 127.0.0.1:8090
+--educator-api-no-auth
+--student-api-no-auth 3BAyX5pUsPCFfK45adsJpj7X6waKEB1kxdvMn1Tj2VYsrJuHApTviPEpK3
 "
 
 # witness params (and educator's as well)

--- a/witness/src/Dscp/CommonCLI.hs
+++ b/witness/src/Dscp/CommonCLI.hs
@@ -9,6 +9,7 @@ module Dscp.CommonCLI
        , baseKeyParamsParser
        , timeReadM
        , coinReadM
+       , addressReadM
        , networkAddressParser
        , clientAddressParser
        , serverParamsParser
@@ -25,12 +26,13 @@ import Text.InterpolatedString.Perl6 (qc)
 import Time.Rational (KnownRat)
 import Time.Units (Microsecond, Millisecond, Minute, Second, Time, toUnit)
 
+import Dscp.Core.Foundation.Address
 import Dscp.Core.Foundation.Witness
 import Dscp.Crypto (mkPassPhrase)
 import Dscp.Resource.AppDir
 import Dscp.Resource.Keys (BaseKeyParams (..))
 import Dscp.Resource.Logging (LoggingParams (..))
-import Dscp.Util (leftToFail)
+import Dscp.Util
 import Dscp.Web (NetworkAddress (..), ServerParams (..), parseNetAddr)
 import Paths_disciplina_witness (version)
 
@@ -102,6 +104,10 @@ timeReadM = asum
 -- | Parses plain number to coin.
 coinReadM :: ReadM Coin
 coinReadM = leftToFail . coinFromInteger =<< auto @Integer
+
+-- | Parses address.
+addressReadM :: ReadM Address
+addressReadM = leftToPanic . addrFromText <$> str
 
 ----------------------------------------------------------------------------
 -- Utils


### PR DESCRIPTION
In order to avoid keeping two API types - with and without authentication - I pass that option via context along with educator secret key.

- [x] Clean up commit history