### PR TITLE
[DSCP-290] Generate less data in educator tests.

### DIFF
--- a/core/src/Dscp/Util/Test.hs
+++ b/core/src/Dscp/Util/Test.hs
@@ -176,6 +176,10 @@ expectOne desc xs  =
 counterexample :: Testable prop => Text -> prop -> Property
 counterexample desc prop = Q.counterexample (toString desc) prop
 
+-- | Generate smaller amounts of data.
+pickSmall :: (Monad m, Show a) => Gen a -> PropertyM m a
+pickSmall = pick . Q.resize 5
+
 ----------------------------------------------------------------------------
 -- Logging
 ----------------------------------------------------------------------------

--- a/educator/tests/Test/Dscp/Educator/Bot/Endpoints.hs
+++ b/educator/tests/Test/Dscp/Educator/Bot/Endpoints.hs
@@ -42,9 +42,10 @@ spec_StudentApiWithBotQueries = describe "Basic properties" $ do
     it "Submissions are graded automatically" $
         educatorPropertyM $ do
             seed <- pick arbitrary
-            env <- pick $ genCoreTestEnv simpleCoreTestParams
-                          { ctpSecretKey = oneTestItem (pure studentSK)
-                          , ctpAssignment = oneTestItem (pure assignmentEx) }
+            env <- pickSmall $
+                    genCoreTestEnv simpleCoreTestParams
+                    { ctpSecretKey = oneTestItem (pure studentSK)
+                    , ctpAssignment = oneTestItem (pure assignmentEx) }
             let sigsub = tiOne $ cteSignedSubmissions env
             submissions <- lift $ do
                 StudentApiEndpoints{..} <- testMakeBotHandlers seed

--- a/educator/tests/Test/Dscp/Educator/Web/Educator/Queries.hs
+++ b/educator/tests/Test/Dscp/Educator/Web/Educator/Queries.hs
@@ -26,7 +26,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
   describe "Students" $ do
     describe "getStudents" $ do
         it "Returns previously added students" $ sqlitePropertyM $ do
-            students <- pick listUnique
+            students <- pickSmall listUnique
             lift $ forM_ students createStudent
 
             students' <- lift $ educatorGetStudents Nothing
@@ -50,7 +50,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
   describe "Courses" $ do
     describe "getCourses" $ do
         it "Returns previously added courses" $ sqlitePropertyM $ do
-            coursesDetails <- nubBy ((==) `on` cdCourseId) <$> pick arbitrary
+            coursesDetails <- nubBy ((==) `on` cdCourseId) <$> pickSmall arbitrary
             lift $ forM_ coursesDetails createCourse
 
             courses' <- lift $ educatorGetCourses Nothing
@@ -85,7 +85,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
         -- so just checking it at least works.
 
         it "Returns existing assignment properly" $ sqlitePropertyM $ do
-            env <- pick $ genCoreTestEnv simpleCoreTestParams
+            env <- pickSmall $ genCoreTestEnv simpleCoreTestParams
             let assignment = tiOne $ cteAssignments env
             let student = tiOne $ cteStudents env
 
@@ -107,7 +107,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
   describe "Submissions" $ do
     describe "getSubmission" $ do
         it "Fails on request of non-existent submission" $ sqlitePropertyM $ do
-            env <- pick $ genCoreTestEnv simpleCoreTestParams
+            env <- pickSmall $ genCoreTestEnv simpleCoreTestParams
             let submission = tiOne $ cteSubmissions env
             let student = _sStudentId submission
 
@@ -117,7 +117,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
                 educatorGetSubmission (getId submission)
 
         it "Returns existing submission properly" $ sqlitePropertyM $ do
-            env <- pick $ genCoreTestEnv simpleCoreTestParams
+            env <- pickSmall $ genCoreTestEnv simpleCoreTestParams
             let assignment = tiOne $ cteAssignments env
                 submission = tiOne $ cteSubmissions env
                 signedSubmission = tiOne $ cteSignedSubmissions env
@@ -135,7 +135,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
 
     describe "getSubmissions" $ do
         it "Student has no last submissions initially" $ sqlitePropertyM $ do
