### PR TITLE
[DSCP-314] Prohibit empty CommitteeSecrets

### DIFF
--- a/core/src/Dscp/Core/Aeson.hs
+++ b/core/src/Dscp/Core/Aeson.hs
@@ -111,7 +111,7 @@ instance ToJSONKey Address
 deriving instance FromJSON GenAddressMap
 deriving instance ToJSON GenAddressMap
 instance FromJSON CommitteeSecret where
-    parseJSON = withText "CommitteeSecret" $ pure . CommitteeSecret . encodeUtf8
+    parseJSON = withText "CommitteeSecret" $ leftToFail . mkCommitteeSecret . encodeUtf8
 
 deriving instance ToJSON GenesisDistribution
 deriving instance FromJSON GenesisDistribution

--- a/core/src/Dscp/Core/Governance.hs
+++ b/core/src/Dscp/Core/Governance.hs
@@ -1,6 +1,8 @@
 module Dscp.Core.Governance
     ( Governance (..)
-    , CommitteeSecret (..)
+    , CommitteeSecret
+    , mkCommitteeSecret
+    , unCommitteeSecret
     , Committee (..)
     , mkClosedCommittee
     , committeeDerive
@@ -30,6 +32,11 @@ data Governance
 newtype CommitteeSecret = CommitteeSecret
     { unCommitteeSecret :: ByteString
     } deriving (Eq, Ord, Show, Generic)
+
+mkCommitteeSecret :: ByteString -> Either Text CommitteeSecret
+mkCommitteeSecret sec
+    | null sec = Left "CommitteeSecret is empty"
+    | otherwise = Right $ CommitteeSecret sec
 
 -- | Committee is a fixed order list of addresses allowed to issue
 -- block. It can be either closed or open (for testing). Participants'

--- a/tools/src/keygen/KeygenSecret.hs
+++ b/tools/src/keygen/KeygenSecret.hs
@@ -45,7 +45,7 @@ parseInputWithSecret = \case
         content <- decode $ LBS.fromStrict input
         fromKeyfileContent pp content
     CommSecret n -> \input ->
-        pure $ committeeDerive (CommitteeSecret input) n
+         flip committeeDerive n <$> eitherToMaybe (mkCommitteeSecret input)
     SecretFromSeed -> \input -> asum
         [ do
             -- we need this clause as soon as many code uses

--- a/witness/src/Dscp/Witness/CLI.hs
+++ b/witness/src/Dscp/Witness/CLI.hs
@@ -19,13 +19,14 @@ import Options.Applicative (Parser, auto, eitherReader, help, long, metavar, opt
 
 import Dscp.CommonCLI (appDirParamParser, baseKeyParamsParser, logParamsParser,
                        networkAddressParser, serverParamsParser)
-import Dscp.Core.Governance (CommitteeSecret (..))
+import Dscp.Core.Governance (mkCommitteeSecret)
 import Dscp.DB.Rocks.Real.Types (RocksDBParams (..))
 import Dscp.Resource.Keys
 import Dscp.Resource.Network (NetCliParams (..), NetServParams (..))
 import Dscp.Web.Metrics (MetricsEndpoint (..), addrToEndpoint)
 import Dscp.Witness.Config
 import Dscp.Witness.Keys
+import Dscp.Util (eitherToMaybe)
 
 ----------------------------------------------------------------------------
 -- DB
@@ -93,7 +94,7 @@ metricsServerParser =
 
 committeeParamsParser :: Parser CommitteeParams
 committeeParamsParser =
-    combine <$> nParser <*> optional commSecretParser
+    combine <$> nParser <*> commSecretParser
   where
     combine cpParticipantN Nothing         = CommitteeParamsOpen {..}
     combine cpParticipantN (Just cpSecret) = CommitteeParamsClosed {..}
@@ -104,7 +105,7 @@ committeeParamsParser =
          help "Committee participant index. In event of secret key file \
               \generation, will be used to derive the secret.")
 
-    commSecretParser = CommitteeSecret <$> strOption
+    commSecretParser = eitherToMaybe . mkCommitteeSecret <$> strOption
         (long "comm-sec" <>
          metavar "BYTESTRING" <>
          help "Committee secret key. Common key for the core nodes \

--- a/witness/tests/Test/Dscp/Witness/Mode.hs
+++ b/witness/tests/Test/Dscp/Witness/Mode.hs
@@ -77,7 +77,7 @@ testCommittee :: Committee
 testCommittee =
     CommitteeOpen
     { commN = 2
-    , commSecret = detGen 12 (CommitteeSecret <$> arbitrary)
+    , commSecret = detGen 121 ((leftToPanic . mkCommitteeSecret) <$> arbitrary)
     }
 
 testCommitteeSecrets :: [SecretKey]


### PR DESCRIPTION
### Description

Prohibit empty `CommitteeSecret`s (throw an error when trying to decode empty string)
Add smart constructor to CommitteeSecret
Change exports and imports

### YT issue

https://issues.serokell.io/issue/DSCP-314

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [ ] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [ ] I have checked the [sample config](/../../tree/master/docs/config-full-sample.yaml) and [launch scripts](/../../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [ ] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](/README.md) as well as subproject READMEs for all related executables).
- [ ] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](/../../tree/master/specs/disciplina) API specs.
  - Any [related documentation](/../../tree/master/docs/api-types.md).
- [ ] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](/../../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
