### PR TITLE
[DSCP-295] Merge multiple configs properly + fix CLI implicit overrides.

### DIFF
--- a/core/package.yaml
+++ b/core/package.yaml
@@ -58,6 +58,7 @@ library:
     - time
     - unix
     - unliftio
+    - unordered-containers
     - vinyl
     - yaml
 

--- a/core/src/Dscp/Core/Config.hs
+++ b/core/src/Dscp/Core/Config.hs
@@ -45,7 +45,7 @@ import Dscp.Crypto (hash)
 
 -- | Slot duration in milliseconds.
 newtype SlotDuration = SlotDuration { unSlotDuration :: Word64 }
-    deriving (Eq, Ord, Num, Generic)
+    deriving (Show, Eq, Ord, Num, Generic)
 
 ---------------------------------------------------------------------
 -- Reading config

--- a/core/src/Dscp/Core/Fees.hs
+++ b/core/src/Dscp/Core/Fees.hs
@@ -44,11 +44,14 @@ data FeePolicy tx where
     LinearFeePolicy :: FeeCoefficients -> FeePolicy tx
     UnknownFeePolicy :: FeePolicy Void
 
+deriving instance Eq (FeePolicy tx)
+deriving instance Show (FeePolicy tx)
+
 -- | All fee policies.
 data FeeConfig = FeeConfig
     { fcMoney       :: FeePolicy Tx
     , fcPublication :: FeePolicy PublicationTx
-    }
+    } deriving (Eq, Show)
 
 -- | Calculate fees from tx size.
 calcLinearFees :: Integral i => FeeCoefficients -> i -> Fees

--- a/core/src/Dscp/Resource/AppDir.hs
+++ b/core/src/Dscp/Resource/AppDir.hs
@@ -20,7 +20,7 @@ data AppDirParam
       -- ^ Dedicated folder inside OS directory for applications
     | AppDirectorySpecific !FilePath
       -- ^ Given path
-    deriving (Show)
+    deriving (Show, Eq)
 
 type AppDir = FilePath
 

--- a/core/src/Dscp/Resource/Logging.hs
+++ b/core/src/Dscp/Resource/Logging.hs
@@ -37,7 +37,7 @@ data LoggingParams = LoggingParams
     -- ^ Path to log directory
     , lpConfigPath  :: !(Maybe FilePath)
     -- ^ Path to logger configuration
-    } deriving Show
+    } deriving (Show, Eq)
 
 ----------------------------------------------------------------------------
 -- Other

--- a/core/src/Dscp/Util/Test.hs
+++ b/core/src/Dscp/Util/Test.hs
@@ -26,6 +26,7 @@ import Fmt ((+|), (+||), (|+), (||+))
 import qualified GHC.Exts as Exts
 import qualified GHC.Generics as G
 import qualified Loot.Log as Log
+import Options.Applicative (Parser, defaultPrefs, execParserPure, getParseResult, info)
 import System.Random (Random)
 import Test.Hspec as T
 import Test.QuickCheck as T (Arbitrary (..), Fixed (..), Gen, Property, Testable (..), conjoin,
@@ -179,6 +180,14 @@ counterexample desc prop = Q.counterexample (toString desc) prop
 -- | Generate smaller amounts of data.
 pickSmall :: (Monad m, Show a) => Gen a -> PropertyM m a
 pickSmall = pick . Q.resize 5
+
+----------------------------------------------------------------------------
+-- CLI interface testing
+----------------------------------------------------------------------------
+
+-- | Run a parser on a list of CLI arguments
+runCliArgs :: Parser a -> [String] -> Maybe a
+runCliArgs p = getParseResult . execParserPure defaultPrefs (info p mempty)
 
 ----------------------------------------------------------------------------
 -- Logging

--- a/educator/exec/Main.hs
+++ b/educator/exec/Main.hs
@@ -21,5 +21,6 @@ getEducatorConfig = do
     (configParams, cliConfig) <- execParser $
         info (helper <*> versionOption <*> parser) $
         fullDesc <> progDesc "Disciplina educator node."
+    let wrapConfig cfg = defaultEducatorConfig <> cfg <> cliConfig
     buildConfig configParams $
-        fmap (<> cliConfig) . fillEducatorConfig
+        fmap wrapConfig . fillEducatorConfig

--- a/educator/src/Dscp/DB/SQLite/Types.hs
+++ b/educator/src/Dscp/DB/SQLite/Types.hs
@@ -29,7 +29,7 @@ data SQLiteRealParams = SQLiteRealParams
       -- ^ Connections pool size.
     , srpMaxPending :: !Int
       -- ^ Maximal number of requests waiting for a free connection.
-    }
+    } deriving (Show, Eq)
 
 -- | Database mode.
 data SQLiteDBMode