-            env <- pick $ genCoreTestEnv simpleCoreTestParams
+            env <- pickSmall $ genCoreTestEnv simpleCoreTestParams
             lift $ prepareForAssignments env
             -- even after this ^ there should be no submissions
 
@@ -144,7 +144,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
 
         it "Returns existing submission properly" $
           sqlitePropertyM $ do
-            env <- pick $ genCoreTestEnv wildCoreTestParams
+            env <- pickSmall $ genCoreTestEnv wildCoreTestParams
             let submission = tiOne $ cteSubmissions env
                 signedSubmission = tiOne $ cteSignedSubmissions env
 
@@ -160,7 +160,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
                 }
 
         it "Returns grade when present" $ sqlitePropertyM $ do
-            env <- pick $ genCoreTestEnv simpleCoreTestParams
+            env <- pickSmall $ genCoreTestEnv simpleCoreTestParams
             let txs     = tiList $ ctePrivateTxs env
                 sigSubs = tiList $ cteSignedSubmissions env
 
@@ -183,7 +183,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
                 sortOn fst submissionsAndGrades'
 
         it "Filtering works" $ sqlitePropertyM $ do
-            env <- pick $ genCoreTestEnv simpleCoreTestParams
+            env <- pickSmall $ genCoreTestEnv simpleCoreTestParams
                                          { ctpAssignment = variousItems }
             courseIdF <- pick arbitrary
             assignHF <- pick arbitrary
@@ -219,7 +219,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
   describe "Proofs" $ do
     describe "getProofs" $ do
         it "No proofs initially" $ sqlitePropertyM $ do
-            env <- pick $ genCoreTestEnv simpleCoreTestParams
+            env <- pickSmall $ genCoreTestEnv simpleCoreTestParams
             let student = tiOne $ cteStudents env
             lift $ prepareAndCreateSubmissions env
 
@@ -228,7 +228,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
             return $ proofs === []
 
         it "Returns existing proof properly" $ sqlitePropertyM $ do
-            env <- pick $ genCoreTestEnv simpleCoreTestParams
+            env <- pickSmall $ genCoreTestEnv simpleCoreTestParams
             let student = tiOne $ cteStudents env
                 ptx = tiOne $ ctePrivateTxs env
 
@@ -243,7 +243,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
             return $ bpiTxs proof === [ptx]
 
         it "Proofs are grouped properly" $ sqlitePropertyM $ do
-            env <- pick $ genCoreTestEnv simpleCoreTestParams
+            env <- pickSmall $ genCoreTestEnv simpleCoreTestParams
             let student = tiOne $ cteStudents env
                 ptxs = tiList $ ctePrivateTxs env
 

--- a/educator/tests/Test/Dscp/Educator/Web/Student/Queries.hs
+++ b/educator/tests/Test/Dscp/Educator/Web/Student/Queries.hs
@@ -406,7 +406,7 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
 
         it "Cannot see the last submission of other students" $
             sqlitePropertyM $ do
-                env <- pick $ genCoreTestEnv wildCoreTestParams
+                env <- pickSmall $ genCoreTestEnv wildCoreTestParams
                 let student = tiOne $ cteStudents env
                     submissions = tiList $ cteSubmissions env
 
@@ -432,7 +432,7 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
 
         it "Fails when student is not submission owner" $
             sqlitePropertyM $ do
-                env <- pick $ genCoreTestEnv simpleCoreTestParams
+                env <- pickSmall $ genCoreTestEnv simpleCoreTestParams
                 user <- pick arbitrary
 
                 let owner = tiOne $ cteStudents env
@@ -458,7 +458,7 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
     describe "getSubmissions" $ do
         it "Returns existing submission properly and only related to student" $
             sqlitePropertyM $ do
-                env <- pick $ genCoreTestEnv wildCoreTestParams
+                env <- pickSmall $ genCoreTestEnv wildCoreTestParams
                 let sigSubs = tiList $ cteSignedSubmissions env
                 pre (length sigSubs >= 2)
                 let submissions@(someSubmission : _) = map _ssSubmission sigSubs

