### PR TITLE
[DSCP-307] Simplify Educator API, bring in line with spec

### DIFF
--- a/educator/src/Dscp/Educator/Web/Educator/API.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/API.hs
@@ -61,8 +61,8 @@ data EducatorApiEndpoints route = EducatorApiEndpoints
 
     , eGetStudents :: route
         :- "students"
+        :> QueryParam "course" Course
         :> Summary "Get a list of all registered students' addresses"
-        :> QueryParam "courseId" Course
         :> Get '[DSON] [StudentInfo]
 
       -- Courses
@@ -76,6 +76,7 @@ data EducatorApiEndpoints route = EducatorApiEndpoints
 
     , eGetCourses :: route
         :- "courses"
+        :> QueryParam "student" Student
         :> Summary "Get all courses"
         :> Get '[DSON] [CourseEducatorInfo]
 
@@ -88,14 +89,6 @@ data EducatorApiEndpoints route = EducatorApiEndpoints
         :> ReqBody '[DSON] EnrollStudentToCourse
         :> PostCreated '[DSON] ()
 
-    , eGetStudentCourses :: route
-        :- "students" :> Capture "studentAddr" Student
-        :> "courses"
-        :> Summary "Get a list of student's courses"
-        :> Description "Gets a list of courses which student is currently \
-                        \attending."
-        :> Get '[DSON] [CourseEducatorInfo]
-
       -- Assignments
 
     , eAddCourseAssignment :: route
@@ -105,12 +98,12 @@ data EducatorApiEndpoints route = EducatorApiEndpoints
         :> ReqBody '[DSON] NewAssignment
         :> PostCreated '[DSON] ()
 
-    , eGetStudentAssignments :: route
-        :- "students" :> Capture "studentAddr" Student
-        :> "assignments"
-        :> Summary "Get active student's assignments"
-        :> Description "Given student address, gets a list of all pending \
-                        \assignments student has."
+    , eGetAssignments :: route
+        :- "assignments"
+        :> QueryParam "course" Course
+        :> QueryParam "student" Student
+        :> QueryParam "isFinal" IsFinal
+        :> Summary "Get all assignments"
         :> Get '[DSON] [AssignmentEducatorInfo]
 
     , eAssignToStudent :: route
@@ -131,17 +124,6 @@ data EducatorApiEndpoints route = EducatorApiEndpoints
                         \raises error."
         :> Delete '[DSON] ()
 
-    , eGetStudentCourseAssignments :: route
-        :- "students" :> Capture "studentAddr" Student
-        :> "courses"  :> Capture "courseId" Course
-        :> "assignments"
-        :> Summary "Get active student's assignments for a given course"
-        :> Description "Given student address and course ID, gets a list of \
-                        \all pending assignments student has as a part of a \
-                        \course."
-        :> QueryParam "isFinal" IsFinal
-        :> Get '[DSON] [AssignmentEducatorInfo]
-
       -- Submissions
 
     , eGetSubmission :: route
@@ -159,34 +141,12 @@ data EducatorApiEndpoints route = EducatorApiEndpoints
 
     , eGetSubmissions :: route
         :- "submissions"
+        :> QueryParam "course" Course
+        :> QueryParam "student" Student
+        :> QueryParam "assignment" (Hash Assignment)
         :> Summary "Get all submissions"
         :> Description "Gets a list of all submissions done by all students. \
                       \This method is inaccessible by students."
-        :> Get '[DSON] [SubmissionEducatorInfo]
-
-    , eGetStudentSubmissions :: route
-        :- "students" :> Capture "studentAddr" Student
-        :> "submissions"
-        :> Summary "Get all student's submissions"
-        :> Description "Gets a list of all student's submissions."
-        :> Get '[DSON] [SubmissionEducatorInfo]
-
-    , eGetStudentAssignmentSubmissions :: route
-        :- "students"    :> Capture "studentAddr" Student
-        :> "assignments" :> Capture "assignmentHash" (Hash Assignment)
-        :> "submissions"
-        :> Summary "Student's submissions for an assignment"
-        :> Description "Gets a list of student's submissions for a given \
-                    \assignment"
-        :> Get '[DSON] [SubmissionEducatorInfo]
-
-    , eGetStudentCourseSubmissions :: route
-        :- "students" :> Capture "studentAddr" Student
-        :> "courses"  :> Capture "courseId" Course
-        :> "submissions"
-        :> Summary "Get student's course submissions"
-        :> Description "Gets a list of student's submissions he made during \
-                        \studying given course."
         :> Get '[DSON] [SubmissionEducatorInfo]
 
       -- Grades
@@ -200,46 +160,24 @@ data EducatorApiEndpoints route = EducatorApiEndpoints
 
     , eGetGrades :: route
         :- "grades"
+        :> QueryParam "course" Course
+        :> QueryParam "student" Student
+        :> QueryParam "assignment" (Hash Assignment)
+        :> QueryParam "isFinal" IsFinal
         :> Summary "Get all grades"
         :> Description "Gets a list of all grades performed by all students."
         :> Get '[DSON] [GradeInfo]
 