@@ -37,10 +37,11 @@ data SQLiteDBMode
       -- ^ In given file using given number of connections
     | SQLiteInMemory
       -- ^ In memory
+    deriving (Show, Eq)
 
 data SQLiteParams = SQLiteParams
     { sdpMode :: SQLiteDBMode
-    }
+    } deriving (Show, Eq)
 
 data SQLiteDB = SQLiteDB
     { sdConnPool   :: Chan Connection

--- a/educator/src/Dscp/Educator/CLI.hs
+++ b/educator/src/Dscp/Educator/CLI.hs
@@ -25,8 +25,10 @@ sqliteParamsParser = do
     srpPath <- strOption $
         long "sql-path" <>
         metavar "FILEPATH" <>
-        help "Path to database directory for educator's private data." <>
-        value "educator-db"
+        help "Path to database directory for educator's private data. If not \
+             \specified, 'educator-db' directory is used."
+        -- Removed default value `educator-db`
+        -- See [Note default-cli-params] in 'Dscp.CommonCLI'
     srpConnNum <- optional . option auto $
         long "sql-conns" <>
         metavar "INTEGER" <>

--- a/educator/src/Dscp/Educator/Config.hs
+++ b/educator/src/Dscp/Educator/Config.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TypeOperators    #-}
 
 -- | All educator's configurations.
 
@@ -6,6 +7,7 @@ module Dscp.Educator.Config
     ( EducatorConfig
     , EducatorConfigRec
     , HasEducatorConfig
+    , defaultEducatorConfig
     , educatorConfig
     , withEducatorConfig
     , fillEducatorConfig
@@ -13,11 +15,12 @@ module Dscp.Educator.Config
     , module Dscp.Witness.Config
     ) where
 
+import Control.Lens ((?~))
 import Data.Reflection (Given, give, given)
-import Loot.Config ((:::), (::<), ConfigKind (Final, Partial), ConfigRec)
+import Loot.Config ((:::), (::<), ConfigKind (Final, Partial), ConfigRec, upcast)
 
 import Dscp.Config
-import Dscp.DB.SQLite (SQLiteParams)
+import Dscp.DB.SQLite (SQLiteDBMode (..), SQLiteParams (..), SQLiteRealParams (..))
 import Dscp.Educator.Launcher.Params (EducatorKeyParams)
 import Dscp.Educator.Web.Params (EducatorWebParams)
 import Dscp.Witness.Config
@@ -34,6 +37,16 @@ type EducatorConfigRecP = ConfigRec 'Partial EducatorConfig
 type EducatorConfigRec = ConfigRec 'Final EducatorConfig
 
 type HasEducatorConfig = Given EducatorConfigRec
+
+defaultEducatorConfig :: EducatorConfigRecP
+defaultEducatorConfig = upcast defaultWitnessConfig
+    & sub #educator . option #db ?~ defSqliteParams
+  where
+    defSqliteParams = SQLiteParams $ SQLiteReal $ SQLiteRealParams
+        { srpPath = "educator-db"
+        , srpConnNum = Nothing
+        , srpMaxPending = 200
+        }
 
 -- instance (HasEducatorConfig, cfg ~ WitnessConfigRec) => Given cfg where
 --     given = rcast (given @EducatorConfigRec)

--- a/educator/src/Dscp/Educator/Launcher/Params.hs
+++ b/educator/src/Dscp/Educator/Launcher/Params.hs
@@ -9,4 +9,4 @@ import Dscp.Resource.Keys (BaseKeyParams)
 -- | Educator key parameters.
 newtype EducatorKeyParams = EducatorKeyParams
     { unEducatorKeyParams :: BaseKeyParams
-    } deriving (Show, FromJSON)
+    } deriving (Show, Eq, FromJSON)

