### PR TITLE
Add a build note for single-user installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ otherwise main Nix binary cache stops working. See [cachix/cachix#128][].
 
 [cachix/cachix#128]: https://github.com/cachix/cachix/pull/128
 
+If you test Disciplina or develop software that integrates with it, run
+`nix-env -if .`. This will install Disciplina packages into your user profile.
+Then you can use `scripts/launch/node.sh` to start the nodes.
+
 For production builds, run `nix-build`.
 
 For incremental builds, run `nix-shell`. Then, use either `stack build` or

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Set up Disciplina binary cache so that you don't have to build dependencies:
 sudo $(nix-build closure.nix -A cachix --no-out-link)/bin/cachix use disciplina
 ```
 
+If you are on a single-user Nix install (`nix-shell -p nix-info --run nix-info`
+should say `multi-user?: no`), omit `sudo` in the command above.
+
 If you are on NixOS, make sure to add `https://cache.nixos.org` to `nix.binaryCaches`,
 otherwise main Nix binary cache stops working. See [cachix/cachix#128][].
 

--- a/shell-native.nix
+++ b/shell-native.nix
@@ -1,0 +1,23 @@
+{ pkgs ? import ./closure.nix }: with pkgs;
+
+stdenv.mkDerivation rec {
+  name = "disciplina";
+
+  nativeBuildInputs = [
+    binutils
+    haskell.compiler.ghc822
+    pkgconfig
+  ];
+
+  buildInputs = [
+    gmp
+    openssl
+    rocksdb
+    zeromq
+    zlib
+  ];
+
+  shellHook = ''
+    export LD_LIBRARY_PATH=${lib.makeLibraryPath buildInputs}:$LD_LIBRARY_PATH
+  '';
+}

--- a/stack.yaml
+++ b/stack.yaml
@@ -95,3 +95,7 @@ extra-deps:
 - pretty-terminal-0.1.0.0
 
 apply-ghc-options: everything
+
+nix:
+  enable: true
+  shell-file: shell-native.nix


### PR DESCRIPTION
> If you are on a single-user Nix install (`nix-shell -p nix-info --run nix-info`
should say `multi-user?: no`), omit `sudo` in the command above.