-    , eGetStudentGrades :: route
-        :- "students" :> Capture "studentAddr" Student
-        :> "grades"
-        :> Summary "Get all student's grades"
-        :> Description "Gets a list of all students grades (aka transactions \
-                        \in a private chain)"
-        :> Get '[DSON] [GradeInfo]
-
-    , eGetStudentCourseGrades :: route
-        :- "students" :> Capture "studentAddr" Student
-        :> "courses"  :> Capture "courseId" Course
-        :> "grades"
-        :> Summary "Get student's course grades"
-        :> Description "Gets a list of grades a student received during \
-                        \studying given course."
-        :> QueryParam "isFinal" IsFinal
-        :> Get '[DSON] [GradeInfo]
-
       -- Proofs
 
-    , eGetStudentProofs :: route
-        :- "students" :> Capture "studentAddr" Student
-        :> "proofs"
+    , eGetProofs :: route
+        :- "proofs"
+        :> QueryParam "course" Course
+        :> QueryParam "student" Student
+        :> QueryParam "assignment" (Hash Assignment)
         :> Summary "Get proofs of all student's activity"
         :> Description "Gets all private transactions related to a student \
                         \together with corresponding Merkle proofs."
-        :> Get '[DSON] [BlkProofInfo]
-
-    , eGetStudentCourseProofs :: route
-        :- "students" :> Capture "studentAddr" Student
-        :> "courses"  :> Capture "courseId" Course
-        :> "proofs"
-        :> Summary "Get proofs of student's course progress"
-        :> Description "Gets student's course grades and submissions in form \
-                        \of private transactions, together with corresponding \
-                        \Merkle proofs."
         :> Get '[DSON] [BlkProofInfo]
 
    } deriving (Generic)

--- a/educator/src/Dscp/Educator/Web/Educator/Queries.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Queries.hs
@@ -110,16 +110,18 @@ isGradedSubmission submissionH = do
 
 educatorGetGrades
     :: MonadEducatorWebQuery m
-    => Maybe Student
-    -> Maybe Course
+    => Maybe Course
+    -> Maybe Student
+    -> Maybe (Hash Assignment)
     -> Maybe IsFinal
     -> DBT t w m [GradeInfo]
-educatorGetGrades studentF courseIdF isFinalF = do
+educatorGetGrades courseIdF studentF assignmentF isFinalF = do
     query queryText (mconcat paramsF)
   where
     (clausesF, paramsF) = unzip
         [ mkFilter "S.student_addr = ?" studentF
         , mkFilter "course_id = ?" courseIdF
+        , mkFilter "A.hash = ?" assignmentF
         , let assignTypeF = isFinalF ^. mapping (from assignmentTypeRaw)
           in mkFilter "A.type = ?" assignTypeF
         ]

--- a/educator/src/Dscp/Educator/Web/Logic.hs
+++ b/educator/src/Dscp/Educator/Web/Logic.hs
@@ -4,18 +4,16 @@ module Dscp.Educator.Web.Logic
     ( commonGetProofs
     ) where
 
-import Dscp.Core
 import Dscp.DB.SQLite
 import Dscp.Educator.Web.Types
 import Dscp.Util.Aeson
 
 commonGetProofs
     :: MonadEducatorWebQuery m
-    => Student
-    -> GetProvenStudentTransactionsFilters
+    => GetProvenStudentTransactionsFilters
     -> DBT 'WithinTx w m [BlkProofInfo]
-commonGetProofs student filters = do
-    rawProofs <- getProvenStudentTransactions student filters
+commonGetProofs filters = do
+    rawProofs <- getProvenStudentTransactions filters
     return
         [ BlkProofInfo{ bpiMtreeSerialized = CustomEncoding mtree, bpiTxs }
         | (mtree, indicedTxs) <- rawProofs

--- a/educator/src/Dscp/Educator/Web/Student/Handlers.hs
+++ b/educator/src/Dscp/Educator/Web/Student/Handlers.hs
@@ -32,8 +32,8 @@ studentApiHandlers student =
 
     , sGetAssignments = \afCourse afDocType afIsFinal ->
         transactR $
-            commonGetAssignments StudentCase student
-                def{ afCourse, afDocType, afIsFinal }
+            commonGetAssignments StudentCase
+                def{ afCourse, afStudent = Just student, afDocType, afIsFinal }
 
     , sGetAssignment = \assignH ->
         transactR $ studentGetAssignment student assignH
@@ -53,7 +53,7 @@ studentApiHandlers student =
         transactW $ commonDeleteSubmission subH (Just student)
 
     , sGetProofs = \pfSince ->
-        transactR $ commonGetProofs student def{ pfSince }
+        transactR $ commonGetProofs def{ pfSince, pfStudent = Just student }
     }
 
 convertStudentApiHandler

--- a/educator/src/Dscp/Educator/Web/Student/Logic.hs
+++ b/educator/src/Dscp/Educator/Web/Student/Logic.hs
@@ -56,8 +56,8 @@ studentGetAssignment
     -> Hash Assignment
     -> DBT 'WithinTx w m AssignmentStudentInfo
 studentGetAssignment student assignH =