--- a/educator/src/Dscp/Educator/Web/Auth.hs
+++ b/educator/src/Dscp/Educator/Web/Auth.hs
@@ -140,6 +140,9 @@ data NoAuthContext s
     = NoAuthOnContext (NoAuthData s)
     | NoAuthOffContext
 
+deriving instance Show (NoAuthData s) => Show (NoAuthContext s)
+deriving instance Eq (NoAuthData s) => Eq (NoAuthContext s)
+
 instance (d ~ NoAuthData s) => IsAuth (NoAuth s) d where
     type AuthArgs (NoAuth s) = '[NoAuthContext s]
     runAuth _ _ = \case

--- a/educator/src/Dscp/Educator/Web/Bot/Params.hs
+++ b/educator/src/Dscp/Educator/Web/Bot/Params.hs
@@ -17,11 +17,12 @@ data EducatorBotParams
       -- ^ Seed to generate initial data (assignments, ...).
     , ebpOperationsDelay :: !(Time Microsecond)
       -- ^ Artificial delay in bot operations.
-    }
+    } deriving (Show, Eq)
 
 data EducatorBotSwitch
     = EducatorBotOff
     | EducatorBotOn EducatorBotParams
+    deriving (Show, Eq)
 
 deriveFromJSON defaultOptions ''EducatorBotParams
 

--- a/educator/src/Dscp/Educator/Web/Params.hs
+++ b/educator/src/Dscp/Educator/Web/Params.hs
@@ -16,6 +16,6 @@ data EducatorWebParams = EducatorWebParams
     , ewpBotParams         :: EducatorBotSwitch
     , ewpEducatorAPINoAuth :: NoAuthContext "educator"
     , ewpStudentAPINoAuth  :: NoAuthContext "student"
-    }
+    } deriving (Show, Eq)
 
 deriveFromJSON defaultOptions ''EducatorWebParams

--- a/educator/tests/Test/Dscp/Educator/CLI.hs
+++ b/educator/tests/Test/Dscp/Educator/CLI.hs
@@ -1,0 +1,9 @@
+module Test.Dscp.Educator.CLI where
+
+import Dscp.Educator.CLI
+import Dscp.Util.Test
+
+spec_EducatorCliParamsNoDefaults :: Spec
+spec_EducatorCliParamsNoDefaults = describe "Educator CLI interface" $
+    it "should not yield any default values if no CLI params are provided" $
+        runCliArgs educatorConfigParser [] `shouldBe` Just mempty

--- a/faucet/exec/Main.hs
+++ b/faucet/exec/Main.hs
@@ -32,5 +32,6 @@ getFaucetConfig = do
     (configParams, cliConfig) <- execParser $
         info (helper <*> versionOption <*> parser) $
         fullDesc <> progDesc "Disciplina faucet node."
+    let wrapConfig cfg = defaultFaucetConfig <> cfg <> cliConfig
     buildConfig configParams $
-        fmap (<> cliConfig) . fillFaucetConfig
+        fmap wrapConfig . fillFaucetConfig

--- a/faucet/package.yaml
+++ b/faucet/package.yaml
@@ -32,6 +32,19 @@ library:
     - wai
     - wai-cors
 
+tests:
+  disciplina-faucet-test:
+    <<: *test-common
+
+    build-tools:
+      - tasty-discover
+
+    dependencies:
+      - disciplina-core
+      - disciplina-faucet
+      - tasty
+      - tasty-hspec
+
 executables:
   dscp-faucet:
     <<: *exec-common

--- a/faucet/src/Dscp/Faucet/CLI.hs
+++ b/faucet/src/Dscp/Faucet/CLI.hs
@@ -5,7 +5,7 @@ module Dscp.Faucet.CLI
     ) where
 
 import Loot.Config (OptParser, (.::), (.:<), (.<>))