--- a/witness/tests/Test/Dscp/Witness/Block/BlockSpec.hs
+++ b/witness/tests/Test/Dscp/Witness/Block/BlockSpec.hs
@@ -3,7 +3,6 @@ module Test.Dscp.Witness.Block.BlockSpec where
 import Control.Lens (ix, to)
 import qualified Data.List as L
 import qualified GHC.Exts as Exts
-import Test.QuickCheck.Modifiers (getPositive)
 import Test.QuickCheck.Monadic (pre)
 
 import Dscp.Core
@@ -88,12 +87,12 @@ spec = describe "Block validation + application" $ do
         lift . noThrow $ mapM_ submitBlock blocks
 
     it "Several good blocks are is fine" $ witnessProperty $ do
-        n <- pick $ getPositive <$> arbitrary
+        n <- pick $ choose (1, 5)
         let blocks = makeBlocksChain n
         lift . noThrow $ mapM_ submitBlock blocks
 
     it "Wrong previous block hash is not fine" $ witnessProperty $ do
-        n <- pick $ getPositive <$> arbitrary
+        n <- pick $ choose (1, 5)
         let blocks = makeBlocksChain n
         let spoilBlock block = do
                 badPrevHash <- arbitrary
@@ -111,7 +110,7 @@ spec = describe "Block validation + application" $ do
     it "Wrong difficulty is fatal" $ witnessProperty $ do
         _ <- stop $ pendingWith "To be resolved in [DSCP-261]"
 
-        n <- pick $ getPositive <$> arbitrary
+        n <- pick $ choose (1, 5)
         let blocks = makeBlocksChain n
         let spoilBlock block = do
                 badDiff <- arbitrary
@@ -123,7 +122,7 @@ spec = describe "Block validation + application" $ do
         _ <- stop $ pendingWith "To be resolved in [DSCP-261]"
 
         issuer <- lift $ getSecretKey @WitnessNode
-        n <- pick $ (+1) . getPositive <$> arbitrary
+        n <- pick $ choose (2, 5)
         -- going to modify block before the last one with too high slotId
         let issuerAddr = mkAddr $ toPublic issuer
             blocks = makeBlocksChain n

--- a/witness/tests/Test/Dscp/Witness/Tx/FeeSpec.hs
+++ b/witness/tests/Test/Dscp/Witness/Tx/FeeSpec.hs
@@ -1,4 +1,4 @@
-module Test.Dscp.Witness.FeeSpec where
+module Test.Dscp.Witness.Tx.FeeSpec where
 
 import Dscp.Core
 import Dscp.Crypto


### PR DESCRIPTION
### Description

Decreases educators tests passing time by 2x-3x

### YT issue

https://issues.serokell.io/DSCP-290

### Introduced changes

<!--
Check all that apply. At least one _should_ be checked, otherwise
describe that weird type of change in the description, maybe it will
make sense to add it to the list.
-->

- [ ] New feature
- [ ] Bugfix
- [x] Refactoring
- [ ] New tests (on functionality not fixed/introduced in this PR)
- [ ] New docs (on functionality not fixed/introduced in this PR)
- [ ] Infrastructure changes

### Checklist

If I added new functionality, I
- [ ] added tests covering it
- [ ] explained it using haddock in the source code

If I fixed a bug, I
- [ ] added a regression test to prevent the bug from silently reappearing again

If I changed public API structure or/and data serialization, I made sure that
- [ ] those changes are reflected in [Swagger API specs](/specs/disciplina)
- [ ] and also in [related](/docs/api-types.md) [documentation](/docs/authentication.md).

If I changed config structure or/and CLI interface of any executable, I made sure that
- [ ] [sample config](/docs/config-full-sample.yaml) is updated accordingly
- [ ] [launch scripts](/scripts/launch) are updated accordingly and work as expected

If I changed the procedure of building a project and/or running any executable or helper script, I
- [ ] updated [README.md](/README.md) accordingly
- [ ] as well as subproject READMEs for all related executables

Also,
- [x] my commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP"
- [x] my code complies with the [style guide](/docs/code-style.md)
- [ ] my documentation is checked with a spell checker (like [Grammarly](https://app.grammarly.com))