-    commonGetAssignments StudentCase student def
-        { afAssignmentHash = Just assignH }
+    commonGetAssignments StudentCase def
+        { afAssignmentHash = Just assignH, afStudent = Just student }
         >>= listToMaybeWarn "assignment"
         >>= nothingToThrow (AbsentError $ AssignmentDomain assignH)
 
@@ -67,7 +67,7 @@ studentGetAllAssignments
     => Student
     -> DBT 'WithinTx w m [AssignmentStudentInfo]
 studentGetAllAssignments student =
-    commonGetAssignments StudentCase student def
+    commonGetAssignments StudentCase def{ afStudent = Just student }
 
 studentGetSubmission
     :: MonadEducatorWebQuery m

--- a/educator/tests/Test/Dscp/DB/SQLite/Queries.hs
+++ b/educator/tests/Test/Dscp/DB/SQLite/Queries.hs
@@ -305,7 +305,8 @@ spec_Instances = do
                     mblock <- runMaybeT (DB.createPrivateBlock Nothing)
                     let !_ = mblock ?: error "No private block created"
 
-                    transPacksSince <- DB.getProvenStudentTransactions studentId def{ pfSince = Just pointSince }
+                    transPacksSince <- DB.getProvenStudentTransactions
+                        def{ pfStudent = Just studentId, pfSince = Just pointSince }
 
                     let transSince = join $ map (map snd . snd) transPacksSince
 

--- a/educator/tests/Test/Dscp/Educator/Web/Educator/Queries.hs
+++ b/educator/tests/Test/Dscp/Educator/Web/Educator/Queries.hs
@@ -94,7 +94,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
                 void $ createAssignment assignment
                 setStudentAssignment student (hash assignment)
 
-            res <- lift $ commonGetAssignments EducatorCase student def
+            res <- lift $ commonGetAssignments EducatorCase def{ afStudent = Just student }
             return $ res === one AssignmentEducatorInfo
                 { aiHash = hash assignment
                 , aiCourseId = _aCourseId assignment
@@ -223,7 +223,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
             let student = tiOne $ cteStudents env
             lift $ prepareAndCreateSubmissions env
 
-            proofs <- lift $ commonGetProofs student def
+            proofs <- lift $ commonGetProofs def{ pfStudent = Just student }
 
             return $ proofs === []
 
@@ -239,7 +239,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
                 let !_ = mblock ?: error "No private block created"
                 return ()
 
-            proofs <- lift $ commonGetProofs student def
+            proofs <- lift $ commonGetProofs def{ pfStudent = Just student }
             let proof = expectOne "block proofs" proofs
 
             return $ bpiTxs proof === [ptx]
@@ -262,7 +262,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
                 let !_ = (mblock1 >> mblock2) ?: error "No private blocks created"
                 return ()
 
-            proofs <- lift $ commonGetProofs student def
+            proofs <- lift $ commonGetProofs def{ pfStudent = Just student }
             let resTxs = map bpiTxs proofs
 
             return $ map sort resTxs === [sort [ptx1, ptx2], [ptx3]]

--- a/educator/tests/Test/Dscp/Educator/Web/Student/Queries.hs
+++ b/educator/tests/Test/Dscp/Educator/Web/Student/Queries.hs
@@ -367,8 +367,8 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
                     let assignH = hash assignment
                     void $ setStudentAssignment student1 assignH
 
-                assignments <- commonGetAssignments StudentCase student1
-                        def{ afCourse = courseF, afDocType = docTypeF, afIsFinal = isFinalF }
+                assignments <- commonGetAssignments StudentCase
+                        def{ afCourse = courseF, afStudent = Just student1, afDocType = docTypeF, afIsFinal = isFinalF }
 
                 let assignments' =
                         applyFilterOn aiCourseId courseF $

--- a/specs/disciplina/educator/api/educator.yaml
+++ b/specs/disciplina/educator/api/educator.yaml
@@ -375,6 +375,11 @@ paths:
         required: false
         type: string
         format: byte
+      - in: query
+        name: isFinal
+        description: Return only grades for final/non-final assignments of the course
+        required: false
+        type: boolean
       responses:
         200:
           description: successful operation
@@ -433,6 +438,11 @@ paths:
         required: false
         type: string
         format: byte
+      - in: query
+        name: isFinal
+        description: Return only final/non-final assignments of the course
+        required: false
+        type: boolean
       produces:
       - application/json
       responses:


### PR DESCRIPTION
### Description

Changed multiple GET endpoints into optional query parameters.

TODO (some other time):
- fix ugly `fromJust` in `commonGetAssignments`
- bring some order and tidiness into API implementation
- run this code at least once

### YT issue

https://issues.serokell.io/issue/DSCP-307

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [ ] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](/../../tree/master/docs/config-full-sample.yaml) and [launch scripts](/../../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](/../../tree/master/specs/disciplina) API specs.
  - Any [related documentation](/../../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](/../../tree/master/docs/code-style.md).
- [ ] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
