### PR TITLE
[DSCP-222] Enable logging in educator APIs

### DIFF
--- a/core/src/Dscp/Core/Foundation/Educator.hs
+++ b/core/src/Dscp/Core/Foundation/Educator.hs
@@ -80,7 +80,7 @@ module Dscp.Core.Foundation.Educator
 
 import Control.Lens (Getter, makeLenses, to)
 import Data.Time.Clock (UTCTime)
-import Fmt (build, mapF, (+|), (|+))
+import Fmt (build, mapF, (+|), (|+), genericF)
 
 import Dscp.Core.Foundation.Address (Address (..))
 import Dscp.Crypto
@@ -110,6 +110,9 @@ newtype Grade = UnsafeGrade
 instance Bounded Grade where
     minBound = UnsafeGrade 0
     maxBound = UnsafeGrade 100
+
+instance Buildable Grade where
+    build = build . getGrade
 
 mkGrade :: Word8 -> Maybe Grade
 mkGrade a =
@@ -237,6 +240,14 @@ newtype ATGDelta = ATGDelta
 instance Buildable ATGDelta where
     build (ATGDelta d) = "ATGDelta { " +| mapF d |+ " }"
 
+instance Buildable Course where
+    build Course{..} = build getCourseId
+
+instance Buildable () where
+    build _ = ""
+
+instance Buildable DocumentType where
+    build = genericF
 ----------------------------------------------------------------------------
 -- Transactions
 ----------------------------------------------------------------------------

--- a/educator/src/Dscp/Educator/Web/Auth.hs
+++ b/educator/src/Dscp/Educator/Web/Auth.hs
@@ -34,6 +34,7 @@ import Servant.Server.Internal.RoutingApplication (DelayedIO, addAuthCheck, dela
                                                    withRequest)
 
 import Dscp.Crypto
+import Dscp.Util.Servant (ApiHasArgClass (..), ApiCanLogArg (..))
 
 ---------------------------------------------------------------------------
 -- Data types