-import Options.Applicative (Parser, help, long, metavar, option, switch)
+import Options.Applicative (Parser, flag', help, long, metavar, option)
 
 import Dscp.CommonCLI
 import Dscp.Faucet.Config
@@ -17,7 +17,7 @@ transferredAmountParser = option (TransferredAmount <$> coinReadM) $
     help "How much money to send on each request to faucet"
 
 dryRunParser :: Parser DryRun
-dryRunParser = fmap DryRun . switch $
+dryRunParser = fmap DryRun . flag' True $
     long "dry-run" <>
     help "Do not communicate with witness backend"
 

--- a/faucet/src/Dscp/Faucet/Config.hs
+++ b/faucet/src/Dscp/Faucet/Config.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TypeOperators    #-}
 
 -- | All witness's configurations.
 
@@ -8,6 +9,7 @@ module Dscp.Faucet.Config
     , HasFaucetConfig
     , TransferredAmount (..)
     , DryRun (..)
+    , defaultFaucetConfig
     , faucetConfig
     , withFaucetConfig
     , fillFaucetConfig
@@ -15,6 +17,7 @@ module Dscp.Faucet.Config
     , module Dscp.Core.Config
     ) where
 
+import Control.Lens ((?~))
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Reflection (Given (..), give)
 import Loot.Config ((:::), (::<), ConfigKind (Final, Partial), ConfigRec)
@@ -29,11 +32,11 @@ import Dscp.Web
 
 -- | How much money would be trasferred on each request.
 newtype TransferredAmount = TransferredAmount { getTranferredAmount :: Coin }
-    deriving (FromJSON, ToJSON)
+    deriving (Show, Eq, FromJSON, ToJSON)
 
 -- | Whether need not to communicate with witness backend.
 newtype DryRun = DryRun Bool
-    deriving (FromJSON, ToJSON)
+    deriving (Show, Eq, FromJSON, ToJSON)
 
 -- | Define config parameters for the Faucet
 --    [@logging@] Logging params.
@@ -65,6 +68,12 @@ type FaucetConfigRecP = ConfigRec 'Partial FaucetConfig
 type FaucetConfigRec = ConfigRec 'Final FaucetConfig
 
 type HasFaucetConfig = Given FaucetConfigRec
+
+defaultFaucetConfig :: FaucetConfigRecP
+defaultFaucetConfig = mempty
+    & sub #faucet . option #logging ?~ LoggingParams "faucet" False Nothing Nothing
+    & sub #faucet . option #keys ?~ BaseKeyParams Nothing False Nothing
+    & sub #faucet . option #dryRun ?~ DryRun False
 
 faucetConfig :: HasFaucetConfig => FaucetConfigRec
 faucetConfig = given

--- a/faucet/tests/Main.hs
+++ b/faucet/tests/Main.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF tasty-discover -optF --tree-display #-}

--- a/faucet/tests/Test/Dscp/Faucet/CLI.hs
+++ b/faucet/tests/Test/Dscp/Faucet/CLI.hs
@@ -1,0 +1,9 @@
+module Test.Dscp.Faucet.CLI where
+
+import Dscp.Faucet.CLI
+import Dscp.Util.Test
+
+spec_FaucetCliParamsNoDefaults :: Spec
+spec_FaucetCliParamsNoDefaults = describe "Educator CLI interface" $
+    it "should not yield any default values if no CLI params are provided" $
+        runCliArgs faucetConfigParser [] `shouldBe` Just mempty

--- a/witness/exec/Main.hs
+++ b/witness/exec/Main.hs
@@ -19,5 +19,6 @@ getWitnessConfig = do
     (configParams, cliConfig) <- execParser $
         info (helper <*> versionOption <*> parser) $
         fullDesc <> progDesc "Disciplina witness node."
+    let wrapConfig cfg = defaultWitnessConfig <> cfg <> cliConfig
     buildConfig configParams $
-        fmap (<> cliConfig) . fillWitnessConfig
+        fmap wrapConfig . fillWitnessConfig

--- a/witness/package.yaml
+++ b/witness/package.yaml
@@ -86,7 +86,6 @@ tests:
       - loot-config
       - loot-log
       - memory
-      - optparse-applicative
       - text-format
       - QuickCheck
 

--- a/witness/package.yaml
+++ b/witness/package.yaml
@@ -86,6 +86,7 @@ tests:
       - loot-config
       - loot-log
       - memory
+      - optparse-applicative
       - text-format
       - QuickCheck
 

