### PR TITLE
Remove nix: enable: true

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -97,5 +97,4 @@ extra-deps:
 apply-ghc-options: everything
 
 nix:
-  enable: true
   shell-file: shell-native.nix


### PR DESCRIPTION
If someone wants to build with Nix, they can either set it in their user conf, pass `--nix` flag to Stack or just enter `nix-shell`.
