### PR TITLE
[DSCP-303] Replace blind chmod with permission check in readStore

### DIFF
--- a/witness/src/Dscp/Resource/Keys/Error.hs
+++ b/witness/src/Dscp/Resource/Keys/Error.hs
@@ -18,6 +18,7 @@ data KeyInitError
     | SecretParseError Text
     | SecretConfMismatch Text
     | SecretIOError Text
+    | SecretFileModeError Text
 
 instance Show KeyInitError where
     show = toString . pretty
@@ -32,6 +33,8 @@ instance Buildable KeyInitError where
             "Configuration/CLI params mismatch: "+|msg|+""
         SecretIOError msg ->
             "Some I/O error occured: "+|msg|+""
+        SecretFileModeError msg ->
+            "File permission error: "+|msg|+""
 
 instance Exception KeyInitError
 

--- a/witness/src/Dscp/Resource/Keys/Functions.hs
+++ b/witness/src/Dscp/Resource/Keys/Functions.hs
@@ -14,14 +14,11 @@ module Dscp.Resource.Keys.Functions
 
 import Data.Aeson (eitherDecode', encode)
 import qualified Data.ByteString.Lazy as LBS
-import Fmt ((+|), (+||), (|+), (||+), octF)
+import Fmt ((+|), (+||), (|+), (||+))
 import Loot.Log (MonadLogging, logDebug, logInfo)
 import qualified System.Directory as D
 import System.FilePath ((</>))
 import qualified System.FilePath as FP
-import System.Posix.Types (FileMode)
-import Data.Bits ((.|.))
-import Dscp.System.Other (IsPosix)
 
 import Dscp.Core
 import Dscp.Crypto
@@ -29,7 +26,7 @@ import Dscp.Resource.AppDir
 import Dscp.Resource.Keys.Error (KeyInitError (..), rewrapKeyIOErrors)
 import Dscp.Resource.Keys.Types (BaseKeyParams (..), CommitteeParams (..), KeyJson (..),
                                  KeyResources (..), KeyfileContent)
-import Dscp.System (mode600, setMode, whenPosix, getAccessMode)
+import Dscp.System (mode600, setMode, whenPosix, checkFileMode)
 import Dscp.Util (leftToThrow)
 import Dscp.Util.Aeson (CustomEncoding (..), Versioned (..))
 
@@ -120,22 +117,12 @@ readStore
 readStore path pp = do
     logDebug $ "Reading key from: " +|| path ||+ ""
     content <- rewrapKeyIOErrors $ do
-        whenPosix $ checkFileMode mode600 path
+        whenPosix $ (checkFileMode mode600 path)
+            >>= leftToThrow SecretFileModeError
         liftIO $ LBS.readFile path
     Versioned mid <- eitherDecode' @KeyfileContent content
         & leftToThrow (SecretParseError . toText)
     mkStore <$> fromSecretJson pp mid
-  where
-    checkFileMode
-      :: (IsPosix, MonadIO m, MonadLogging m, MonadThrow m)
-      => FileMode -> FilePath -> m ()
-    checkFileMode mode filePath = do
-      accessMode <- getAccessMode filePath
-      unless ((accessMode .|. mode) <= mode) $ do
-          throwM $ SecretFileModeError $
-              "File permissions for "+|filePath|+" are too loose: "+|octF accessMode|+
-              ". Should be 0600 or lower. Possible fix: `chmod 0600 "+|filePath|+"`."
-
 
 -- | Write given secret to store.
 writeStoreDumb


### PR DESCRIPTION
When reading a file we did not create immediately before, we can not be certain
to have the necessary permissions for `chmod`. For example, the file might have
been provisioned separately, and be owned by root. Instead, check if we believe
the file has permissions that are too loose and throw an error.

This PR does not include tests. Because I honestly have no idea how to
implement them.


https://issues.serokell.io/issue/DSCP-303


Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [ ] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [ ] I have checked the [sample config](/../../tree/master/docs/config-full-sample.yaml) and [launch scripts](/../../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [ ] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](/README.md) as well as subproject READMEs for all related executables).
- [ ] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](/../../tree/master/specs/disciplina) API specs.
  - Any [related documentation](/../../tree/master/docs/api-types.md).
- [ ] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](/../../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).