@@ -73,6 +74,11 @@ instance ( HasServer api ctxs
             case authRes of
                 (Authenticated (r :: res)) -> return r
                 _ -> delayedFailFatal $ err401 { errHeaders = [("WWW-Authenticate", authMsg)] }
+
+instance ApiHasArgClass (Auth' auths res) where
+    apiArgName = const "Authenticate"
+
+instance ApiCanLogArg (Auth' auths res)
 
 ---------------------------------------------------------------------------
 -- Helpers

--- a/educator/src/Dscp/Educator/Web/Educator/Types.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Types.hs
@@ -27,10 +27,12 @@ module Dscp.Educator.Web.Educator.Types
 import Control.Lens (from)
 import Data.Aeson.Options (defaultOptions)
 import Data.Aeson.TH (deriveJSON)
+import Fmt (build, (+|), (|+), listF)
 
 import Dscp.Core
 import Dscp.Crypto
 import Dscp.Educator.Web.Types
+import Dscp.Util.Servant (ForResponseLog (..))
 
 data NewStudent = NewStudent
     { nsAddr :: Student
@@ -129,6 +131,71 @@ requestToAssignment NewAssignment{..} =
     , _aType = naIsFinal ^. from assignmentTypeRaw
     , _aDesc = naDesc
     }
+
+---------------------------------------------------------------------------
+-- Buildable instances
+---------------------------------------------------------------------------
+
+instance Buildable (NewCourse) where
+    build (NewCourse{..}) =
+      "{ course id = " +| ncId |+
+      ", description = " +| ncDesc |+
+      ", subjects = " +| fmap listF ncSubjects |+
+      " }"
+
+instance Buildable (NewGrade) where
+    build (NewGrade{..}) =
+      "{ submission hash = " +| ngSubmissionHash |+
+      ", grade = " +| ngGrade |+
+      " }"
+
+instance Buildable (NewAssignment) where
+    build (NewAssignment{..}) =
+      "{ course id = " +| naCourseId |+
+      ", is final = " +| naIsFinal |+
+      ", description = " +| naDesc |+
+      " }"
+
+instance Buildable (EnrollStudentToCourse) where
+    build (EnrollStudentToCourse{..}) =
+      "{ course id = " +| escCourseId |+
+      " }"
+
+instance Buildable (CourseEducatorInfo) where
+    build (CourseEducatorInfo{..}) =
+      "{ course id = " +| ciId |+
+      ", description = " +| ciDesc |+
+      ", subjects = " +| listF ciSubjects |+
+      " }"
+
+instance Buildable (AssignmentEducatorInfo) where
+    build (AssignmentEducatorInfo{..}) =
+      "{ hash = " +| aiHash |+
+      ", course id = " +| aiCourseId |+
+      ", description = " +| aiDesc |+
+      " }"
+
+instance Buildable (SubmissionEducatorInfo) where
+    build (SubmissionEducatorInfo{..}) =
+      "{ hash = " +| siHash |+
+      ", content hash = " +| siContentsHash |+
+      ", assignment hash = " +| siAssignmentHash |+
+      " }"
+
+instance Buildable (ForResponseLog CourseEducatorInfo) where
+    build (ForResponseLog CourseEducatorInfo{..}) =
+      "{ course id = " +| ciId |+
+      " }"
+
+instance Buildable (ForResponseLog AssignmentEducatorInfo) where
+    build (ForResponseLog AssignmentEducatorInfo{..}) =
+      "{ hash = " +| aiHash |+
+      " }"
+
+instance Buildable (ForResponseLog SubmissionEducatorInfo) where
+    build (ForResponseLog SubmissionEducatorInfo{..})=
+      "{ hash = " +| siHash |+
+      " }"
 
 ---------------------------------------------------------------------------
 -- JSON instances

--- a/educator/src/Dscp/Educator/Web/Educator/Types.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Types.hs
@@ -32,7 +32,7 @@ import Fmt (build, (+|), (|+), listF)
 import Dscp.Core
 import Dscp.Crypto
 import Dscp.Educator.Web.Types
-import Dscp.Util.Servant (ForResponseLog (..))
+import Dscp.Util.Servant (ForResponseLog (..), buildShortResponseList, buildLongResponseList)
 
 data NewStudent = NewStudent
     { nsAddr :: Student
@@ -136,11 +136,16 @@ requestToAssignment NewAssignment{..} =
 -- Buildable instances
 ---------------------------------------------------------------------------
 
+instance Buildable (NewStudent) where
+    build (NewStudent{..}) =
+      "{ address = " +| nsAddr |+
+      " }"
+
 instance Buildable (NewCourse) where
     build (NewCourse{..}) =
       "{ course id = " +| ncId |+
       ", description = " +| ncDesc |+
-      ", subjects = " +| fmap listF ncSubjects |+
+      ", subjects = " +| listF ncSubjects |+
       " }"
 
 instance Buildable (NewGrade) where
@@ -159,6 +164,11 @@ instance Buildable (NewAssignment) where
 instance Buildable (EnrollStudentToCourse) where
     build (EnrollStudentToCourse{..}) =
       "{ course id = " +| escCourseId |+
+      " }"
+
+instance Buildable AssignToStudent where
+    build (AssignToStudent{..}) =
+      "{ hash = " +| atsAssignmentHash |+
       " }"
 
 instance Buildable (CourseEducatorInfo) where
@@ -196,6 +206,15 @@ instance Buildable (ForResponseLog SubmissionEducatorInfo) where
     build (ForResponseLog SubmissionEducatorInfo{..})=
       "{ hash = " +| siHash |+
       " }"
+
+instance Buildable (ForResponseLog [CourseEducatorInfo]) where
+    build = buildLongResponseList
+
+instance Buildable (ForResponseLog [AssignmentEducatorInfo]) where
+    build = buildShortResponseList
+
+instance Buildable (ForResponseLog [SubmissionEducatorInfo]) where
+    build = buildShortResponseList
 
 ---------------------------------------------------------------------------
 -- JSON instances

--- a/educator/src/Dscp/Educator/Web/Student/Types.hs
+++ b/educator/src/Dscp/Educator/Web/Student/Types.hs
@@ -26,11 +26,13 @@ module Dscp.Educator.Web.Student.Types
 import Data.Aeson.Options (defaultOptions)
 import Data.Aeson.TH (deriveJSON)
 import Servant (FromHttpApiData)
+import Fmt (build, (+|), (|+), blockListF)
 
 import Dscp.Core
 import Dscp.Crypto
 import Dscp.Educator.Web.Types
 import Dscp.Util
+import Dscp.Util.Servant (ForResponseLog (..))
 
 -- | Whether student is enrolled into a course.
 newtype IsEnrolled = IsEnrolled { unIsEnrolled :: Bool }
@@ -113,6 +115,59 @@ signedSubmissionToRequest sigSub =
         , nsContentsHash = _sContentsHash submission
         , nsWitness = _ssWitness sigSub
         }
+
+---------------------------------------------------------------------------
+-- Buildable instances
+---------------------------------------------------------------------------
+
+instance Buildable (IsEnrolled) where
+    build (IsEnrolled{..}) =
+      "{ is enrolled = " +| unIsEnrolled |+
+      " }"
+
+instance Buildable (NewSubmission) where
+    build (NewSubmission{..}) =
+      "{ assignment hash = " +| nsAssignmentHash |+
+      ", content hash = " +| nsContentsHash |+
+      " }"
+
+instance Buildable (CourseStudentInfo) where
+    build (CourseStudentInfo{..}) =
+      "{ course id = " +| ciId |+
+      ", description = " +| ciDesc |+
+      ", subjects = " +| blockListF ciSubjects |+
+      ", is enrolled =" +| ciIsEnrolled |+
+      ", is finished =" +|ciIsFinished |+
+      " }"
+
+instance Buildable (AssignmentStudentInfo) where
+    build (AssignmentStudentInfo{..}) =
+      "{ course id = " +| aiCourseId |+
+      ", assignment hash = " +| aiHash |+
+      ", description = " +| aiDesc |+
+      " }"
+
+instance Buildable (SubmissionStudentInfo) where
+    build (SubmissionStudentInfo{..}) =
+      "{ submission hash = " +| siHash |+
+      ", content hash = " +| siContentsHash |+
+      ", assignment hash = " +| siAssignmentHash |+
+      " }"
+
+instance Buildable (ForResponseLog CourseStudentInfo) where
+    build (ForResponseLog CourseStudentInfo{..}) =
+      "{ course id = " +| ciId |+
+      " }"
+
+instance Buildable (ForResponseLog AssignmentStudentInfo) where
+    build (ForResponseLog AssignmentStudentInfo{..}) =
+      "{ hash = " +| aiHash |+
+      " }"
+
+instance Buildable (ForResponseLog SubmissionStudentInfo) where
+    build (ForResponseLog SubmissionStudentInfo{..}) =
+      "{ hash = " +| siHash |+
+      " }"
 
 ---------------------------------------------------------------------------
 -- JSON instances

--- a/educator/src/Dscp/Educator/Web/Student/Types.hs
+++ b/educator/src/Dscp/Educator/Web/Student/Types.hs
@@ -32,7 +32,7 @@ import Dscp.Core
 import Dscp.Crypto
 import Dscp.Educator.Web.Types
 import Dscp.Util
-import Dscp.Util.Servant (ForResponseLog (..))
+import Dscp.Util.Servant (ForResponseLog (..), buildShortResponseList)
 
 -- | Whether student is enrolled into a course.
 newtype IsEnrolled = IsEnrolled { unIsEnrolled :: Bool }
@@ -168,6 +168,15 @@ instance Buildable (ForResponseLog SubmissionStudentInfo) where
     build (ForResponseLog SubmissionStudentInfo{..}) =
       "{ hash = " +| siHash |+
       " }"
+
+instance Buildable (ForResponseLog [CourseStudentInfo]) where
+    build = buildShortResponseList
+
+instance Buildable (ForResponseLog [AssignmentStudentInfo]) where
+    build = buildShortResponseList
+
+instance Buildable (ForResponseLog [SubmissionStudentInfo]) where
+    build = buildShortResponseList
 
 ---------------------------------------------------------------------------
 -- JSON instances

--- a/educator/src/Dscp/Educator/Web/Types.hs
+++ b/educator/src/Dscp/Educator/Web/Types.hs
@@ -39,6 +39,7 @@ import Data.Singletons.Bool (SBoolI)
 import UnliftIO (MonadUnliftIO)
 import Loot.Log (MonadLogging)
 import Loot.Base.HasLens (HasCtx)
+import Fmt (build, (+|), (|+), (+||), (||+))
 
 import Dscp.DB.SQLite.Types
 import Dscp.Util.Type (type (==))
@@ -46,6 +47,7 @@ import Dscp.Core
 import Dscp.Crypto
 import Dscp.DB.SQLite.Instances ()
 import Dscp.Util.Aeson (CustomEncoding, HexEncoded)
+import Dscp.Util.Servant (ForResponseLog (..), buildForResponse)
 
 type MonadEducatorWebQuery m =
     ( MonadIO m
@@ -112,6 +114,50 @@ data BlkProofInfo = BlkProofInfo
     { bpiMtreeSerialized :: (CustomEncoding HexEncoded (MerkleProof PrivateTx))
     , bpiTxs             :: [PrivateTx]
     } deriving (Show, Eq, Generic)
+
+---------------------------------------------------------------------------
+-- Buildable instances
+---------------------------------------------------------------------------
+
+instance Buildable (IsFinal) where
+    build (IsFinal{..}) =
+      "{ is final = " +| unIsFinal |+
+      " }"
+
+instance Buildable (StudentInfo) where
+    build (StudentInfo{..}) =
+      "{ address = " +| siAddr |+
+      " }"
+
+instance Buildable (GradeInfo) where
+    build (GradeInfo{..}) =
+      "{ submission hash = " +| giSubmissionHash |+
+      ", grade = " +| giGrade |+
+      ", timestamp = " +| giTimestamp |+
+      ", has proof = " +| giHasProof |+
+      " }"
+
+instance Buildable (BlkProofInfo) where
+    build (BlkProofInfo{..}) =
+      "{ tree root hash = " +||
+          fmap getMerkleProofRoot bpiMtreeSerialized ||+
+      ", transactons num = " +| length bpiTxs |+
+      "} "
+
+instance Buildable (ForResponseLog StudentInfo) where
+    build = buildForResponse
+
+instance Buildable (ForResponseLog GradeInfo) where
+    build (ForResponseLog GradeInfo{..}) =
+      "{ submission hash = " +| giSubmissionHash |+
+      ", grade = " +| giGrade |+
+      " }"
+
+instance Buildable (ForResponseLog BlkProofInfo) where
+    build (ForResponseLog BlkProofInfo{..}) =
+      "{ tree root hash = " +||
+          fmap getMerkleProofRoot bpiMtreeSerialized ||+
+      "} "
 
 ---------------------------------------------------------------------------
 -- Simple conversions

--- a/educator/src/Dscp/Educator/Web/Types.hs
+++ b/educator/src/Dscp/Educator/Web/Types.hs
@@ -47,7 +47,8 @@ import Dscp.Core
 import Dscp.Crypto
 import Dscp.DB.SQLite.Instances ()
 import Dscp.Util.Aeson (CustomEncoding, HexEncoded)
-import Dscp.Util.Servant (ForResponseLog (..), buildForResponse)
+import Dscp.Util.Servant (ForResponseLog (..), buildForResponse,
+                          buildShortResponseList, buildLongResponseList)
 
 type MonadEducatorWebQuery m =
     ( MonadIO m
@@ -158,6 +159,18 @@ instance Buildable (ForResponseLog BlkProofInfo) where
       "{ tree root hash = " +||
           fmap getMerkleProofRoot bpiMtreeSerialized ||+
       "} "
+
+instance Buildable (ForResponseLog Course) where
+    build = buildForResponse
+
+instance Buildable (ForResponseLog [GradeInfo]) where
+    build = buildShortResponseList
+
+instance Buildable (ForResponseLog [StudentInfo]) where
+    build = buildLongResponseList
+
+instance Buildable (ForResponseLog [BlkProofInfo]) where
+    build = buildLongResponseList
 
 ---------------------------------------------------------------------------
 -- Simple conversions

--- a/witness/src/Dscp/Util/Servant.hs
+++ b/witness/src/Dscp/Util/Servant.hs
@@ -16,6 +16,8 @@ module Dscp.Util.Servant
     , ForResponseLog (..)
     , buildListForResponse
     , buildForResponse
+    , buildShortResponseList
+    , buildLongResponseList
     , ApiHasArgClass (..)
     , ApiCanLogArg (..)
 
@@ -34,7 +36,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Buildable as B
 import qualified Data.Text.Lazy.Builder as B
 import Data.Time.Clock.POSIX (getPOSIXTime)
-import Fmt (blockListF, (+|), (|+))
+import Fmt (blockListF, (+|), (|+), Builder)
 import GHC.IO.Unsafe (unsafePerformIO)
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import Loot.Log (Level (Info))
@@ -429,8 +431,11 @@ instance Buildable (ForResponseLog ()) where
 instance Buildable (ForResponseLog Integer) where
     build = buildForResponse
 
-instance Buildable x => Buildable (ForResponseLog [x]) where
-    build = blockListF . (take 8) . unForResponseLog
+buildShortResponseList :: Buildable a => ForResponseLog [a] -> Builder
+buildShortResponseList = blockListF . (take 4) . unForResponseLog
+
+buildLongResponseList :: Buildable a => ForResponseLog [a] -> Builder
+buildLongResponseList = blockListF . (take 8) . unForResponseLog
 
 -------------------------------------------------------------------------
 -- Deserialisation errors

--- a/witness/src/Dscp/Util/Servant.hs
+++ b/witness/src/Dscp/Util/Servant.hs
@@ -16,6 +16,8 @@ module Dscp.Util.Servant
     , ForResponseLog (..)
     , buildListForResponse
     , buildForResponse
+    , ApiHasArgClass (..)
+    , ApiCanLogArg (..)
 
     , SimpleJSON
     ) where
@@ -426,6 +428,9 @@ instance Buildable (ForResponseLog ()) where
 
 instance Buildable (ForResponseLog Integer) where
     build = buildForResponse
+
+instance Buildable x => Buildable (ForResponseLog [x]) where
+    build = blockListF . (take 8) . unForResponseLog
 
 -------------------------------------------------------------------------
 -- Deserialisation errors


### PR DESCRIPTION
### Description

Requests to student & educator APIs are logged.

### YT issue

https://issues.serokell.io/DSCP-222

### Introduced changes

New buildable instances for educator's types.
serveWithContext accepts different proxy which allows logging API requests and responses.

- [x] New feature
- [ ] Bugfix
- [ ] Refactoring
- [ ] New tests (on functionality not fixed/introduced in this PR)
- [ ] New docs (on functionality not fixed/introduced in this PR)
- [ ] Infrastructure changes

### Checklist

If I added new functionality, I
- [ ] added tests covering it
- [ ] explained it using haddock in the source code

If I fixed a bug, I
- [ ] added a regression test to prevent the bug from silently reappearing again

If I changed public API structure or/and data serialization, I made sure that
- [ ] those changes are reflected in [Swagger API specs](/specs/disciplina)
- [ ] and also in [related](/docs/api-types.md) [documentation](/docs/authentication.md).

If I changed config structure or/and CLI interface of any executable, I made sure that
- [ ] [sample config](/docs/config-full-sample.yaml) is updated accordingly
- [ ] [launch scripts](/scripts/launch) are updated accordingly and work as expected

If I changed the procedure of building a project and/or running any executable or helper script, I
- [ ] updated [README.md](/README.md) accordingly
- [ ] as well as subproject READMEs for all related executables

Also,
- [x] my commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP"
- [ ] my code complies with the [style guide](/docs/code-style.md)
- [ ] my documentation is checked with a spell checker (like [Grammarly](https://app.grammarly.com))
