### PR TITLE
[DSCP-274] Fix keygen

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -94,7 +94,7 @@ cat /dev/urandom | head -c 32 | dscp-keygen --seed --command secret
 * Generate key file with password:
 
 ```bash
-echo 1000 | dscp-keygen --seed --command secret > secret.key
+echo 1000 | dscp-keygen --seed --command keyfile:password > secret.key
 chmod 660 secret.key
 ```
 

--- a/tools/package.yaml
+++ b/tools/package.yaml
@@ -41,3 +41,4 @@ executables:
       - optparse-applicative
       - serialise
       - text
+      - word8

--- a/tools/src/keygen/Main.hs
+++ b/tools/src/keygen/Main.hs
@@ -1,5 +1,6 @@
 import qualified Data.ByteString as BS
 
+import Data.Word8 (isSpace)
 import Options.Applicative (execParser, fullDesc, helper, info, progDesc)
 
 import Dscp.CommonCLI
@@ -12,7 +13,8 @@ main :: IO ()
 main = do
     KeygenConfig inputType command <- getKeygenConfig
 
-    input <- BS.getContents
+    rawInput <- BS.getContents
+    let (input, _) = BS.spanEnd isSpace rawInput
     let !secret = parseInputWithSecret inputType input
                ?: error "Cannot parse input"
 


### PR DESCRIPTION
### Description

The main mistake which was present - when one does `echo "something"` the newline
symbol is automatically inserted, and it cannot be parsed by e.g. `fromBase64`
obviously.

There was another mistake - I selected a bytestring parsing way (raw/hex/base64)
just depending on whether it was parsed successfully, disregard whether
we can later convert it to the required data.

Tested everything this time.

### YT issue

https://issues.serokell.io/DSCP-274

### Introduced changes

<!-- 
Check all that apply. At least one _should_ be checked, otherwise
describe that weird type of change in the description, maybe it will
make sense to add it to the list.
-->

- [ ] New feature
- [x] Bugfix 
- [ ] Refactoring
- [ ] New tests (on functionality not fixed/introduced in this PR)
- [ ] New docs (on functionality not fixed/introduced in this PR)
- [ ] Infrastructure changes 

### Checklist

If I added new functionality, I
- [ ] added tests covering it
- [ ] explained it using haddock in the source code

If I fixed a bug, I
- [ ] added a regression test to prevent the bug from silently reappearing again

If I changed public API structure or/and data serialization, I made sure that
- [ ] those changes are reflected in [Swagger API specs](/specs/disciplina)
- [ ] and also in [related](/docs/api-types.md) [documentation](/docs/authentication.md).

If I changed config structure or/and CLI interface of any executable, I made sure that
- [ ] [sample config](/docs/config-full-sample.yaml) is updated accordingly
- [ ] [launch scripts](/scripts/launch) are updated accordingly and work as expected

If I changed the procedure of building a project and/or running any executable or helper script, I
- [ ] updated [README.md](/README.md) accordingly
- [x] as well as subproject READMEs for all related executables

Also,
- [x] my commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP"
- [x] my code complies with the [style guide](/docs/code-style.md)
- [x] my documentation is checked with a spell checker (like [Grammarly](https://app.grammarly.com))
