### PR TITLE
[DSCP-284][DSCP-203] Include public key into JWS authentication header

### DIFF
--- a/core/package.yaml
+++ b/core/package.yaml
@@ -27,6 +27,7 @@ library:
     - generic-arbitrary
     - hashable
     - hspec
+    - jose
     - log-warper
     - loot-base
     - loot-config
@@ -68,6 +69,7 @@ tests:
       - containers
       - disciplina-core
       - hspec
+      - jose
       - tasty
       - tasty-discover
       - tasty-hspec

--- a/core/package.yaml
+++ b/core/package.yaml
@@ -17,6 +17,7 @@ library:
     - base58-bytestring
     - containers
     - componentm
+    - crypto-api
     - cryptonite
     - cryptonite-openssl
     - data-default

--- a/core/src/Dscp/Crypto/Encrypt.hs
+++ b/core/src/Dscp/Crypto/Encrypt.hs
@@ -41,7 +41,7 @@ import Crypto.Cipher.Types (AEAD, AEADMode (AEAD_GCM), AuthTag (..),
 import Crypto.Error (onCryptoFailure)
 import Crypto.Hash.Algorithms (SHA512 (..))
 import qualified Crypto.KDF.PBKDF2 as PBKDF2
-import Crypto.Random (MonadRandom, getRandomBytes)
+import Crypto.Random.Types (MonadRandom, getRandomBytes)
 import Data.ByteArray (ByteArray, ByteArrayAccess, ScrubbedBytes)
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString.Lazy as BSL

--- a/core/src/Dscp/Crypto/Impl.hs
+++ b/core/src/Dscp/Crypto/Impl.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PackageImports       #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 
 -- | Actual implementations of abstract crypto primitives used in Dscp.
@@ -31,8 +32,8 @@ module Dscp.Crypto.Impl
 
 import Crypto.Error (CryptoFailable (..))
 import Crypto.Hash.Algorithms (Blake2b_256)
-import Crypto.Random (ChaChaDRG, MonadPseudoRandom, drgNewSeed, seedFromBinary, seedFromInteger,
-                      withDRG)
+import "cryptonite" Crypto.Random (ChaChaDRG, MonadPseudoRandom, drgNewSeed, seedFromBinary,
+                                   seedFromInteger, withDRG)
 import qualified Data.ByteString as BS
 import Fmt (build, (+|), (|+))
 

--- a/core/src/Dscp/Crypto/JWS.hs
+++ b/core/src/Dscp/Crypto/JWS.hs
@@ -16,7 +16,7 @@ import Crypto.JOSE (CompactJWS, Error, FromCompact (..), HasJwk (jwk), HeaderPar
                     JWSHeader, KeyMaterial (..), OKPKeyParameters (..), ToCompact (..), asPublicKey,
                     bestJWSAlg, fromKeyMaterial, header, jwkMaterial, newJWSHeader, param, signJWS,
                     signatures, verifyJWS')
-import Crypto.Random (MonadRandom (..))
+import Crypto.Random.Types (MonadRandom (..))
 
 import Dscp.Crypto.Impl
 import Dscp.Crypto.Signing.Class

--- a/core/src/Dscp/Crypto/JWS.hs
+++ b/core/src/Dscp/Crypto/JWS.hs
@@ -1,0 +1,148 @@
+{-# LANGUAGE DeriveFunctor #-}
+
+module Dscp.Crypto.JWS
+       ( JWitness
+       , secretToJwk
+       , publicToJwk
+       , jwkToSecret
+       , jwkToPublic
+
+       , signJWitness
+       , verifyJWitness
+       ) where
+
+import Control.Lens (_Just)
+import Crypto.JOSE (CompactJWS, Error, FromCompact (..), HasJwk (jwk), HeaderParam (..), JWK,
+                    JWSHeader, KeyMaterial (..), OKPKeyParameters (..), ToCompact (..), asPublicKey,
+                    bestJWSAlg, fromKeyMaterial, header, jwkMaterial, newJWSHeader, param, signJWS,
+                    signatures, verifyJWS')
+import Crypto.Random (MonadRandom (..))
+
+import Dscp.Crypto.Impl
+import Dscp.Crypto.Signing.Class
+import Dscp.Util
+
+---------------------------------------------------------------------------
+-- JSON Web Keys with underlying Disciplina keys
+---------------------------------------------------------------------------
+
+-- | Create a JWK containing secret from a secret key.
+secretToJwk :: SecretKey -> JWK
+secretToJwk = fromKeyMaterial . OKPKeyMaterial . secretToOKPKeyParameters
+
+-- | Helper function to create proper key parameters from a secret key.
+secretToOKPKeyParameters :: SecretKey -> OKPKeyParameters
+secretToOKPKeyParameters ask'@(AbstractSK sk) = Ed25519Key pk $ Just sk
+  where pk = unAbstractPk $ toPublic ask'
+
+-- | Create a public JWK from public key
+publicToJwk :: PublicKey -> JWK
+publicToJwk = fromKeyMaterial . OKPKeyMaterial . publicToOKPKeyParamerers
+
+-- | Helper function to create proper key parameters from a public key.
+publicToOKPKeyParamerers :: PublicKey -> OKPKeyParameters
+publicToOKPKeyParamerers (AbstractPK pk) = Ed25519Key pk Nothing
+
+-- | Get a secret key from given JWK
+jwkToSecret :: JWK -> Either Text SecretKey
+jwkToSecret key = do
+    (_, msk) <- keypairFromKeyMaterial $ key ^. jwkMaterial
+    maybeToRight "JWK does not contain secret key" msk
+
+-- | Get a public key from given JWK
+jwkToPublic :: JWK -> Either Text PublicKey
+jwkToPublic = fmap fst . keypairFromKeyMaterial . (^. jwkMaterial)
+
+-- | Get a Ed25519 keypair from JWK, if possible
+keypairFromKeyMaterial :: KeyMaterial -> Either Text (PublicKey, Maybe SecretKey)
+keypairFromKeyMaterial = \case
+    (OKPKeyMaterial okpParams) -> case okpParams of
+        Ed25519Key pk msk -> Right (AbstractPK pk, AbstractSK <$> msk)
+        X25519Key _ _     -> unexpectedKeyType "X25519"
+    (ECKeyMaterial _)  -> unexpectedKeyType "EC"
+    (RSAKeyMaterial _) -> unexpectedKeyType "RSA"
+    (OctKeyMaterial _) -> unexpectedKeyType "symmetric"
+  where unexpectedKeyType keyType = Left ("Expected Ed25519 key, found " <> keyType <> " key")
+
+---------------------------------------------------------------------------
+-- JSON Web Signatures
+---------------------------------------------------------------------------
+
+-- | Datatype which represents a JWS with payload and corresponding
+-- public key included (in "jwk" field).
+newtype JWitness = JWitness { unJWitness :: CompactJWS JWSHeader }
+    deriving (Eq, Show, ToCompact)
+
+-- Cannot derive 'FromCompact' automatically for some GHC reasons.
+instance FromCompact JWitness where
+    fromCompact = fmap JWitness . fromCompact
+
+-- | Given a 'SecretKey' and a payload, create valid JWS
+-- which includes a public key.
+--
+-- Note: 'Crypto.JOSE.JWS.signJWS' require 'MonadError' and 'MonadRandom'
+-- constraints on runner monad. However, 'MonadRandom' instance is
+-- unnecessary for Ed25519 keys, and for those keys 'signJWS' throws an
+-- error only if secret key is missing from 'JWK'. As long as we create
+-- 'JWK' from 'SecretKey', guaranteeing that such error will not be thrown,
+-- this function is really not partial.
+signJWitness :: SecretKey -> ByteString -> JWitness
+signJWitness sk payload =
+    JWitness . errToPanic . runFakeRandom . runExceptT $
+    signJWS payload $ pure (hdr, key)
+  where
+    key = secretToJwk sk
+    hdr = jwsHeaderWithKey key
+
+-- | Given a JWS with public key included, verify that JWS
+-- against included public key and return public key and payload.
+verifyJWitness :: JWitness -> Either Text (PublicKey, ByteString)
+verifyJWitness witness = do
+    key <- getJWitnessKey witness
+    pk <- jwkToPublic key
+    payload <- first (show @Text @Error) $
+        verifyJWS' key (unJWitness witness)
+    return (pk, payload)
+
+-- | Creates a new JWS header which contains the correct
+-- "alg" field and also "jwk" field containing the public key.
+--
+-- This particular function assumes that best algorithm
+-- for given JWK exists, and panics otherwise. For Ed25519
+-- this always works (see source for 'Crypto.JOSE.JWK.bestJWSAlg')
+--
+-- It also only works only for asymmetric keys, for which
+-- a public key actually exists (obviously).
+--
+-- This function also creates only protected headers, because
+-- we use only them.
+jwsHeaderWithKey :: JWK -> JWSHeader ()
+jwsHeaderWithKey key =
+    newJWSHeader ((), alg) &
+    jwk .~ Just (HeaderParam () publicKey)
+  where
+    alg = errToPanic $ bestJWSAlg key
+    publicKey = nothingToPanic "jwsHeaderWithKey: symmetric key!" $
+        key ^. asPublicKey
+
+-- | Newtype which has not working 'MonadRandom' instance. Only for
+-- usage in 'signJWitness'.
+newtype FakeRandom a = FakeRandom { unFakeRandom :: Identity a }
+    deriving (Functor, Applicative, Monad)
+
+runFakeRandom :: FakeRandom a -> a
+runFakeRandom = runIdentity . unFakeRandom
+
+instance MonadRandom FakeRandom where
+    getRandomBytes _ = error "panic: FakeRandom is used!"
+
+-- | Given a JWS, fetch the JWK contained inside the "jwk"
+-- field, throw and error if there is none.
+getJWitnessKey :: JWitness -> Either Text JWK
+getJWitnessKey (JWitness jws) =
+    maybeToRight "No public key included into JWS" $
+    jws ^? signatures.header.jwk._Just.param
+
+-- | Helper function to panic on 'Error'
+errToPanic :: Either Error a -> a
+errToPanic = leftToPanic . first (show @String)

--- a/core/src/Dscp/Crypto/JWS.hs
+++ b/core/src/Dscp/Crypto/JWS.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveFunctor #-}
 
 module Dscp.Crypto.JWS
-       ( JWitness
+       ( JWitness (..)
        , secretToJwk
        , publicToJwk
        , jwkToSecret

--- a/core/src/Dscp/Crypto/Random.hs
+++ b/core/src/Dscp/Crypto/Random.hs
@@ -12,7 +12,7 @@ module Dscp.Crypto.Random
 import Crypto.Number.Basic (numBytes)
 import Crypto.Number.Serialize (os2ip)
 import Crypto.OpenSSL.Random (randBytes)
-import Crypto.Random (MonadRandom, getRandomBytes)
+import Crypto.Random.Types (MonadRandom, getRandomBytes)
 import qualified Data.ByteArray as ByteArray (convert)
 
 -- | Generate a cryptographically random 'ByteString' of specific length.

--- a/core/src/Dscp/Crypto/Signing/Class.hs
+++ b/core/src/Dscp/Crypto/Signing/Class.hs
@@ -13,7 +13,7 @@ module Dscp.Crypto.Signing.Class
        , MonadRandom
        ) where
 
-import Crypto.Random (MonadRandom)
+import Crypto.Random.Types (MonadRandom)
 import Data.ByteArray (ByteArray, ByteArrayAccess)
 import Fmt (build, (+|))
 import qualified Text.Show

--- a/core/src/Dscp/Crypto/Util.hs
+++ b/core/src/Dscp/Crypto/Util.hs
@@ -1,0 +1,18 @@
+-- | Small utility functions
+
+module Dscp.Crypto.Util
+       ( constTimeEq
+       ) where
+
+import qualified Crypto.Util as CU (constTimeEq)
+import Data.ByteArray (ByteArrayAccess, convert)
+
+-- | Checks two bytestrings for equality without breaches for
+-- timing attacks.
+--
+-- Adapts 'Crypto.Util.constTimeEq' for any 'ByteArrayAccess' instance.
+-- See <http://codahale.com/a-lesson-in-timing-attacks/> for more info.
+constTimeEq
+    :: (ByteArrayAccess b1, ByteArrayAccess b2)
+    => b1 -> b2 -> Bool
+constTimeEq b1 b2 = CU.constTimeEq (convert b1) (convert b2)

--- a/core/src/Dscp/Util/Test.hs
+++ b/core/src/Dscp/Util/Test.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PackageImports             #-}
 {-# LANGUAGE PartialTypeSignatures      #-}
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
@@ -16,7 +17,7 @@ module Dscp.Util.Test
 import Codec.Serialise (Serialise, deserialise, serialise)
 import Control.Exception.Safe (catchJust)
 import Control.Lens (LensLike')
-import Crypto.Random (ChaChaDRG, MonadPseudoRandom)
+import "cryptonite" Crypto.Random (ChaChaDRG, MonadPseudoRandom)
 import Data.Aeson (FromJSON, ToJSON, eitherDecode, encode)
 import qualified Data.Hashable as H
 import qualified Data.Text.Buildable

--- a/core/tests/Test/Dscp/Crypto/JWS.hs
+++ b/core/tests/Test/Dscp/Crypto/JWS.hs
@@ -1,9 +1,23 @@
 module Test.Dscp.Crypto.JWS where
 
-import Crypto.JOSE.JWK (asPublicKey)
+import Crypto.JOSE (Alg (EdDSA), CompactJWS, Error, HeaderParam (..), JWK, JWSHeader, asPublicKey,
+                    jwk, newJWSHeader, signJWS)
 
 import Dscp.Crypto
+import Dscp.Util
 import Dscp.Util.Test
+
+signBareWithHeader :: JWSHeader () -> SecretKey -> ByteString -> CompactJWS JWSHeader
+signBareWithHeader hd sk bs =
+    leftToPanic . first (show @String @Error) . withIntSeed 42 . runExceptT $
+    signJWS bs (pure $ (hd, secretToJwk sk))
+
+signBare :: SecretKey -> ByteString -> CompactJWS JWSHeader
+signBare = signBareWithHeader $ newJWSHeader ((), EdDSA)
+
+signBareWithKey :: JWK -> SecretKey -> ByteString -> CompactJWS JWSHeader
+signBareWithKey key = signBareWithHeader $
+    newJWSHeader ((), EdDSA) & jwk .~ Just (HeaderParam () key)
 
 spec_JWS :: Spec
 spec_JWS = describe "JSON Web Signatures with Disciplina keys" $ do
@@ -16,3 +30,11 @@ spec_JWS = describe "JSON Web Signatures with Disciplina keys" $ do
     it "roundtrips JWS extended with public keys" $ property $
         \(sk :: SecretKey, bs :: ByteString) ->
             verifyJWitness (signJWitness sk bs) === Right (toPublic sk, bs)
+    it "fails to verify if `jwk` is absent from the JWS header" $ property $
+        \(sk :: SecretKey, bs :: ByteString) ->
+            let badJws = JWitness $ signBare sk bs
+            in verifyJWitness @ByteString badJws === Left "No public key included into JWS"
+    it "fails to verify if included JWK doesn't match the signature" $ property $
+        \(sk :: SecretKey, bs :: ByteString, key :: JWK) ->
+            let badJws = JWitness $ signBareWithKey key sk bs
+            in isLeft $ verifyJWitness @ByteString badJws

--- a/core/tests/Test/Dscp/Crypto/JWS.hs
+++ b/core/tests/Test/Dscp/Crypto/JWS.hs
@@ -1,0 +1,18 @@
+module Test.Dscp.Crypto.JWS where
+
+import Crypto.JOSE.JWK (asPublicKey)
+
+import Dscp.Crypto
+import Dscp.Util.Test
+
+spec_JWS :: Spec
+spec_JWS = describe "JSON Web Signatures with Disciplina keys" $ do
+    it "have the diamond property: `publicToJwk  . toPublic === toPublic . skToJWK`" $ property $
+        \(sk :: SecretKey) -> Just (publicToJwk (toPublic sk)) === secretToJwk sk ^. asPublicKey
+    it "roundtrip secret keys" $ property $
+        \(sk :: SecretKey) -> Right sk === jwkToSecret (secretToJwk sk)
+    it "roundtrip public keys" $ property $
+        \(pk :: PublicKey) -> Right pk === jwkToPublic (publicToJwk pk)
+    it "roundtrips JWS extended with public keys" $ property $
+        \(sk :: SecretKey, bs :: ByteString) ->
+            verifyJWitness (signJWitness sk bs) === Right (toPublic sk, bs)

--- a/specs/disciplina/educator/api/educator.yaml
+++ b/specs/disciplina/educator/api/educator.yaml
@@ -758,20 +758,29 @@ securityDefinitions:
     name: Authorization
     in: header
     description: |
-      Authentication system requires a signed JWT in Authorization header in `Bearer <JWT>` format. Example header:
+      Authentication system requires a JWS in Authorization header in `Bearer <JWS>` format. Example header:
       ```
-      Authorization: Bearer eyJhbGciOiJFZERTQSJ9.eyJkYXQiOnsiYWRQYXRoIjoiL2FwaS9lZHVjYXRvci92MS9zdHVkZW50cyIsImFkVGltZSI6IjIwOTktMDgtMTBUMTM6MjY6NTkuNDYxOTk4MTM2WiJ9fQ.gU032BGkGwllzPtBLxsvXNZttI6qmEh4M2DGfdiIV6k2L_SuPNR8-YHGphQ2_bytOSKl4Hf8LKPt9g0wNjJbAQ
+      Authorization: Bearer eyJhbGciOiJFZERTQSIsImp3ayI6eyJjcnYiOiJFZDI1NTE5IiwieCI6InFlU3ZrUzZnaW9CcjRlX2I2em8zTWlPT1NYQW90VjkwdDVLajNsMjh5cm8iLCJrdHkiOiJPS1AifX0.eyJwYXRoIjoiL2FwaS9lZHVjYXRvci92MS9zdHVkZW50cyIsInRpbWUiOiIyMDI1LTAxLTAxVDAwOjAwOjAwWiJ9.0_sRvkXTaJTlnLHSjReH70VNFOLx0kdGHDmiDWhUr6H25UCvc5kPD6qn9pDlUwe0uKMpQCGIt_v4hnwWcfVlDA
       ```
-      The JWT should be signed by the educator's private key and contain one claim "dat". The claim should have an object inside with two fields "adPath" and "adTime'. "adPath" should contain the path to the endpoint as it is going to be in the raw request and "adTime" should have the current time in ISO-8601 format. Example JWT object:
+
+      JWS header MUST contain "jwk" parameter ([RFC7515, section 4.1.3](https://tools.ietf.org/html/rfc7515#section-4.1.3)) with a
+      public JWK corresponding to the signature. JWK MUST have key type "OKP" and curve type "Ed25519", public key parameter "x"
+      should be encoded via base64Url (accordingly to [RFC8037](https://tools.ietf.org/html/rfc8037)). Example JWK:
+      ```
+      { "kty": "OKP", "crv": "Ed25519", "x": "2qbm2mPrVVW_yFsHUMzNt3hLdalGLTN8ucI4e-Cn6fI" }
+      ```
+      This JWK represents a Disciplina public key of an Educator. The whole JWS should be created via the Educator's secret key.
+      JWS payload MUST be a JSON object with fields "path" and "time". Field "path" should contain the endpoint URL path and "time"
+      should contain the time the request has been made in [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) format. Example JWS
+      payload:
       ```
       {
-        "dat": {
-          "adTime": "2018-08-10T13:22:40.461998136Z",
-          "adPath": "/api/educator/v1/students"
-        }
+        "time": "2025-01-01T00:00:00.000000000Z",
+        "path": "/api/educator/v1/students"
       }
       ```
-      If the request's raw path doesn't match the one in "adPath" or "adTime" is more than 5 minutes behind the server current time the authentication process will fail.
+      If the request's raw path doesn't match the one in "path" or "time" is more than 5 minutes behind the server current time,
+      the authentication process will fail.
 
 responses:
   Unauthorized:

--- a/specs/disciplina/educator/api/student.yaml
+++ b/specs/disciplina/educator/api/student.yaml
@@ -243,20 +243,29 @@ securityDefinitions:
     name: Authorization
     in: header
     description: |
-      Authentication system requires a signed JWT in Authorization header in `Bearer <JWT>` format. Example header:
+      Authentication system requires a JWS in Authorization header in `Bearer <JWS>` format. Example header:
       ```
-      Authorization: Bearer eyJhbGciOiJFZERTQSJ9.eyJkYXQiOnsiYWRQYXRoIjoiL2FwaS9lZHVjYXRvci92MS9zdHVkZW50cyIsImFkVGltZSI6IjIwOTktMDgtMTBUMTM6MjY6NTkuNDYxOTk4MTM2WiJ9fQ.gU032BGkGwllzPtBLxsvXNZttI6qmEh4M2DGfdiIV6k2L_SuPNR8-YHGphQ2_bytOSKl4Hf8LKPt9g0wNjJbAQ
+      Authorization: Bearer eyJhbGciOiJFZERTQSIsImp3ayI6eyJjcnYiOiJFZDI1NTE5IiwieCI6InFlU3ZrUzZnaW9CcjRlX2I2em8zTWlPT1NYQW90VjkwdDVLajNsMjh5cm8iLCJrdHkiOiJPS1AifX0.eyJwYXRoIjoiL2FwaS9zdHVkZW50L3YxL2NvdXJzZXMiLCJ0aW1lIjoiMjAyNS0wMS0wMVQwMDowMDowMFoifQ.JYO_dINCZWhzHuER7377ETxf-Vg1Sw9eImc5cVxrFKFP9PlIXS9fGlzvrKsSpe8FbkAsYkU_cjBoBiaVx6KiDA
       ```
-      The JWT should be signed by the student's private key and contain one claim "dat". The claim should have an object inside with two fields "adPath" and "adTime'. "adPath" should contain the path to the endpoint as it is going to be in the raw request and "adTime" should have the current time in ISO-8601 format. Example JWT object:
+
+      JWS header MUST contain "jwk" parameter ([RFC7515, section 4.1.3](https://tools.ietf.org/html/rfc7515#section-4.1.3)) with a
+      public JWK corresponding to the signature. JWK MUST have key type "OKP" and curve type "Ed25519", public key parameter "x"
+      should be encoded via base64Url (accordingly to [RFC8037](https://tools.ietf.org/html/rfc8037)). Example JWK:
+      ```
+      { "kty": "OKP", "crv": "Ed25519", "x": "2qbm2mPrVVW_yFsHUMzNt3hLdalGLTN8ucI4e-Cn6fI" }
+      ```
+      This JWK represents a Disciplina public key of a Student querying the API. The whole JWS should be created via the Student's secret key.
+      JWS payload MUST be a JSON object with fields "path" and "time". Field "path" should contain the endpoint URL path and "time"
+      should contain the time the request has been made in [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) format. Example JWS
+      payload:
       ```
       {
-        "dat": {
-          "adTime": "2018-08-10T13:22:40.461998136Z",
-          "adPath": "/api/student/v1/courses"
-        }
+        "time": "2025-01-01T00:00:00.000000000Z",
+        "path": "/api/student/v1/courses"
       }
       ```
-      If the request's raw path doesn't match the one in "adPath" or "adTime" is more than 5 minutes behind the server current time the authentication process will fail.
+      If the request's raw path doesn't match the one in "path" or "time" is more than 5 minutes behind the server current time,
+      the authentication process will fail.
 
 responses:
   Unauthorized:


### PR DESCRIPTION
### Description

This PR changes the authentication scheme of Student API in the following way:
- JOSE header of JWS passed in the `Authorization` header now must include public JWK in `jwk` field (https://tools.ietf.org/html/rfc7515#section-4.1.3)
- This allows to determine the student which made the query without traversing some hardcoded set of allowed keys in `O(n)`.
- Which allows for actually checking if the student exists in the database (if the bot is disabled and we don't want to allow everybody to use our API).

PR is WIP, because docs are not updated and not all desired tests are implemented.

### YT issue

https://issues.serokell.io/DSCP-284
https://issues.serokell.io/DSCP-203

### Introduced changes

<!-- 
Check all that apply. At least one _should_ be checked, otherwise
describe that weird type of change in the description, maybe it will
make sense to add it to the list.
-->

- [x] New feature
- [ ] Bugfix 
- [x] Refactoring
- [ ] New tests (on functionality not fixed/introduced in this PR)
- [ ] New docs (on functionality not fixed/introduced in this PR)
- [ ] Infrastructure changes 

### Checklist

If I added new functionality, I
- [x] added tests covering it
- [x] explained it using haddock in the source code

If I fixed a bug, I
- [ ] added a regression test to prevent the bug from silently reappearing again

If I changed public API structure or/and data serialization, I made sure that
- [ ] those changes are reflected in [Swagger API specs](/specs/disciplina)
- [ ] and also in [related](/docs/api-types.md) [documentation](/docs/authentication.md).

If I changed config structure or/and CLI interface of any executable, I made sure that
- [ ] [sample config](/docs/config-full-sample.yaml) is updated accordingly
- [ ] [launch scripts](/scripts/launch) are updated accordingly and work as expected

If I changed the procedure of building a project and/or running any executable or helper script, I
- [ ] updated [README.md](/README.md) accordingly
- [ ] as well as subproject READMEs for all related executables

Also,
- [x] my commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP"
- [x] my code complies with the [style guide](/docs/code-style.md)
- [x] my documentation is checked with a spell checker (like [Grammarly](https://app.grammarly.com))
