### PR TITLE
[DSCP-322]  Rename SecretWrongPassPhraseError and provide better message for it

### DIFF
--- a/witness/src/Dscp/Resource/Keys/Error.hs
+++ b/witness/src/Dscp/Resource/Keys/Error.hs
@@ -14,7 +14,7 @@ import Dscp.Util (wrapRethrow)
 
 -- | Exception during secret key extraction from storage.
 data KeyInitError
-    = SecretWrongPassPhraseError DecryptionError
+    = SecretDecryptionError DecryptionError
     | SecretParseError Text
     | SecretConfMismatch Text
     | SecretIOError Text
@@ -25,8 +25,10 @@ instance Show KeyInitError where
 
 instance Buildable KeyInitError where
     build = \case
-        SecretWrongPassPhraseError password ->
-            "Wrong password for educator key storage provided ("+|password|+")"
+        SecretDecryptionError msg ->
+            "Error while decrypting educator key: "+|msg|+
+            ". Either retype password or" +|
+            "make sure educator.key file corresponds to the right account"
         SecretParseError _ ->
             "Invalid educator secret key storage format"
         SecretConfMismatch msg ->

--- a/witness/src/Dscp/Resource/Keys/Functions.hs
+++ b/witness/src/Dscp/Resource/Keys/Functions.hs
@@ -42,7 +42,7 @@ toSecretJson pp secret =
 fromSecretJson :: MonadThrow m => PassPhrase -> KeyJson -> m SecretKey
 fromSecretJson pp KeyJson{..} = do
     decrypt pp (unCustomEncoding kjEncSecretKey)
-        & leftToThrow SecretWrongPassPhraseError
+        & leftToThrow SecretDecryptionError
 
 toKeyfileContent :: PassPhrase -> SecretKey -> KeyfileContent
 toKeyfileContent pp sk = Versioned $ toSecretJson pp sk


### PR DESCRIPTION
### Description

It contains DecryptionError, which might not only mean wrong passphrase, but also malformed key (cc Kostya Ivanov)

### YT issue

https://issues.serokell.io/issue/DSCP-322

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [ ] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [ ] I have checked the [sample config](/../../tree/master/docs/config-full-sample.yaml) and [launch scripts](/../../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [ ] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](/README.md) as well as subproject READMEs for all related executables).
- [ ] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](/../../tree/master/specs/disciplina) API specs.
  - Any [related documentation](/../../tree/master/docs/api-types.md).
- [ ] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](/../../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