--- a/witness/src/Dscp/DB/Rocks/Real/Types.hs
+++ b/witness/src/Dscp/DB/Rocks/Real/Types.hs
@@ -32,7 +32,7 @@ data DB = DB
 data RocksDBParams = RocksDBParams
     { rdpPath :: !FilePath
     -- ^ Path to the database
-    } deriving Show
+    } deriving (Show, Eq)
 
 data RocksDB = RocksDB
     { _rdDatabase :: !DB

--- a/witness/src/Dscp/Resource/Keys/Types.hs
+++ b/witness/src/Dscp/Resource/Keys/Types.hs
@@ -37,7 +37,7 @@ data BaseKeyParams = BaseKeyParams
       -- When 'False', file should be present and it will be used.
     , bkpPassphrase :: !(Maybe PassPhrase)
       -- ^ Password of encrypted secret key stored on disk.
-    } deriving (Show)
+    } deriving (Show, Eq)
 
 -- | In case of committee governance, these keys help us to generate
 -- keys.
@@ -48,7 +48,7 @@ data CommitteeParams
                             , cpSecret       :: CommitteeSecret }
       -- ^ In closed committee you should provide a (common) secret
       -- and your index.
-    deriving (Show)
+    deriving (Show, Eq)
 
 -- | Context providing access to secret key.
 --

--- a/witness/src/Dscp/Resource/Network.hs
+++ b/witness/src/Dscp/Resource/Network.hs
@@ -111,7 +111,7 @@ data NetServParams = NetServParams
     , nsInternalAddress :: !(Maybe PreZTNodeId)
       -- ^ Optional internal address that we'll bind to
       -- (nsOurAddress should be an external, addressable one anyway).
-    } deriving (Show)
+    } deriving (Show, Eq)
 
 -- | Resources needed for ZMQ TCP client + server.
 data NetServResources = NetServResources

--- a/witness/src/Dscp/Web/Metrics.hs
+++ b/witness/src/Dscp/Web/Metrics.hs
@@ -15,7 +15,7 @@ import Dscp.Util (countingTime)
 import Dscp.Web.Types (NetworkAddress (..))
 
 newtype MetricsEndpoint = MetricsEndpoint { unMetricsEndpoint :: Maybe Endpoint }
-    deriving (Show)
+    deriving (Show, Eq)
 
 reportTime :: MonadIO m => Name -> MetricsEndpoint -> m a -> m a
 reportTime name (MetricsEndpoint mEndpoint) m = case mEndpoint of
@@ -27,7 +27,7 @@ reportTime name (MetricsEndpoint mEndpoint) m = case mEndpoint of
         return a
 
 responseTimeMetric :: MetricsEndpoint -> Middleware
-responseTimeMetric endpoint app = \request f ->
+responseTimeMetric endpoint app request f =
     reportTime "disciplina.timer.http_request" endpoint (app request f)
 
 addrToEndpoint :: NetworkAddress -> Endpoint

--- a/witness/src/Dscp/Witness/Config.hs
+++ b/witness/src/Dscp/Witness/Config.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TypeOperators    #-}
 
 -- | All witness's configurations.
 
@@ -6,6 +7,7 @@ module Dscp.Witness.Config
     ( WitnessConfig
     , WitnessConfigRec
     , HasWitnessConfig
+    , defaultWitnessConfig
     , witnessConfig
     , withWitnessConfig
     , fillWitnessConfig
@@ -13,17 +15,19 @@ module Dscp.Witness.Config
     , module Dscp.Core.Config
     ) where
 
+import Control.Lens ((?~))
 import Data.Reflection (Given (..), give)
-import Loot.Config ((:::), (::<), ConfigKind (Final, Partial), ConfigRec)
+import Loot.Config ((:::), (::<), ConfigKind (Final, Partial), ConfigRec, option, sub)
 
 import Dscp.Config
 import Dscp.Core.Config
-import Dscp.DB.Rocks.Real.Types (RocksDBParams)
-import Dscp.Resource.AppDir (AppDirParam)
-import Dscp.Resource.Logging (LoggingParams)
+import Dscp.DB.Rocks.Real.Types (RocksDBParams (..))
+import Dscp.Resource.AppDir (AppDirParam (..))
+import Dscp.Resource.Keys (BaseKeyParams (..))
+import Dscp.Resource.Logging (LoggingParams (..))
 import Dscp.Resource.Network (NetServParams)
