### PR TITLE
Recommend `nix-env -f release.nix -iA disciplina-static` to frontend devs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -54,7 +54,7 @@ steps:
     - specs/result/*.pdf
     label: specs
 
-  - command: nix-build release.nix -A disciplina-static --no-out-link
+  - command: nix-build release.nix -A disciplina --no-out-link
     agents:
       system: x86_64-linux
     label: static

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ nix-env -f closure.nix -iA nix
 [NixOS/nix#2409]: https://github.com/NixOS/nix/pull/2409
 
 If you test Disciplina or develop software that integrates with it, run
-`nix-env -if .`. This will install Disciplina packages into your user profile.
-Then you can use `scripts/launch/node.sh` to start the nodes.
+`nix-env -f release.nix -iA disciplina`. This will install Disciplina packages
+into your user profile. Then you can use `scripts/launch/node.sh` to start nodes.
 
 For production builds, run `nix-build`.
 

--- a/release.nix
+++ b/release.nix
@@ -21,6 +21,15 @@ let
 in
 
 rec {
+  disciplina = symlinkJoin {
+    name = "disciplina";
+    paths = with project; map haskell.lib.justStaticExecutables [
+      disciplina-educator
+      disciplina-faucet
+      disciplina-witness
+    ];
+  };
+
   disciplina-config = runCommand "disciplina-config.yaml" {} "cp ${./config.yaml} $out";
 
   disciplina-haddock = with lib;
@@ -39,15 +48,6 @@ rec {
   disciplina-hlint = runCommand "hlint.html" {} ''
     ${hlint}/bin/hlint ${source} --no-exit-code --report=$out -j
   '';
-
-  disciplina-static = symlinkJoin {
-    name = "disciplina-static";
-    paths = with project; map haskell.lib.justStaticExecutables [
-      disciplina-educator
-      disciplina-faucet
-      disciplina-witness
-    ];
-  };
 
   disciplina-trailing-whitespace = runCheck ''
     for f in $(find ${source} -type f); do


### PR DESCRIPTION
### Description

Current recommendation is not as good as it requires downloading way more stuff from cache and causes path conflict when installed to user environment.

### YT issue

https://issues.serokell.io/OPS-538

### Introduced changes

<!-- 
Check all that apply. At least one _should_ be checked, otherwise
describe that weird type of change in the description, maybe it will
make sense to add it to the list.
-->

- [ ] New feature
- [ ] Bugfix 
- [ ] Refactoring
- [ ] New tests (on functionality not fixed/introduced in this PR)
- [ ] New docs (on functionality not fixed/introduced in this PR)
- [ ] Infrastructure changes 

### Checklist

If I added new functionality, I
- [ ] added tests covering it
- [ ] explained it using haddock in the source code

If I fixed a bug, I
- [ ] added a regression test to prevent the bug from silently reappearing again

If I changed public API structure or/and data serialization, I made sure that
- [ ] those changes are reflected in [Swagger API specs](/specs/disciplina)
- [ ] and also in [related](/docs/api-types.md) [documentation](/docs/authentication.md).

If I changed config structure or/and CLI interface of any executable, I made sure that
- [ ] [sample config](/docs/config-full-sample.yaml) is updated accordingly
- [ ] [launch scripts](/scripts/launch) are updated accordingly and work as expected

If I changed the procedure of building a project and/or running any executable or helper script, I
- [x] updated [README.md](/README.md) accordingly
- [ ] as well as subproject READMEs for all related executables

Also,
- [ ] my commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP"
- [ ] my code complies with the [style guide](/docs/code-style.md)
- [ ] my documentation is checked with a spell checker (like [Grammarly](https://app.grammarly.com))
