### PR TITLE
[DSCP-269] Add missing fees validation check

### DIFF
--- a/witness/src/Dscp/Snowdrop/AccountValidation.hs
+++ b/witness/src/Dscp/Snowdrop/AccountValidation.hs
@@ -131,7 +131,8 @@ preValidateSimpleMoneyTransfer =
         let balanceBefore = aBalance before
         -- Total amount of coins sent (sum of real tx outputs + a fee output)
         let receivedTotal = sum allOutputs
-        -- Previous value minus fees (the outputs that were specified in the tx itself)
+        -- Previous value minus fees (the outputs that were specified in the
+        -- tx itself + innacuracy in fee calcuation comparing to minimal fees)
         let receivedNoFees = receivedTotal - coinToInteger (unFees fees)
 
         paid <- validateSaneDeparture payer before

--- a/witness/src/Dscp/Snowdrop/Configuration.hs
+++ b/witness/src/Dscp/Snowdrop/Configuration.hs
@@ -38,6 +38,7 @@ module Dscp.Snowdrop.Configuration
     , AccountExpanderException (..)
     , _MTxNoOutputs
     , _CantResolveSender
+    , _InsufficientFees
     , PublicationExpanderException (..)
 
     , TxIds (..)
@@ -269,10 +270,14 @@ data Proofs
 -- Exceptions
 ----------------------------------------------------------------------------
 
+-- TODO [DSCP-256]: Since expansion and validatoin are always couples,
+-- merge 'AccountExpanderException' and 'AccountValidationException'
+-- TODO [DSCP-256]: Add fieldsPublicationExpanderError
 data AccountExpanderException
     = MTxNoOutputs
     | MTxDuplicateOutputs
     | CantResolveSender
+    | InsufficientFees
     | ExpanderInternalError String
 
 makePrisms ''AccountExpanderException
@@ -285,6 +290,7 @@ instance Buildable AccountExpanderException where
         MTxNoOutputs -> "Transaction has no outputs"
         MTxDuplicateOutputs -> "Duplicated transaction outputs"
         CantResolveSender -> "Source account is not registered in chain"
+        InsufficientFees -> "Amount of money left for fees in transaction is not enough"
         ExpanderInternalError s ->
             fromString $ "Expander failed internally: " <> s
 


### PR DESCRIPTION
### Description

Check that transaction has enough money remaining for fees.
Tested with wallet:

- [x] Can send transaction if little money is sent
- [x] Cannot send transaction if more money is sent than the user has
- [x] Cannot send transaction if a bit less money is sent than the user has

### YT issue

https://issues.serokell.io/DSCP-269

### Introduced changes

<!-- 
Check all that apply. At least one _should_ be checked, otherwise
describe that weird type of change in the description, maybe it will
make sense to add it to the list.
-->

- [ ] New feature
- [x] Bugfix 
- [ ] Refactoring
- [ ] New tests (on functionality not fixed/introduced in this PR)
- [ ] New docs (on functionality not fixed/introduced in this PR)
- [ ] Infrastructure changes 

### Checklist

If I added new functionality, I
- [ ] added tests covering it
- [ ] explained it using haddock in the source code

If I fixed a bug, I
- [x] added a regression test to prevent the bug from silently reappearing again

If I changed public API structure or/and data serialization, I made sure that
- [ ] those changes are reflected in [Swagger API specs](/specs/disciplina)
- [ ] and also in [related](/docs/api-types.md) [documentation](/docs/authentication.md).

If I changed config structure or/and CLI interface of any executable, I made sure that
- [ ] [sample config](/docs/config-full-sample.yaml) is updated accordingly
- [ ] [launch scripts](/scripts/launch) are updated accordingly and work as expected

If I changed the procedure of building a project and/or running any executable or helper script, I
- [ ] updated [README.md](/README.md) accordingly
- [ ] as well as subproject READMEs for all related executables

Also,
- [ ] my commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP"
- [ ] my code complies with the [style guide](/docs/code-style.md)
- [ ] my documentation is checked with a spell checker (like [Grammarly](https://app.grammarly.com))