-import Dscp.Web (MetricsEndpoint, ServerParams)
-import Dscp.Witness.Keys (WitnessKeyParams)
+import Dscp.Web (MetricsEndpoint (..), ServerParams)
+import Dscp.Witness.Keys (WitnessKeyParams (..))
 
 type WitnessConfig = CoreConfig ++
     '[ "witness" ::<
@@ -50,6 +54,15 @@ instance HasWitnessConfig => Given CoreConfigRec where
 ---------------------------------------------------------------------------
 -- Config itself
 ---------------------------------------------------------------------------
+
+defaultWitnessConfig :: WitnessConfigRecP
+defaultWitnessConfig = mempty
+    & sub #witness . option #logging ?~ LoggingParams "witness" False Nothing Nothing
+    & sub #witness . option #db ?~ RocksDBParams "witness-db"
+    & sub #witness . option #keys ?~ Basic (BaseKeyParams Nothing False Nothing)
+    & sub #witness . option #api ?~ Nothing
+    & sub #witness . option #appDir ?~ AppDirectoryOS
+    & sub #witness . option #metricsEndpoint ?~ MetricsEndpoint Nothing
 
 witnessConfig :: HasWitnessConfig => WitnessConfigRec
 witnessConfig = given

--- a/witness/src/Dscp/Witness/Keys.hs
+++ b/witness/src/Dscp/Witness/Keys.hs
@@ -12,7 +12,7 @@ import Dscp.Resource.Keys
 data WitnessKeyParams
     = Basic BaseKeyParams       -- ^ Basic key management with a keyfile
     | Committee CommitteeParams -- ^ Generate a key from committee params
-    deriving (Show)
+    deriving (Show, Eq)
 
 -- | JSON instance (for configuration specs)
 instance FromJSON WitnessKeyParams where

--- a/witness/tests/Test/Dscp/Witness.hs
+++ b/witness/tests/Test/Dscp/Witness.hs
@@ -1,1 +1,0 @@
-{-# OPTIONS_GHC -F -pgmF autoexporter #-}

--- a/witness/tests/Test/Dscp/Witness/CLISpec.hs
+++ b/witness/tests/Test/Dscp/Witness/CLISpec.hs
@@ -1,14 +1,9 @@
 module Test.Dscp.Witness.CLISpec where
 
-import Options.Applicative (Parser, defaultPrefs, execParserPure, getParseResult, info)
-
 import Dscp.Util.Test
 import Dscp.Witness.CLI
-
-runArgs :: Parser a -> [String] -> Maybe a
-runArgs p = getParseResult . execParserPure defaultPrefs (info p mempty)
 
 spec :: Spec
 spec = describe "Witness node CLI interface" $
     it "should not yield any default values if no CLI params are provided" $
-        runArgs witnessConfigParser [] `shouldBe` Just mempty
+        runCliArgs witnessConfigParser [] `shouldBe` Just mempty

--- a/witness/tests/Test/Dscp/Witness/CLISpec.hs
+++ b/witness/tests/Test/Dscp/Witness/CLISpec.hs
@@ -1,0 +1,14 @@
+module Test.Dscp.Witness.CLISpec where
+
+import Options.Applicative (Parser, defaultPrefs, execParserPure, getParseResult, info)
+
+import Dscp.Util.Test
+import Dscp.Witness.CLI
+
+runArgs :: Parser a -> [String] -> Maybe a
+runArgs p = getParseResult . execParserPure defaultPrefs (info p mempty)
+
+spec :: Spec
+spec = describe "Witness node CLI interface" $
+    it "should not yield any default values if no CLI params are provided" $
+        runArgs witnessConfigParser [] `shouldBe` Just mempty


### PR DESCRIPTION
### Description

The following is done:
- Multiple YAML configs are now merged as `Value`s before parsing as `ConfigRec`s. This allows for overriding separate fields in records.
- There are no CLI parsers which always succeed anymore (those which did this are changed and now fail if no relevant parameters are passed). This behavior together with overriding config sections via CLI params led to very confusing bugs where some config parameters were seemingly ignored. Now default values for those parameters are provided via default config records, which do not override Yaml configs.

### YT issue

https://issues.serokell.io/issue/DSCP-295

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](/../../tree/master/docs/config-full-sample.yaml) and [launch scripts](/../../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](/../../tree/master/specs/disciplina) API specs.
  - Any [related documentation](/../../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](/../../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
