### PR TITLE
Convert API specs to OpenAPI 3.0.0

### DIFF
--- a/specs/disciplina/educator/api/educator.yaml
+++ b/specs/disciplina/educator/api/educator.yaml
@@ -1,27 +1,33 @@
-swagger: "2.0"
+openapi: 3.0.0
 info:
-  description: This is an HTTP API for interacting with Disciplina Educator node on Educator side. It is meant to be used for integrating external systems, CRMs and CMSs with Disciplina
+  description: >-
+    This is an HTTP API for interacting with Disciplina Educator node on
+    Educator side. It is meant to be used for integrating external systems, CRMs
+    and CMSs with Disciplina
   version: 1.0.0
   title: Disciplina Educator API
-  termsOfService: https://disciplina.io/tnc.pdf
+  termsOfService: 'https://disciplina.io/tnc.pdf'
   contact:
     email: hi@serokell.io
   license:
     name: Apache 2.0
-    url: http://www.apache.org/licenses/LICENSE-2.0.html
-host: localhost:8090
-basePath: /api/educator/v1
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+externalDocs:
+  description: Find out more about Swagger
+  url: 'http://swagger.io'
+servers:
+  - url: 'https://localhost:8090/api/educator/v1'
+  - url: 'http://localhost:8090/api/educator/v1'
+security:
+  - EducatorAuth: []
 tags:
-- name: students
-  description: Methods for working with students and their data.
-schemes:
-- https
-- http
+  - name: students
+    description: Methods for working with students and their data.
 paths:
   /students:
     get:
       tags:
-      - students
+        - students
       summary: Get a list of all registered students' addresses
       operationId: getStudents
       parameters:
@@ -29,771 +35,842 @@ paths:
           name: course
           description: Return only students attending the given course
           required: false
-          type: integer
-          format: int32
-      produces:
-      - application/json
+          schema:
+            type: integer
+            format: int32
       responses:
         200:
           description: A list of all registered students' addresses
-          schema:
-            type: array
-            items:
-              $ref: "#/definitions/Student"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Student'
         401:
-          $ref: "#/responses/Unauthorized"
+          $ref: '#/components/responses/Unauthorized'
     post:
       tags:
-      - students
+        - students
       summary: Add a new student address to a database
       operationId: addStudent
-      consumes:
-      - application/json
-      produces:
-      - application/json
-      parameters:
-      - in: body
-        name: body
-        description: Student object that needs to be added to the system
-        required: true
-        schema:
-          $ref: "#/definitions/Student"
       responses:
         201:
           description: successful operation
         400:
           description: Invalid input
-          schema:
-            $ref: "#/definitions/ErrResponse"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
         401:
-          $ref: "#/responses/Unauthorized"
-
+          $ref: '#/components/responses/Unauthorized'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Student'
+        description: Student object that needs to be added to the system
+        required: true
   /courses:
     get:
       tags:
-      - courses
+        - courses
       summary: Get all courses
       operationId: getCourses
-      produces:
-      - application/json
       parameters:
-      - in: query
-        name: student
-        description: Return only courses which student with given address attends
-        required: false
-        type: string
-        format: byte
+        - in: query
+          name: student
+          description: Return only courses which student with given address attends
+          required: false
+          schema:
+            type: string
+            format: byte
       responses:
         200:
           description: A list of all courses
-          schema:
-            type: array
-            items:
-              $ref: "#/definitions/Course"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Course'
         401:
-          $ref: "#/responses/Unauthorized"
+          $ref: '#/components/responses/Unauthorized'
     post:
       tags:
-      - courses
+        - courses
       summary: Add a new course to a database
       operationId: addCourse
-      consumes:
-      - application/json
-      produces:
-      - application/json
-      parameters:
-      - in: body
-        name: body
-        description: Course object that needs to be added to the system
-        required: true
-        schema:
-          $ref: "#/definitions/Course"
       responses:
         201:
           description: successful operation
-          schema:
-            $ref: "#/definitions/CourseId"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CourseId'
         400:
           description: Invalid input
-          schema:
-            $ref: "#/definitions/ErrResponse"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
         401:
-          $ref: "#/responses/Unauthorized"
-
+          $ref: '#/components/responses/Unauthorized'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Course'
+        description: Course object that needs to be added to the system
+        required: true
   /students/{studentAddr}:
     delete:
       tags:
-      - students
+        - students
       summary: Remove a student from a database
-      description: Removes a student only if he's not currently attending any course. We will not automatically perform a cascade deletion, because it will make this operation particularly dangerous. If a student attends any course, an error will be raised.
+      description: >-
+        Removes a student only if he's not currently attending any course. We
+        will not automatically perform a cascade deletion, because it will make
+        this operation particularly dangerous. If a student attends any course,
+        an error will be raised.
       operationId: deleteStudent
-      produces:
-      - application/json
       parameters:
-      - $ref: "#/parameters/StudentAddr"
+        - $ref: '#/components/parameters/StudentAddr'
       responses:
         200:
           description: successful operation
-          schema:
-            $ref: "#/definitions/Student"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Student'
         400:
           description: Invalid address value
-          schema:
-            $ref: "#/definitions/ErrResponse"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
+        401:
+          $ref: '#/components/responses/Unauthorized'
         403:
           description: Student cannot be deleted, as they are currently attending a course
-          schema:
-            $ref: "#/definitions/ErrResponse"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
         404:
           description: Student with given address not found
-          schema:
-            $ref: "#/definitions/ErrResponse"
-        401:
-          $ref: "#/responses/Unauthorized"
-
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
   /students/{studentAddr}/courses:
     post:
       tags:
-      - students
+        - students
       summary: Enroll a student in a new course
       description: Given existing student and course, enroll the student to the course.
       operationId: enrollStudentToCourse
-      produces:
-      - application/json
       parameters:
-      - $ref: "#/parameters/StudentAddr"
-      - in: body
-        name: courseId
-        description: Course to enroll
-        required: true
-        schema:
-          $ref: "#/definitions/EnrollStudentToCourse"
+        - $ref: '#/components/parameters/StudentAddr'
       responses:
         201:
           description: successful operation
         400:
           description: Student address value or request body is invalid
-          schema:
-            $ref: "#/definitions/ErrResponse"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
+        401:
+          $ref: '#/components/responses/Unauthorized'
         403:
           description: Course with given ID does not exist
-          schema:
-            $ref: "#/definitions/ErrResponse"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
         404:
           description: Student with given address not found
-          schema:
-            $ref: "#/definitions/ErrResponse"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
         409:
           description: Student is already enrolled on this course
-          schema:
-            $ref: "#/definitions/ErrResponse"
-        401:
-          $ref: "#/responses/Unauthorized"
-
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EnrollStudentToCourse'
+        description: Course to enroll
+        required: true
   /students/{studentAddr}/assignments:
     post:
       tags:
-      - students
+        - students
       summary: Assign an assignment to a student
       description: Assigns a new assignment to a student in scope of given course.
       operationId: assignToStudent
-      produces:
-      - application/json
-      consumes:
-      - application/json
       parameters:
-      - $ref: "#/parameters/StudentAddr"
-      - in: body
-        name: assignmentHash
-        description: Assignment to assign
-        required: true
-        schema:
-          $ref: "#/definitions/AssignToStudent"
+        - $ref: '#/components/parameters/StudentAddr'
       responses:
         201:
           description: successful operation
         400:
           description: Student address value or request body is invalid
-          schema:
-            $ref: "#/definitions/ErrResponse"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
+        401:
+          $ref: '#/components/responses/Unauthorized'
         403:
           description: Assignment with given hash does not exist
-          schema:
-            $ref: "#/definitions/ErrResponse"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
         404:
           description: Student with given address not found
-          schema:
-            $ref: "#/definitions/ErrResponse"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
         409:
           description: Student is already subscribed on assignment
-          schema:
-            $ref: "#/definitions/ErrResponse"
-        401:
-          $ref: "#/responses/Unauthorized"
-
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssignToStudent'
+        description: Assignment to assign
+        required: true
   /students/{studentAddr}/assignments/{assignmentHash}:
     delete:
       tags:
-      - students
+        - students
       summary: Unassign an assignment from a student
-      description: If given student has been assigned a given assignment, then unassigns it from them, otherwise raises error.
+      description: >-
+        If given student has been assigned a given assignment, then unassigns it
+        from them, otherwise raises error.
       operationId: unassignFromStudent
-      produces:
-      - application/json
       parameters:
-      - $ref: "#/parameters/StudentAddr"
-      - $ref: "#/parameters/AssignmentHash"
+        - $ref: '#/components/parameters/StudentAddr'
+        - $ref: '#/components/parameters/AssignmentHash'
       responses:
         400:
           description: Student address or assignment hash are invalid
-          schema:
-            $ref: "#/definitions/ErrResponse"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
+        401:
+          $ref: '#/components/responses/Unauthorized'
         404:
           description: Given student didn't have given assignment
-          schema:
-            $ref: "#/definitions/ErrResponse"
-        401:
-          $ref: "#/responses/Unauthorized"
-
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
   /submissions:
     get:
       tags:
-      - submissions
+        - submissions
       summary: Get all submissions
-      description: Gets a list of all submissions done by all students. This method is inaccessible by students.
+      description: >-
+        Gets a list of all submissions done by all students. This method is
+        inaccessible by students.
       operationId: getSubmissions
       parameters:
-      - in: query
-        name: course
-        description: Return only submissions related to course with given ID
-        required: false
-        type: integer
-        format: int32
-      - in: query
-        name: student
-        description: Return only submissions submitted by student with given address
-        required: false
-        type: string
-        format: byte
-      - in: query
-        name: assignment
-        description: Return only submissions for given assignment
-        required: false
-        type: string
-        format: byte
-      produces:
-      - application/json
+        - in: query
+          name: course
+          description: Return only submissions related to course with given ID
+          required: false
+          schema:
+            type: integer
+            format: int32
+        - in: query
+          name: student
+          description: Return only submissions submitted by student with given address
+          required: false
+          schema:
+            type: string
+            format: byte
+        - in: query
+          name: assignment
+          description: Return only submissions for given assignment
+          required: false
+          schema:
+            type: string
+            format: byte
       responses:
         200:
           description: successful operation
-          schema:
-            type: array
-            items:
-              $ref: "#/definitions/Submission"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Submission'
         401:
-          $ref: "#/responses/Unauthorized"
-
+          $ref: '#/components/responses/Unauthorized'
   /submissions/{submissionHash}:
     get:
       tags:
-      - submissions
+        - submissions
       summary: Get info about a submission
       description: Gets a submission data by given submission hash.
       operationId: getSubmission
-      produces:
-      - application/json
       parameters:
-      - $ref: "#/parameters/SubmissionHash"
+        - $ref: '#/components/parameters/SubmissionHash'
       responses:
         200:
           description: successful operation
-          schema:
-            $ref: "#/definitions/Submission"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Submission'
         400:
           description: Submission hash value is invalid
-          schema:
-            $ref: "#/definitions/ErrResponse"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
+        401:
+          $ref: '#/components/responses/Unauthorized'
         404:
           description: Submission with given hash not found
-          schema:
-            $ref: "#/definitions/ErrResponse"
-        401:
-          $ref: "#/responses/Unauthorized"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
     delete:
       tags:
-      - submissions
+        - submissions
       summary: Delete a submission
-      description: Deletes a submission from a database. Only ungraded submissions can be deleted.
+      description: >-
+        Deletes a submission from a database. Only ungraded submissions can be
+        deleted.
       operationId: deleteSubmission
-      produces:
-      - application/json
       parameters:
-      - $ref: "#/parameters/SubmissionHash"
+        - $ref: '#/components/parameters/SubmissionHash'
       responses:
         200:
           description: successful operation
         400:
           description: Submission hash value is invalid
-          schema:
-            $ref: "#/definitions/ErrResponse"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
+        401:
+          $ref: '#/components/responses/Unauthorized'
         403:
           description: Submission has already been graded.
-          schema:
-            $ref: "#/definitions/ErrResponse"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
         404:
           description: Submission with given hash not found
-          schema:
-            $ref: "#/definitions/ErrResponse"
-        401:
-          $ref: "#/responses/Unauthorized"
-
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
   /grades:
     get:
       tags:
-      - grades
+        - grades
       summary: Get all grades
       description: Gets a list of all grades performed by all students.
       operationId: getGrades
-      produces:
-      - application/json
       parameters:
-      - in: query
-        name: course
-        description: Return only grades related to course with given ID
-        required: false
-        type: integer
-        format: int32
-      - in: query
-        name: student
-        description: Return only grades for student with given address
-        required: false
-        type: string
-        format: byte
-      - in: query
-        name: assignment
-        description: Return only grades for given assignment
-        required: false
-        type: string
-        format: byte
-      - in: query
-        name: isFinal
-        description: Return only grades for final/non-final assignments of the course
-        required: false
-        type: boolean
+        - in: query
+          name: course
+          description: Return only grades related to course with given ID
+          required: false
+          schema:
+            type: integer
+            format: int32
+        - in: query
+          name: student
+          description: Return only grades for student with given address
+          required: false
+          schema:
+            type: string
+            format: byte
+        - in: query
+          name: assignment
+          description: Return only grades for given assignment
+          required: false
+          schema:
+            type: string
+            format: byte
+        - in: query
+          name: isFinal
+          description: Return only grades for final/non-final assignments of the course
+          required: false
+          schema:
+            type: boolean
       responses:
         200:
           description: successful operation
-          schema:
-            type: array
-            items:
-              $ref: "#/definitions/Grade"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Grade'
         401:
-          $ref: "#/responses/Unauthorized"
+          $ref: '#/components/responses/Unauthorized'
     post:
       tags:
-      - grades
+        - grades
       summary: Post a new grade
       description: Posts a new grade with a given body.
       operationId: postGrade
-      produces:
-      - application/json
-      consumes:
-      - application/json
-      parameters:
-      - in: body
-        name: grade
-        description: A grade
-        required: true
-        schema:
-          $ref: "#/definitions/Grade"
       responses:
         201:
           description: successful operation
-          schema:
-            $ref: "#/definitions/Grade"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Grade'
         400:
           description: Request body is invalid
-          schema:
-            $ref: "#/definitions/ErrResponse"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
         401:
-          $ref: "#/responses/Unauthorized"
-
+          $ref: '#/components/responses/Unauthorized'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Grade'
+        description: A grade
+        required: true
   /assignments:
     get:
       tags:
-      - assignments
+        - assignments
       summary: Get all assignments
-      description: Gets a list of all student assignments. Filter parameters are used to specify specific course or student.
+      description: >-
+        Gets a list of all student assignments. Filter parameters are used to
+        specify specific course or student.
       operationId: getAssignments
       parameters:
-      - in: query
-        name: course
-        description: Return only assignments related to course with given ID
-        required: false
-        type: integer
-        format: int32
-      - in: query
-        name: student
-        description: Return only assignments assigned to a student with given address
-        required: false
-        type: string
-        format: byte
-      - in: query
-        name: isFinal
-        description: Return only final/non-final assignments of the course
-        required: false
-        type: boolean
-      produces:
-      - application/json
+        - in: query
+          name: course
+          description: Return only assignments related to course with given ID
+          required: false
+          schema:
+            type: integer
+            format: int32
+        - in: query
+          name: student
+          description: Return only assignments assigned to a student with given address
+          required: false
+          schema:
+            type: string
+            format: byte
+        - in: query
+          name: isFinal
+          description: Return only final/non-final assignments of the course
+          required: false
+          schema:
+            type: boolean
       responses:
         200:
           description: successful operation
-          schema:
-            type: array
-            items:
-              $ref: "#/definitions/Assignment"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Assignment'
         401:
-          $ref: "#/responses/Unauthorized"
+          $ref: '#/components/responses/Unauthorized'
     post:
       tags:
-      - assignments
+        - assignments
       summary: Add assignment to a course
       operationId: addCourseAssignment
       parameters:
-        - in: body
-          name: Assignment
-          description: An assignment
-          required: true
-          schema:
-            $ref: "#/definitions/AssignmentReq"
         - in: query
           name: autoAssign
-          description: Automatically subscribe all students attending related course to new assignment.
+          description: >-
+            Automatically subscribe all students attending related course to new
+            assignment.
           required: false
-          type: boolean
-      produces:
-      - application/json
+          schema:
+            type: boolean
       responses:
         201:
           description: successful operation
         400:
           description: Request body is invalid
-          schema:
-            $ref: "#/definitions/ErrResponse"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
         401:
-          $ref: "#/responses/Unauthorized"
-
+          $ref: '#/components/responses/Unauthorized'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssignmentReq'
+        description: An assignment
+        required: true
   /proofs:
     get:
       tags:
-      - proofs
+        - proofs
       summary: Get Merkle proofs of grades (i. e. private blocks or parts of them)
-      description: Gets all private transactions related with corresponding Merkle proofs, grouped by blocks.
+      description: >-
+        Gets all private transactions related with corresponding Merkle proofs,
+        grouped by blocks.
       operationId: getProofs
-      produces:
-      - application/json
       parameters:
-      - in: query
-        name: course
-        description: Return only proofs related to the course with given ID
-        required: false
-        type: integer
-        format: int32
-      - in: query
-        name: student
-        description: Return only proofs related to the student with given address
-        required: false
-        type: string
-        format: byte
-      - in: query
-        name: assignment
-        description: Return proofs only for given assignment
-        required: false
-        type: string
-        format: byte
+        - in: query
+          name: course
+          description: Return only proofs related to the course with given ID
+          required: false
+          schema:
+            type: integer
+            format: int32
+        - in: query
+          name: student
+          description: Return only proofs related to the student with given address
+          required: false
+          schema:
+            type: string
+            format: byte
+        - in: query
+          name: assignment
+          description: Return proofs only for given assignment
+          required: false
+          schema:
+            type: string
+            format: byte
       responses:
         200:
           description: successful operation
-          schema:
-            $ref: "#/definitions/Proofs"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Proofs'
         400:
           description: Student address value is invalid
-          schema:
-            $ref: "#/definitions/ErrResponse"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
+        401:
+          $ref: '#/components/responses/Unauthorized'
         404:
           description: Student with given address not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
+components:
+  parameters:
+    StudentAddr:
+      in: path
+      name: studentAddr
+      description: Student's Disciplina address
+      required: true
+      schema:
+        type: string
+        format: byte
+    CourseId:
+      in: path
+      name: courseId
+      description: Course ID
+      required: true
+      schema:
+        type: integer
+        format: int32
+    AssignmentHash:
+      in: path
+      name: assignmentHash
+      description: Assignment hash
+      required: true
+      schema:
+        type: string
+        format: byte
+    SubmissionHash:
+      in: path
+      name: submissionHash
+      description: Submission hash
+      required: true
+      schema:
+        type: string
+        format: byte
+  responses:
+    Unauthorized:
+      description: Unauthorized
+      headers:
+        WWW-Authenticate:
           schema:
-            $ref: "#/definitions/ErrResponse"
-        401:
-          $ref: "#/responses/Unauthorized"
+            type: string
+  securitySchemes:
+    EducatorAuth:
+      type: apiKey
+      name: Authorization
+      in: header
+      description: >
+        Authentication system requires a JWS in Authorization header in `Bearer
+        ` format. Example header:
 
-securityDefinitions:
-  EducatorAuth:
-    type: apiKey
-    name: Authorization
-    in: header
-    description: |
-      Authentication system requires a JWS in Authorization header in `Bearer <JWS>` format. Example header:
-      ```
-      Authorization: Bearer eyJhbGciOiJFZERTQSIsImp3ayI6eyJjcnYiOiJFZDI1NTE5IiwieCI6InFlU3ZrUzZnaW9CcjRlX2I2em8zTWlPT1NYQW90VjkwdDVLajNsMjh5cm8iLCJrdHkiOiJPS1AifX0.eyJwYXRoIjoiL2FwaS9lZHVjYXRvci92MS9zdHVkZW50cyIsInRpbWUiOiIyMDI1LTAxLTAxVDAwOjAwOjAwWiJ9.0_sRvkXTaJTlnLHSjReH70VNFOLx0kdGHDmiDWhUr6H25UCvc5kPD6qn9pDlUwe0uKMpQCGIt_v4hnwWcfVlDA
-      ```
+        ```
 
-      JWS header MUST contain "jwk" parameter ([RFC7515, section 4.1.3](https://tools.ietf.org/html/rfc7515#section-4.1.3)) with a
-      public JWK corresponding to the signature. JWK MUST have key type "OKP" and curve type "Ed25519", public key parameter "x"
-      should be encoded via base64Url (accordingly to [RFC8037](https://tools.ietf.org/html/rfc8037)). Example JWK:
-      ```
-      { "kty": "OKP", "crv": "Ed25519", "x": "2qbm2mPrVVW_yFsHUMzNt3hLdalGLTN8ucI4e-Cn6fI" }
-      ```
-      This JWK represents a Disciplina public key of an Educator. The whole JWS should be created via the Educator's secret key.
-      JWS payload MUST be a JSON object with fields "path" and "time". Field "path" should contain the endpoint URL path and "time"
-      should contain the time the request has been made in [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) format. Example JWS
-      payload:
-      ```
-      {
-        "time": "2025-01-01T00:00:00.000000000Z",
-        "path": "/api/educator/v1/students"
-      }
-      ```
-      If the request's raw path doesn't match the one in "path" or "time" is more than 5 minutes behind the server current time,
-      the authentication process will fail.
+        Authorization: Bearer
+        eyJhbGciOiJFZERTQSIsImp3ayI6eyJjcnYiOiJFZDI1NTE5IiwieCI6InFlU3ZrUzZnaW9CcjRlX2I2em8zTWlPT1NYQW90VjkwdDVLajNsMjh5cm8iLCJrdHkiOiJPS1AifX0.eyJwYXRoIjoiL2FwaS9lZHVjYXRvci92MS9zdHVkZW50cyIsInRpbWUiOiIyMDI1LTAxLTAxVDAwOjAwOjAwWiJ9.0_sRvkXTaJTlnLHSjReH70VNFOLx0kdGHDmiDWhUr6H25UCvc5kPD6qn9pDlUwe0uKMpQCGIt_v4hnwWcfVlDA
 
-responses:
-  Unauthorized:
-    description: Unauthorized
-    headers:
-      WWW-Authenticate:
-        type: string
+        ```
 
-security:
-  - EducatorAuth: []
 
-definitions:
-  Hash:
-    type: string
-    format: byte
-    description: Hex encoded blake2b (256 bits) hash
-  Address:
-    type: string
-    format: byte
-  Time:
-    type: string
-    format: date-time
-  Student:
-    type: object
-    required:
-    - addr
-    properties:
-      addr:
-        $ref: "#/definitions/Address"
-  CourseId:
-    type: integer
-    format: int32
-  Course:
-    type: object
-    required:
-    - desc
-    - subjects
-    properties:
-      id:
-        $ref: "#/definitions/CourseId"
-      desc:
-        type: string
-      subjects:
-        type: array
-        items:
-          $ref: "#/definitions/Subject"
-  EnrollStudentToCourse:
-    required:
-    - course
-    properties:
-      course:
-        $ref: "#/definitions/CourseId"
-  Assignment:
-    type: object
-    required:
-    - hash
-    - courseId
-    - contentsHash
-    - isFinal
-    - desc
-    properties:
-      hash:
-        $ref: "#/definitions/Hash"
-      courseId:
-        $ref: "#/definitions/CourseId"
-      contentsHash:
-        $ref: "#/definitions/Hash"
-      isFinal:
-        type: boolean
-      desc:
-        type: string
-  AssignmentReq:
-    type: object
-    required:
-    - courseId
-    - contentsHash
-    - isFinal
-    - desc
-    properties:
-      courseId:
-        $ref: "#/definitions/CourseId"
-      contentsHash:
-        $ref: "#/definitions/Hash"
-      isFinal:
-        type: boolean
-      desc:
-        type: string
-  AssignToStudent:
-    type: object
-    required:
-    - assignmentHash
-    properties:
-      assignmentHash:
-        $ref: "#/definitions/Hash"
-  Submission:
-    type: object
-    required:
-    - hash
-    - contentsHash
-    - assignmentHash
-    - studentAddr
-    - witness
-    properties:
-      hash:
-        $ref: "#/definitions/Hash"
-      contentsHash:
-        $ref: "#/definitions/Hash"
-      assignment:
-        $ref: "#/definitions/Assignment"
-      studentAddr:
-        $ref: "#/definitions/Address"
-      witness:
-        type: string
-        format: binary
-  Grade:
-    type: object
-    required:
-    - submissionHash
-    - grade
-    properties:
-      submissionHash:
-        $ref: "#/definitions/Hash"
-      grade:
-        type: integer
-        format: int32
-      timestamp:
-        $ref: "#/definitions/Time"
-        readOnly: true
-      hasProof:
-        type: boolean
-        readOnly: true
+        JWS header MUST contain "jwk" parameter ([RFC7515, section
+        4.1.3](https://tools.ietf.org/html/rfc7515#section-4.1.3)) with a
 
-  Transaction:
-    type: object
-    required:
-    - submission
-    - grade
-    - timestamp
-    properties:
-      submission:
-        $ref: "#/definitions/Submission"
-      grade:
-        type: integer
-        format: int32
-      timestamp:
-        $ref: "#/definitions/Time"
+        public JWK corresponding to the signature. JWK MUST have key type "OKP"
+        and curve type "Ed25519", public key parameter "x"
 
-  BlkProof:
-    type: object
-    required:
-    - mtreeSerialized
-    - txs
-    properties:
-      mtreeSerialized:
-        type: string
-        format: binary
-      txs:
-        type: array
-        items:
-          $ref: "#/definitions/Transaction"
+        should be encoded via base64Url (accordingly to
+        [RFC8037](https://tools.ietf.org/html/rfc8037)). Example JWK:
 
-  Proofs:
-    type: array
-    items:
-      $ref: "#/definitions/BlkProof"
+        ```
 
-  Subject:
-    type: integer
-    format: int32
-  ErrResponse:
-    type: object
-    required:
-      - error
-    properties:
-      error:
-        type: string
-        enum:
-          - InvalidFormat
+        { "kty": "OKP", "crv": "Ed25519", "x":
+        "2qbm2mPrVVW_yFsHUMzNt3hLdalGLTN8ucI4e-Cn6fI" }
 
-          - StudentNotFound
-          - CourseNotFound
-          - AssignmentNotFound
+        ```
 
-          - StudentAlreadyExists
-          - CourseAlreadyExists
-          - AssignmentAlreadyExists
+        This JWK represents a Disciplina public key of an Educator. The whole
+        JWS should be created via the Educator's secret key.
 
-          - StudentDoesNotAttendCourse
-          - StudentIsActive
-          - StudentHasNoAssignment
-        description: >-
-          Error type:
-            * `InvalidFormat` - Failed to deserialise one of parameters.
+        JWS payload MUST be a JSON object with fields "path" and "time". Field
+        "path" should contain the endpoint URL path and "time"
 
-            * `StudentNotFound` - Specified student does not exist.
-            * `CourseNotFound` - Specified course does not exist.
-            * `AssignmentNotFound` - Specified assignment does not exist.
+        should contain the time the request has been made in
+        [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) format. Example JWS
 
-            * `StudentAlreadyExists` - Student being added already exists.
-            * `CourseAlreadyExists` - Course with such id already exists.
-            * `AssignmentAlreadyExists` - Exactly the same assignment already exists.
-            * `StudentDoesNotAttendCourse` - Student does not attend the course.
+        payload:
 
-            * `StudentAlreadyAttendsCourse` - Student already attends given course.
-            * `StudentAlreadyHasAssignment` - Student is already subscribed on given assignment.
-            * `StudentHasNoAssignment` - Given student didn't have given assignment.
+        ```
 
-            * `StudentIsActive` - Can not delete a student because he is attending a course.
-            * `DeletingGradedSubmission` - Attempt to delete an already graded submission.
-parameters:
-  StudentAddr:
-    in: path
-    name: studentAddr
-    description: Student's Disciplina address
-    required: true
-    type: string
-    format: byte
-  CourseId:
-    in: path
-    name: courseId
-    description: Course ID
-    required: true
-    type: integer
-    format: int32
-  AssignmentHash:
-    in: path
-    name: assignmentHash
-    description: Assignment hash
-    required: true
-    type: string
-    format: byte
-  SubmissionHash:
-    in: path
-    name: submissionHash
-    description: Submission hash
-    required: true
-    type: string
-    format: byte
-externalDocs:
-  description: Find out more about Swagger
-  url: http://swagger.io
+        {
+          "time": "2025-01-01T00:00:00.000000000Z",
+          "path": "/api/educator/v1/students"
+        }
+
+        ```
+
+        If the request's raw path doesn't match the one in "path" or "time" is
+        more than 5 minutes behind the server current time,
+
+        the authentication process will fail.
+  schemas:
+    Hash:
+      type: string
+      format: byte
+      description: Hex encoded blake2b (256 bits) hash
+    Address:
+      type: string
+      format: byte
+    Time:
+      type: string
+      format: date-time
+    Student:
+      type: object
+      required:
+        - addr
+      properties:
+        addr:
+          $ref: '#/components/schemas/Address'
+    CourseId:
+      type: integer
+      format: int32
+    Course:
+      type: object
+      required:
+        - desc
+        - subjects
+      properties:
+        id:
+          $ref: '#/components/schemas/CourseId'
+        desc:
+          type: string
+        subjects:
+          type: array
+          items:
+            $ref: '#/components/schemas/Subject'
+    EnrollStudentToCourse:
+      required:
+        - course
+      properties:
+        course:
+          $ref: '#/components/schemas/CourseId'
+    Assignment:
+      type: object
+      required:
+        - hash
+        - courseId
+        - contentsHash
+        - isFinal
+        - desc
+      properties:
+        hash:
+          $ref: '#/components/schemas/Hash'
+        courseId:
+          $ref: '#/components/schemas/CourseId'
+        contentsHash:
+          $ref: '#/components/schemas/Hash'
+        isFinal:
+          type: boolean
+        desc:
+          type: string
+    AssignmentReq:
+      type: object
+      required:
+        - courseId
+        - contentsHash
+        - isFinal
+        - desc
+      properties:
+        courseId:
+          $ref: '#/components/schemas/CourseId'
+        contentsHash:
+          $ref: '#/components/schemas/Hash'
+        isFinal:
+          type: boolean
+        desc:
+          type: string
+    AssignToStudent:
+      type: object
+      required:
+        - assignmentHash
+      properties:
+        assignmentHash:
+          $ref: '#/components/schemas/Hash'
+    Submission:
+      type: object
+      required:
+        - hash
+        - contentsHash
+        - assignmentHash
+        - studentAddr
+        - witness
+      properties:
+        hash:
+          $ref: '#/components/schemas/Hash'
+        contentsHash:
+          $ref: '#/components/schemas/Hash'
+        assignment:
+          $ref: '#/components/schemas/Assignment'
+        studentAddr:
+          $ref: '#/components/schemas/Address'
+        witness:
+          type: string
+          format: binary
+    Grade:
+      type: object
+      required:
+        - submissionHash
+        - grade
+      properties:
+        submissionHash:
+          $ref: '#/components/schemas/Hash'
+        grade:
+          type: integer
+          format: int32
+        timestamp:
+          $ref: '#/components/schemas/Time'
+          readOnly: true
+        hasProof:
+          type: boolean
+          readOnly: true
+    Transaction:
+      type: object
+      required:
+        - submission
+        - grade
+        - timestamp
+      properties:
+        submission:
+          $ref: '#/components/schemas/Submission'
+        grade:
+          type: integer
+          format: int32
+        timestamp:
+          $ref: '#/components/schemas/Time'
+    BlkProof:
+      type: object
+      required:
+        - mtreeSerialized
+        - txs
+      properties:
+        mtreeSerialized:
+          type: string
+          format: binary
+        txs:
+          type: array
+          items:
+            $ref: '#/components/schemas/Transaction'
+    Proofs:
+      type: array
+      items:
+        $ref: '#/components/schemas/BlkProof'
+    Subject:
+      type: integer
+      format: int32
+    ErrResponse:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          enum:
+            - InvalidFormat
+            - StudentNotFound
+            - CourseNotFound
+            - AssignmentNotFound
+            - StudentAlreadyExists
+            - CourseAlreadyExists
+            - AssignmentAlreadyExists
+            - StudentDoesNotAttendCourse
+            - StudentIsActive
+            - StudentHasNoAssignment
+          description: |-
+            Error type:
+              * `InvalidFormat` - Failed to deserialise one of parameters.
+
+              * `StudentNotFound` - Specified student does not exist.
+              * `CourseNotFound` - Specified course does not exist.
+              * `AssignmentNotFound` - Specified assignment does not exist.
+
+              * `StudentAlreadyExists` - Student being added already exists.
+              * `CourseAlreadyExists` - Course with such id already exists.
+              * `AssignmentAlreadyExists` - Exactly the same assignment already exists.
+              * `StudentDoesNotAttendCourse` - Student does not attend the course.
+
+              * `StudentAlreadyAttendsCourse` - Student already attends given course.
+              * `StudentAlreadyHasAssignment` - Student is already subscribed on given assignment.
+              * `StudentHasNoAssignment` - Given student didn't have given assignment.
+
+              * `StudentIsActive` - Can not delete a student because he is attending a course.
+              * `DeletingGradedSubmission` - Attempt to delete an already graded submission.

--- a/specs/disciplina/educator/api/student.yaml
+++ b/specs/disciplina/educator/api/student.yaml
@@ -1,28 +1,35 @@
-swagger: "2.0"
+openapi: 3.0.0
 info:
-  description: "This is an HTTP API for interacting with Disciplina Educator node from Student side. It is used by Student application to receive info about assignments and grades, submit submissions and fetch proofs of grades from Educator."
+  description: >-
+    This is an HTTP API for interacting with Disciplina Educator node from
+    Student side. It is used by Student application to receive info about
+    assignments and grades, submit submissions and fetch proofs of grades from
+    Educator.
   version: 0.1.0
   title: Disciplina Student API
-  termsOfService: "https://disciplina.io/tnc.pdf"
+  termsOfService: 'https://disciplina.io/tnc.pdf'
   contact:
     email: hi@serokell.io
   license:
     name: Apache 2.0
-    url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-host: "localhost:8090"
-basePath: /api/student/v1
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+externalDocs:
+  description: Find out more about Swagger
+  url: 'http://swagger.io'
+servers:
+  - url: 'https://localhost:8090/api/student/v1'
+  - url: 'http://localhost:8090/api/student/v1'
+security:
+  - StudentAuth: []
 tags:
   - name: courses
-    description: "Methods for working with student's courses."
+    description: Methods for working with student's courses.
   - name: assignments
-    description: "Methods for working with student's assignments."
+    description: Methods for working with student's assignments.
   - name: submissions
-    description: "Methods for working with student's submissions."
+    description: Methods for working with student's submissions.
   - name: proofs
-    description: "Methods for working with private transactions and grade's proofs"
-schemes:
-  - https
-  - http
+    description: Methods for working with private transactions and grade's proofs
 paths:
   /courses:
     get:
@@ -35,20 +42,23 @@ paths:
         - in: query
           name: enrolled
           required: false
-          description: If set to `true`, show only courses in which student is currently enrolled, if set to `false` - show only available courses, otherwise should all of them.
-          type: boolean
-      produces:
-        - application/json
+          description: >-
+            If set to `true`, show only courses in which student is currently
+            enrolled, if set to `false` - show only available courses, otherwise
+            should all of them.
+          schema:
+            type: boolean
       responses:
         200:
           description: successful operation
-          schema:
-            type: array
-            items:
-              $ref: '#/definitions/Course'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Course'
         401:
-          $ref: "#/responses/Unauthorized"
-
+          $ref: '#/components/responses/Unauthorized'
   /courses/{courseId}:
     get:
       tags:
@@ -57,477 +67,514 @@ paths:
       description: Gets all info about the given course.
       operationId: getCourse
       parameters:
-        - $ref: '#/parameters/CourseIdPath'
-      produces:
-        - application/json
+        - $ref: '#/components/parameters/CourseIdPath'
       responses:
         200:
           description: successful operation
-          schema:
-            $ref: '#/definitions/Course'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Course'
+        401:
+          $ref: '#/components/responses/Unauthorized'
         404:
           description: Course with given ID not found
-        401:
-          $ref: "#/responses/Unauthorized"
-
   /assignments:
     get:
       tags:
         - assignments
       summary: Get student\'s assignments
-      description: Gets a list of student\'s assignments. Filter parameters are used to specify
-        specific course, type, etc.
+      description: >-
+        Gets a list of student\'s assignments. Filter parameters are used to
+        specify specific course, type, etc.
       operationId: getAssignments
       parameters:
-        - $ref: '#/parameters/CourseId'
-        - $ref: '#/parameters/DocumentType'
+        - $ref: '#/components/parameters/CourseId'
+        - $ref: '#/components/parameters/DocumentType'
         - in: query
           name: final
           required: false
           description: Select only final assignments
-          type: boolean
-      produces:
-        - application/json
+          schema:
+            type: boolean
       responses:
         200:
           description: successful operation
-          schema:
-            type: array
-            items:
-              $ref: '#/definitions/Assignment'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Assignment'
         401:
-          $ref: "#/responses/Unauthorized"
-
+          $ref: '#/components/responses/Unauthorized'
   /assignments/{assignmentHash}:
     get:
       tags:
         - assignments
       summary: Get info about an assignment
-      description: Gets an assignment info by given submission hash. Returns 404 if a student tries to get an assignment which is not assigned to them.
+      description: >-
+        Gets an assignment info by given submission hash. Returns 404 if a
+        student tries to get an assignment which is not assigned to them.
       operationId: getAsssignment
       parameters:
-        - $ref: '#/parameters/AssignmentHashPath'
-      produces:
-        - application/json
+        - $ref: '#/components/parameters/AssignmentHashPath'
       responses:
         200:
           description: successful operation
-          schema:
-            $ref: '#/definitions/Assignment'
-        404:
-          description: Assignment with given wasn not found (or a user has no rights to look it up)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Assignment'
         401:
-          $ref: "#/responses/Unauthorized"
-
+          $ref: '#/components/responses/Unauthorized'
+        404:
+          description: >-
+            Assignment with given wasn not found (or a user has no rights to
+            look it up)
   /submissions:
     get:
       tags:
         - submissions
       summary: Get student\'s submissions
-      description: Gets a list of student\'s submissions. Filter parameters are used to specify
-        specific course, assignment, etc.
+      description: >-
+        Gets a list of student\'s submissions. Filter parameters are used to
+        specify specific course, assignment, etc.
       operationId: getSubmissions
       parameters:
-        - $ref: '#/parameters/CourseId'
-        - $ref: '#/parameters/AssignmentHash'
-        - $ref: '#/parameters/DocumentType'
-      produces:
-        - application/json
+        - $ref: '#/components/parameters/CourseId'
+        - $ref: '#/components/parameters/AssignmentHash'
+        - $ref: '#/components/parameters/DocumentType'
       responses:
-        '200':
+        200:
           description: successful operation
-          schema:
-            type: array
-            items:
-              $ref: '#/definitions/Submission'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Submission'
         401:
-          $ref: "#/responses/Unauthorized"
+          $ref: '#/components/responses/Unauthorized'
     post:
       tags:
         - submissions
       summary: Make a new submission
-      description: Posts a new submission with a given body. Request body should contain valid student\'s signature of submission contents, otherwise an error will be raised.
+      description: >-
+        Posts a new submission with a given body. Request body should contain
+        valid student\'s signature of submission contents, otherwise an error
+        will be raised.
       operationId: makeSubmission
-      produces:
-        - application/json
-      consumes:
-        - application/json
-      parameters:
-        - in: body
-          name: submission
-          description: A submission
-          required: true
-          schema:
-            $ref: '#/definitions/SignedSubmission'
       responses:
-        '201':
+        201:
           description: successful operation
-          schema:
-            $ref: '#/definitions/Submission'
-        '403':
-          description: Either submission body or submission signature is invalid
-          schema:
-            $ref: '#/definitions/ErrResponse'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Submission'
         401:
-          $ref: "#/responses/Unauthorized"
-
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          description: Either submission body or submission signature is invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SignedSubmission'
+        description: A submission
+        required: true
   /submissions/{submissionHash}:
     get:
       tags:
         - submissions
       summary: Get info about a submission
-      description: Gets a submission data by given submission hash. Returns a 404 if a student tries to get a submission which is not their own.
+      description: >-
+        Gets a submission data by given submission hash. Returns a 404 if a
+        student tries to get a submission which is not their own.
       operationId: getSubmission
-      produces:
-        - application/json
       parameters:
-        - $ref: '#/parameters/SubmissionHashPath'
+        - $ref: '#/components/parameters/SubmissionHashPath'
       responses:
-        '200':
+        200:
           description: successful operation
-          schema:
-            $ref: '#/definitions/Submission'
-        '404':
-          description: Submission with given hash was not found (or a user has no rights to look it up)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Submission'
         401:
-          $ref: "#/responses/Unauthorized"
+          $ref: '#/components/responses/Unauthorized'
+        404:
+          description: >-
+            Submission with given hash was not found (or a user has no rights to
+            look it up)
     delete:
       tags:
         - submissions
       summary: Delete a submission
-      description: Deletes a submission from a database. Only ungraded submissions can be deleted.
+      description: >-
+        Deletes a submission from a database. Only ungraded submissions can be
+        deleted.
       operationId: deleteSubmission
-      produces:
-        - application/json
       parameters:
-        - $ref: '#/parameters/SubmissionHashPath'
+        - $ref: '#/components/parameters/SubmissionHashPath'
       responses:
-        '200':
+        200:
           description: successful operation
-        '403':
-          description: Cannot delete a graded submission
-          schema:
-            $ref: '#/definitions/ErrResponse'
-        '404':
-          description: Submission with given hash not found
         401:
-          $ref: "#/responses/Unauthorized"
-
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          description: Cannot delete a graded submission
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
+        404:
+          description: Submission with given hash not found
   /proofs:
     get:
       tags:
         - proofs
       summary: Get available proofs for student
-      description: Gets private transactions together with corresponding Merkle subtrees. Transactions from same blocks are grouped together and each group has one proof, which is a corresponding Merkle subtree.
+      description: >-
+        Gets private transactions together with corresponding Merkle subtrees.
+        Transactions from same blocks are grouped together and each group has
+        one proof, which is a corresponding Merkle subtree.
       operationId: getProofs
-      produces:
-        - application/json
       parameters:
         - in: query
           name: since
           description: Do not include transactions which were created earlier this time
           required: false
-          type: string
-          format: date-time
+          schema:
+            type: string
+            format: date-time
       responses:
         200:
           description: successfull operation
-          schema:
-            $ref: '#/definitions/Proofs'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Proofs'
         401:
-          $ref: "#/responses/Unauthorized"
-
-securityDefinitions:
-  StudentAuth:
-    type: apiKey
-    name: Authorization
-    in: header
-    description: |
-      Authentication system requires a JWS in Authorization header in `Bearer <JWS>` format. Example header:
-      ```
-      Authorization: Bearer eyJhbGciOiJFZERTQSIsImp3ayI6eyJjcnYiOiJFZDI1NTE5IiwieCI6InFlU3ZrUzZnaW9CcjRlX2I2em8zTWlPT1NYQW90VjkwdDVLajNsMjh5cm8iLCJrdHkiOiJPS1AifX0.eyJwYXRoIjoiL2FwaS9zdHVkZW50L3YxL2NvdXJzZXMiLCJ0aW1lIjoiMjAyNS0wMS0wMVQwMDowMDowMFoifQ.JYO_dINCZWhzHuER7377ETxf-Vg1Sw9eImc5cVxrFKFP9PlIXS9fGlzvrKsSpe8FbkAsYkU_cjBoBiaVx6KiDA
-      ```
-
-      JWS header MUST contain "jwk" parameter ([RFC7515, section 4.1.3](https://tools.ietf.org/html/rfc7515#section-4.1.3)) with a
-      public JWK corresponding to the signature. JWK MUST have key type "OKP" and curve type "Ed25519", public key parameter "x"
-      should be encoded via base64Url (accordingly to [RFC8037](https://tools.ietf.org/html/rfc8037)). Example JWK:
-      ```
-      { "kty": "OKP", "crv": "Ed25519", "x": "2qbm2mPrVVW_yFsHUMzNt3hLdalGLTN8ucI4e-Cn6fI" }
-      ```
-      This JWK represents a Disciplina public key of a Student querying the API. The whole JWS should be created via the Student's secret key.
-      JWS payload MUST be a JSON object with fields "path" and "time". Field "path" should contain the endpoint URL path and "time"
-      should contain the time the request has been made in [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) format. Example JWS
-      payload:
-      ```
-      {
-        "time": "2025-01-01T00:00:00.000000000Z",
-        "path": "/api/student/v1/courses"
-      }
-      ```
-      If the request's raw path doesn't match the one in "path" or "time" is more than 5 minutes behind the server current time,
-      the authentication process will fail.
-
-responses:
-  Unauthorized:
-    description: Unauthorized
-    headers:
-      WWW-Authenticate:
-        type: string
-
-security:
-  - StudentAuth: []
-
-definitions:
-  Hash:
-    type: string
-    format: byte
-    description: "Hex encoded blake2b (256 bits) hash"
-
-  Address:
-    type: string
-    format: byte
-
-  Time:
-    type: string
-    format: date-time
-
-  Subject:
-    type: integer
-    format: int32
-
-  CourseId:
-    type: integer
-    format: int32
-    description : Course ID
-
-  Course:
-    type: object
-    required:
-      - id
-      - desc
-      - subjects
-      - isEnrolled
-      - isFinished
-    properties:
-      id:
-        $ref: '#/definitions/CourseId'
-      desc:
-        type: string
-      subjects:
-        type: array
-        items:
-          $ref: '#/definitions/Subject'
-      isEnrolled:
-        type: boolean
-      isFinished:
-        type: boolean
-
-  Assignment:
-    type: object
-    required:
-      - hash
-      - courseId
-      - contentsHash
-      - isFinal
-      - desc
-    properties:
-      hash:
-        $ref: '#/definitions/Hash'
-      courseId:
-        $ref: '#/definitions/CourseId'
-      contentsHash:
-        $ref: '#/definitions/Hash'
-      isFinal:
-        type: boolean
-      desc:
-        type: string
-      lastSubmission:
-        $ref: '#/definitions/Submission'
-
-  Submission:
-    type: object
-    required:
-      - hash
-      - contentsHash
-      - assignmentHash
-    properties:
-      hash:
-        $ref: '#/definitions/Hash'
-      contentsHash:
-        $ref: '#/definitions/Hash'
-      assignmentHash:
-        $ref: '#/definitions/Hash'
-      grade:
-        $ref: '#/definitions/Grade'
-
-  Grade:
-    type: object
-    required:
-      - signedSubmissionHash
-      - grade
-      - timestamp
-      - hasProof
-    properties:
-      submissionHash:
-        $ref: "#/definitions/Hash"
-      grade:
+          $ref: '#/components/responses/Unauthorized'
+components:
+  parameters:
+    CourseId:
+      in: query
+      name: course
+      description: Course ID
+      required: false
+      schema:
         type: integer
         format: int32
-      timestamp:
-        $ref: '#/definitions/Time'
-      hasProof:
-        type: boolean
-
-  SignedSubmission:
-    type: object
-    required:
-      - submission
-      - witness
-    properties:
-      submission:
-        type: object
-        required:
-          - studentId
-          - contentsHash
-          - assignment
-        properties:
-          studentId:
-            $ref: '#/definitions/Address'
-          contentsHash:
-            $ref: '#/definitions/Hash'
-          assignment:
-            type: object
-            required:
-              - courseId
-              - contentsHash
-              - type
-              - desc
-            properties:
-              courseId:
-                $ref: '#/definitions/CourseId'
-              contentsHash:
-                $ref: '#/definitions/Hash'
-              type:
-                type: string
-                enum: [regular, courseFinal]
-              desc:
-                type: string
-      witness:
-        type: string
-        format: binary
-        description: Concatenated student public key and submission hash signed with student secret key.
-    example:
-      assignmentHash: "3ac844212387a8ed8a1702a3ba7309bd2841f7d2959749fecd08781d986480d3"
-      contentsHash: "7b6d0c6de38639cc6063e9c36f9dcdb71fff60fe551ccc757246a3bf2fa00f37"
-      witness: "830058206adc59f0c7c600740614cc9e008e8d498e641a48d012b8cc532d9fc8b6709b7e5840601d28410a8ccd18065738d8ddaee331922963757565e9716d973c9a306d919f8e15cd4d3d6cac59a2049c926eb66aafd277965886dcb0cfa67afc90d8a1c902"
-
-  Transaction:
-    type: object
-    required:
-      - signedSubmission
-      - grade
-      - timestamp
-    properties:
-      signedSubmission:
-        $ref: '#/definitions/SignedSubmission'
-      grade:
+    CourseIdPath:
+      in: path
+      name: courseId
+      description: Course ID
+      required: true
+      schema:
         type: integer
         format: int32
-      timestamp:
-        $ref: '#/definitions/Time'
-  BlkProof:
-    type: object
-    required:
-      - mtreeSerialized
-      - txs
-    properties:
-      mtreeSerialized:
-        type: string
-        format: binary
-      txs:
-        type: array
-        items:
-          $ref: '#/definitions/Transaction'
-  Proofs:
-    type: array
-    items:
-      $ref: '#/definitions/BlkProof'
-
-  ErrResponse:
-    type: object
-    required:
-      - error
-    properties:
-      error:
+    DocumentType:
+      in: query
+      name: type
+      description: Type of assignment or submission
+      required: false
+      schema:
         type: string
         enum:
-          - SubmissionSignatureInvalid
-          - FakeSubmissionSignature
-          - DeletingGradedSubmission
-          - CourseDoesNotExist
-          - StudentDoesNotExist
-          - AssignmentDoesNotExist
-          - StudentWasNotEnrolledOnTheCourse
-          - StudentWasNotSubscribedOnAssignment
-          - SubmissionDoesNotExist
-          - TransactionDoesNotExist
-          - SubmissionAlreadyExists
-        description: >-
-          * `SubmissionSignatureInvalid`: Signature does not match to claimed submission author.
-          * `FakeSubmissionSignature`: Claimed owner of submission does not match to authenticated user.
-          * `DeletingGradedSubmission`: Attempt to delete an already graded submission.
-          * `CourseDoesNotExist`: Given course does not exist.
-          * `StudentDoesNotExist`: Given student is not known to the educator.
-          * `AssignmentDoesNotExist`: Given assignment does not exist.
-          * `StudentWasNotEnrolledOnTheCourse`: Cannot perform this operation because student is not enrolled on the course.
-          * `StudentWasNotSubscribedOnAssignment`: Cannot perform this operation because student is not subscribed on this assignment.
-          * `SubmissionDoesNotExist`: Submission does not exist.
-          * `TransactionDoesNotExist`: Transaction does not exist.
-          * `SubmissionAlreadyExists`: Exactly the same submission has already been submitted.
+          - online
+          - offline
+    AssignmentHash:
+      in: query
+      name: assignment
+      description: Assignment hash
+      required: false
+      schema:
+        type: string
+        format: byte
+    AssignmentHashPath:
+      in: path
+      name: assignmentHash
+      description: Assignment hash
+      required: true
+      schema:
+        type: string
+        format: byte
+    SubmissionHashPath:
+      in: path
+      name: submissionHash
+      description: Submission hash
+      required: true
+      schema:
+        type: string
+        format: byte
+  responses:
+    Unauthorized:
+      description: Unauthorized
+      headers:
+        WWW-Authenticate:
+          schema:
+            type: string
+  securitySchemes:
+    StudentAuth:
+      type: apiKey
+      name: Authorization
+      in: header
+      description: >
+        Authentication system requires a JWS in Authorization header in `Bearer
+        ` format. Example header:
 
-parameters:
-  CourseId:
-    in: query
-    name: course
-    description: Course ID
-    required: false
-    type: integer
-    format: int32
-  CourseIdPath:
-    in: path
-    name: courseId
-    description: Course ID
-    required: true
-    type: integer
-    format: int32
-  DocumentType:
-    in: query
-    name: type
-    description: Type of assignment or submission
-    required: false
-    type: string
-    enum: ["online", "offline"]
-  AssignmentHash:
-    in: query
-    name: assignment
-    description: Assignment hash
-    type: string
-    format: byte
-    required: false
-  AssignmentHashPath:
-    in: path
-    name: assignmentHash
-    description: Assignment hash
-    required: true
-    type: string
-    format: byte
-  SubmissionHashPath:
-    in: path
-    name: submissionHash
-    description: Submission hash
-    required: true
-    type: string
-    format: byte
-externalDocs:
-  description: Find out more about Swagger
-  url: 'http://swagger.io'
+        ```
+
+        Authorization: Bearer
+        eyJhbGciOiJFZERTQSIsImp3ayI6eyJjcnYiOiJFZDI1NTE5IiwieCI6InFlU3ZrUzZnaW9CcjRlX2I2em8zTWlPT1NYQW90VjkwdDVLajNsMjh5cm8iLCJrdHkiOiJPS1AifX0.eyJwYXRoIjoiL2FwaS9zdHVkZW50L3YxL2NvdXJzZXMiLCJ0aW1lIjoiMjAyNS0wMS0wMVQwMDowMDowMFoifQ.JYO_dINCZWhzHuER7377ETxf-Vg1Sw9eImc5cVxrFKFP9PlIXS9fGlzvrKsSpe8FbkAsYkU_cjBoBiaVx6KiDA
+
+        ```
+
+
+        JWS header MUST contain "jwk" parameter ([RFC7515, section
+        4.1.3](https://tools.ietf.org/html/rfc7515#section-4.1.3)) with a
+
+        public JWK corresponding to the signature. JWK MUST have key type "OKP"
+        and curve type "Ed25519", public key parameter "x"
+
+        should be encoded via base64Url (accordingly to
+        [RFC8037](https://tools.ietf.org/html/rfc8037)). Example JWK:
+
+        ```
+
+        { "kty": "OKP", "crv": "Ed25519", "x":
+        "2qbm2mPrVVW_yFsHUMzNt3hLdalGLTN8ucI4e-Cn6fI" }
+
+        ```
+
+        This JWK represents a Disciplina public key of a Student querying the
+        API. The whole JWS should be created via the Student's secret key.
+
+        JWS payload MUST be a JSON object with fields "path" and "time". Field
+        "path" should contain the endpoint URL path and "time"
+
+        should contain the time the request has been made in
+        [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) format. Example JWS
+
+        payload:
+
+        ```
+
+        {
+          "time": "2025-01-01T00:00:00.000000000Z",
+          "path": "/api/student/v1/courses"
+        }
+
+        ```
+
+        If the request's raw path doesn't match the one in "path" or "time" is
+        more than 5 minutes behind the server current time,
+
+        the authentication process will fail.
+  schemas:
+    Hash:
+      type: string
+      format: byte
+      description: Hex encoded blake2b (256 bits) hash
+    Address:
+      type: string
+      format: byte
+    Time:
+      type: string
+      format: date-time
+    Subject:
+      type: integer
+      format: int32
+    CourseId:
+      type: integer
+      format: int32
+      description: Course ID
+    Course:
+      type: object
+      required:
+        - id
+        - desc
+        - subjects
+        - isEnrolled
+        - isFinished
+      properties:
+        id:
+          $ref: '#/components/schemas/CourseId'
+        desc:
+          type: string
+        subjects:
+          type: array
+          items:
+            $ref: '#/components/schemas/Subject'
+        isEnrolled:
+          type: boolean
+        isFinished:
+          type: boolean
+    Assignment:
+      type: object
+      required:
+        - hash
+        - courseId
+        - contentsHash
+        - isFinal
+        - desc
+      properties:
+        hash:
+          $ref: '#/components/schemas/Hash'
+        courseId:
+          $ref: '#/components/schemas/CourseId'
+        contentsHash:
+          $ref: '#/components/schemas/Hash'
+        isFinal:
+          type: boolean
+        desc:
+          type: string
+        lastSubmission:
+          $ref: '#/components/schemas/Submission'
+    Submission:
+      type: object
+      required:
+        - hash
+        - contentsHash
+        - assignmentHash
+      properties:
+        hash:
+          $ref: '#/components/schemas/Hash'
+        contentsHash:
+          $ref: '#/components/schemas/Hash'
+        assignmentHash:
+          $ref: '#/components/schemas/Hash'
+        grade:
+          $ref: '#/components/schemas/Grade'
+    Grade:
+      type: object
+      required:
+        - signedSubmissionHash
+        - grade
+        - timestamp
+        - hasProof
+      properties:
+        submissionHash:
+          $ref: '#/components/schemas/Hash'
+        grade:
+          type: integer
+          format: int32
+        timestamp:
+          $ref: '#/components/schemas/Time'
+        hasProof:
+          type: boolean
+    SignedSubmission:
+      type: object
+      required:
+        - submission
+        - witness
+      properties:
+        submission:
+          type: object
+          required:
+            - studentId
+            - contentsHash
+            - assignment
+          properties:
+            studentId:
+              $ref: '#/components/schemas/Address'
+            contentsHash:
+              $ref: '#/components/schemas/Hash'
+            assignment:
+              type: object
+              required:
+                - courseId
+                - contentsHash
+                - type
+                - desc
+              properties:
+                courseId:
+                  $ref: '#/components/schemas/CourseId'
+                contentsHash:
+                  $ref: '#/components/schemas/Hash'
+                type:
+                  type: string
+                  enum:
+                    - regular
+                    - courseFinal
+                desc:
+                  type: string
+        witness:
+          type: string
+          format: binary
+          description: >-
+            Concatenated student public key and submission hash signed with
+            student secret key.
+      example:
+        assignmentHash: 3ac844212387a8ed8a1702a3ba7309bd2841f7d2959749fecd08781d986480d3
+        contentsHash: 7b6d0c6de38639cc6063e9c36f9dcdb71fff60fe551ccc757246a3bf2fa00f37
+        witness: >-
+          830058206adc59f0c7c600740614cc9e008e8d498e641a48d012b8cc532d9fc8b6709b7e5840601d28410a8ccd18065738d8ddaee331922963757565e9716d973c9a306d919f8e15cd4d3d6cac59a2049c926eb66aafd277965886dcb0cfa67afc90d8a1c902
+    Transaction:
+      type: object
+      required:
+        - signedSubmission
+        - grade
+        - timestamp
+      properties:
+        signedSubmission:
+          $ref: '#/components/schemas/SignedSubmission'
+        grade:
+          type: integer
+          format: int32
+        timestamp:
+          $ref: '#/components/schemas/Time'
+    BlkProof:
+      type: object
+      required:
+        - mtreeSerialized
+        - txs
+      properties:
+        mtreeSerialized:
+          type: string
+          format: binary
+        txs:
+          type: array
+          items:
+            $ref: '#/components/schemas/Transaction'
+    Proofs:
+      type: array
+      items:
+        $ref: '#/components/schemas/BlkProof'
+    ErrResponse:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          enum:
+            - SubmissionSignatureInvalid
+            - FakeSubmissionSignature
+            - DeletingGradedSubmission
+            - CourseDoesNotExist
+            - StudentDoesNotExist
+            - AssignmentDoesNotExist
+            - StudentWasNotEnrolledOnTheCourse
+            - StudentWasNotSubscribedOnAssignment
+            - SubmissionDoesNotExist
+            - TransactionDoesNotExist
+            - SubmissionAlreadyExists
+          description: >-
+            * `SubmissionSignatureInvalid`: Signature does not match to claimed submission author.
+            * `FakeSubmissionSignature`: Claimed owner of submission does not match to authenticated user.
+            * `DeletingGradedSubmission`: Attempt to delete an already graded submission.
+            * `CourseDoesNotExist`: Given course does not exist.
+            * `StudentDoesNotExist`: Given student is not known to the educator.
+            * `AssignmentDoesNotExist`: Given assignment does not exist.
+            * `StudentWasNotEnrolledOnTheCourse`: Cannot perform this operation because student is not enrolled on the course.
+            * `StudentWasNotSubscribedOnAssignment`: Cannot perform this operation because student is not subscribed on this assignment.
+            * `SubmissionDoesNotExist`: Submission does not exist.
+            * `TransactionDoesNotExist`: Transaction does not exist.
+            * `SubmissionAlreadyExists`: Exactly the same submission has already been submitted.

--- a/specs/disciplina/faucet/api/faucet.yaml
+++ b/specs/disciplina/faucet/api/faucet.yaml
@@ -1,135 +1,136 @@
-swagger: "2.0"
+openapi: 3.0.0
 info:
-  description: "This is an HTTP API for interacting with Disciplina Faucet. It is used by Faucet frontend to generate keys and submitting money to user accounts."
+  description: >-
+    This is an HTTP API for interacting with Disciplina Faucet. It is used by
+    Faucet frontend to generate keys and submitting money to user accounts.
   version: 0.1.0
   title: Disciplina Faucet API
-  termsOfService: "https://disciplina.io/tnc.pdf"
+  termsOfService: 'https://disciplina.io/tnc.pdf'
   contact:
     email: hi@serokell.io
   license:
     name: Apache 2.0
-    url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-host: "localhost:8095"
-basePath: /api/faucet/v1
-schemes:
-  - https
-  - http
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+servers:
+  - url: 'https://localhost:8095/api/faucet/v1'
+  - url: 'http://localhost:8095/api/faucet/v1'
 paths:
   /keygen:
     post:
       summary: Generate a key pair.
       operationId: genKeyPair
-      consumes:
-      - application/json
-      produces:
-      - application/json
-      parameters:
-      - in: body
-        name: body
-        required: false
-        description: Hex-encoded password.
-        schema:
-          $ref: "#/definitions/GenKeyReq"
       responses:
         200:
           description: successful operation
-          schema:
-            type: object
-            required:
-            - encSecretKey
-            - secretKey
-            - publicKey
-            - address
-            properties:
-              encSecretKey:
-                type: string
-                format: byte
-                description: "Secret key encrypted with the given password (empty pass is also a pass)"
-              secretKey:
-                type: string
-                format: byte
-                description: "Plain secret key"
-              publicKey:
-                type: string
-                format: byte
-                description: "Public key corresponding to secret key"
-              address:
-                type: string
-                description: "Address corresponding to public key"
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - encSecretKey
+                  - secretKey
+                  - publicKey
+                  - address
+                properties:
+                  encSecretKey:
+                    type: string
+                    format: byte
+                    description: >-
+                      Secret key encrypted with the given password (empty pass
+                      is also a pass)
+                  secretKey:
+                    type: string
+                    format: byte
+                    description: Plain secret key
+                  publicKey:
+                    type: string
+                    format: byte
+                    description: Public key corresponding to secret key
+                  address:
+                    type: string
+                    description: Address corresponding to public key
         400:
           description: Password is too short or too long
-          schema:
-            $ref: "#/definitions/ErrResponse"
-
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GenKeyReq'
+        description: Hex-encoded password.
   /transfer:
     post:
       summary: Transfer money to given address
       operationId: transferMoneyTo
-      consumes:
-      - application/json
-      produces:
-      - application/json
-      parameters:
-      - in: body
-        name: body
-        required: true
-        schema:
-          $ref: "#/definitions/TransferReq"
       responses:
         200:
           description: successful operation
-          schema:
-            type: object
-            required:
-            - txId
-            - amount
-            properties:
-              txId:
-                type: string
-                format: byte
-                description: "Transaction id"
-              amount:
-                type: integer
-                description: "Amount of money transfered"
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - txId
+                  - amount
+                properties:
+                  txId:
+                    type: string
+                    format: byte
+                    description: Transaction id
+                  amount:
+                    type: integer
+                    description: Amount of money transfered
         403:
           description: Given address already received money previously
-          schema:
-            $ref: "#/definitions/ErrResponse"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
         503:
           description: Source account exhausted
-          schema:
-            $ref: "#/definitions/ErrResponse"
-
-definitions:
-  ErrResponse:
-    type: object
-    required:
-      - error
-    properties:
-      error:
-        type: string
-        enum:
-          - InvalidFormat
-          - AddressAlreadyGifted
-          - SourceAccountExhausted
-        description: >-
-          * `InvalidFormat` - Failed to deserialise one of parameters.
-          * `AddressAlreadyGifted`: Given address has already requested faucet for money and cannot do that again.
-          * `SourceAccountExhausted`: Specified source account has not enough money for further transfers, the event is over!
-
-  TransferReq:
-    type: object
-    required:
-    - destination
-    properties:
-      destination:
-        type: string
-        description: Hex-encoded destination address
-        example: LL4qKmtpBGs95j1fDYWsyPJSzvkATGNvu1PXyxMbEkZrsVSshB1dGCDp
-  GenKeyReq:
-    type: object
-    properties:
-      password:
-        type: string
-        description: Hex-encoded password for secret key
-        example: 70617373776f7264
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransferReq'
+        required: true
+components:
+  schemas:
+    ErrResponse:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          enum:
+            - InvalidFormat
+            - AddressAlreadyGifted
+            - SourceAccountExhausted
+          description: >-
+            * `InvalidFormat` - Failed to deserialise one of parameters.
+            * `AddressAlreadyGifted`: Given address has already requested faucet for money and cannot do that again.
+            * `SourceAccountExhausted`: Specified source account has not enough money for further transfers, the event is over!
+    TransferReq:
+      type: object
+      required:
+        - destination
+      properties:
+        destination:
+          type: string
+          description: Hex-encoded destination address
+          example: LL4qKmtpBGs95j1fDYWsyPJSzvkATGNvu1PXyxMbEkZrsVSshB1dGCDp
+    GenKeyReq:
+      type: object
+      properties:
+        password:
+          type: string
+          description: Hex-encoded password for secret key
+          example: 70617373776f7264

--- a/specs/disciplina/witness/api/witness.yaml
+++ b/specs/disciplina/witness/api/witness.yaml
@@ -1,18 +1,22 @@
-swagger: "2.0"
+openapi: 3.0.0
 info:
-  description: "This is an HTTP API for interacting with Disciplina Witness node. It is used by Block Explorer frontend to request info about blocks, accounts and transactions, and by Disciplina Wallet to make transactions."
+  description: >-
+    This is an HTTP API for interacting with Disciplina Witness node. It is used
+    by Block Explorer frontend to request info about blocks, accounts and
+    transactions, and by Disciplina Wallet to make transactions.
   version: 0.1.0
-  title:  Disciplina Witness API
-  termsOfService: "https://disciplina.io/tnc.pdf"
+  title: Disciplina Witness API
+  termsOfService: 'https://disciplina.io/tnc.pdf'
   contact:
     email: hi@serokell.io
   license:
     name: Apache 2.0
-    url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-basePath: /api/witness/v1
-schemes:
-  - https
-  - http
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+externalDocs:
+  description: Find out more about Swagger
+  url: 'http://swagger.io'
+servers:
+  - url: /api/witness/v1
 paths:
   /ping:
     get:
@@ -25,248 +29,276 @@ paths:
     get:
       summary: Get type of entity identified by given hash
       operationId: getHashType
-      produces:
-      - application/json
       parameters:
-      - in: path
-        name: hash
-        description: Block header hash, tx id or address.
-        required: true
-        type: string
-        format: byte
+        - in: path
+          name: hash
+          description: Block header hash, tx id or address.
+          required: true
+          schema:
+            type: string
+            format: byte
       responses:
         200:
-          description: >-
+          description: |-
             Type of the entity:
               * `block`
               * `address`
               * `money-transaction`
               * `publication-transaction`
               * `unknown`
-          schema:
-            type: string
-            enum:
-            - block
-            - address
-            - money-transaction
-            - publication-transaction
-            - unknown
+          content:
+            application/json:
+              schema:
+                type: string
+                enum:
+                  - block
+                  - address
+                  - money-transaction
+                  - publication-transaction
+                  - unknown
   /blocks:
     get:
       summary: Get list of blocks.
       description: >-
-        Return a batch of `count` most recent blocks, skipping `skip` blocks from the tip.
+        Return a batch of `count` most recent blocks, skipping `skip` blocks
+        from the tip.
       operationId: getBlocks
-      produces:
-      - application/json
       parameters:
-      - in: query
-        name: skip
-        description: The amount of blocks to skip.
-        default: 0
-        type: integer
-        format: int64
-      - in: query
-        name: count
-        description: The amount of blocks returned.
-        default: 100
-        maximum: 100
-        type: integer
-        format: int32
+        - in: query
+          name: skip
+          description: The amount of blocks to skip.
+          schema:
+            type: integer
+            format: int64
+            default: 0
+        - in: query
+          name: count
+          description: The amount of blocks returned.
+          schema:
+            type: integer
+            format: int32
+            maximum: 100
+            default: 100
       responses:
         200:
           description: Successful operation
-          schema:
-            type: object
-            properties:
-              blocks:
-                type: array
-                items:
-                  $ref: "#/definitions/BlockInfo"
-              totalCount:
-                type: integer
-                format: int64
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  blocks:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/BlockInfo'
+                  totalCount:
+                    type: integer
+                    format: int64
         400:
           description: Invalid input
-          schema:
-            $ref: "#/definitions/ErrResponse"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
   /blocks/{headerHash}:
     get:
       summary: Get information about a block.
       operationId: getBlock
-      produces:
-      - application/json
       parameters:
-      - in: path
-        name: headerHash
-        description: Block identifier (hash of the block header).
-        required: true
-        type: string
-        format: byte
+        - in: path
+          name: headerHash
+          description: Block identifier (hash of the block header).
+          required: true
+          schema:
+            type: string
+            format: byte
       responses:
         200:
           description: Successful operation
-          schema:
-            allOf:
-            - $ref: "#/definitions/BlockInfo"
-            - $ref: "#/definitions/BlockTransactionList"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BlockInfo'
+                  - $ref: '#/components/schemas/BlockTransactionList'
         400:
           description: Invalid input
-          schema:
-            $ref: "#/definitions/ErrResponse"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
         404:
           description: Block not found
-          schema:
-            $ref: "#/definitions/ErrResponse"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
   /accounts/{address}:
     get:
       summary: Get information about an account.
       operationId: getAccount
-      produces:
-      - application/json
       parameters:
-      - in: path
-        name: address
-        description: Address of an account being requested.
-        required: true
-        type: string
-        format: byte
-      - in: query
-        name: includeTxs
-        description: >-
-          Whether to include transaction history for the account.
-          Both incoming and outgoing transactions are included
-        type: boolean
-        allowEmptyValue: true
+        - in: path
+          name: address
+          description: Address of an account being requested.
+          required: true
+          schema:
+            type: string
+            format: byte
+        - in: query
+          name: includeTxs
+          description: >-
+            Whether to include transaction history for the account. Both
+            incoming and outgoing transactions are included
+          allowEmptyValue: true
+          schema:
+            type: boolean
       responses:
         200:
           description: Successful operation
-          schema:
-            allOf:
-            - $ref: "#/definitions/AccountInfo"
-            - $ref: "#/definitions/TransactionList"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/AccountInfo'
+                  - $ref: '#/components/schemas/TransactionList'
         400:
           description: Invalid input
-          schema:
-            $ref: "#/definitions/ErrResponse"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
         404:
           description: Account not found
-          schema:
-            $ref: "#/definitions/ErrResponse"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
   /transactions:
     get:
       summary: Get list of recent transactions.
       description: >-
-        Return a batch of `count` most recent transactions.
-        If `nextId` key is present in the result, it can be passed as `from` parameter to get the next batch.
+        Return a batch of `count` most recent transactions. If `nextId` key is
+        present in the result, it can be passed as `from` parameter to get the
+        next batch.
       operationId: getTransactions
-      produces:
-      - application/json
       parameters:
-      - in: query
-        name: from
-        description: >-
-          Get a batch of transactions starting with the specified one.
-          If not specified, get the most recent transactions.
-        type: string
-        format: byte
-      - in: query
-        name: count
-        description: The amount of transactions returned.
-        default: 100
-        maximum: 100
-        type: integer
-        format: int32
-      - in: query
-        name: account
-        description: Remain only transactions affecting given account.
-        type: string
-        format: byte
+        - in: query
+          name: from
+          description: >-
+            Get a batch of transactions starting with the specified one. If not
+            specified, get the most recent transactions.
+          schema:
+            type: string
+            format: byte
+        - in: query
+          name: count
+          description: The amount of transactions returned.
+          schema:
+            type: integer
+            format: int32
+            maximum: 100
+            default: 100
+        - in: query
+          name: account
+          description: Remain only transactions affecting given account.
+          schema:
+            type: string
+            format: byte
       responses:
         200:
           description: Successful operation
-          schema:
-            type: object
-            properties:
-              transactions:
-                type: array
-                items:
-                  allOf:
-                  - $ref: "#/definitions/TransactionInfo"
-                  - $ref: "#/definitions/AndBlockInfo"
-              nextId:
-                $ref: "#/definitions/Hash"
-
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  transactions:
+                    type: array
+                    items:
+                      allOf:
+                        - $ref: '#/components/schemas/TransactionInfo'
+                        - $ref: '#/components/schemas/AndBlockInfo'
+                  nextId:
+                    $ref: '#/components/schemas/Hash'
     post:
       summary: Submit a formed transaction.
       operationId: submitTx
-      produces:
-      - application/json
-      parameters:
-      - in: body
-        name: txWitnessed
-        schema:
-          $ref: "#/definitions/TxWitnessed"
       responses:
         201:
-          description: Transaction passed validation. If no transactions spending money from the same account are submitted concurrently to other witness node, transaction will eventually appear in blockchain. Returns transaction id.
-          schema:
-            $ref: "#/definitions/Hash"
+          description: >-
+            Transaction passed validation. If no transactions spending money
+            from the same account are submitted concurrently to other witness
+            node, transaction will eventually appear in blockchain. Returns
+            transaction id.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Hash'
         400:
           description: Formed transaction is invalid.
-          schema:
-            $ref: '#/definitions/TxValidationError'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TxValidationError'
         403:
           description: Transaction cannot be applied.
-          schema:
-            $ref: '#/definitions/TxValidationError'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TxValidationError'
+      requestBody:
+        $ref: '#/components/requestBodies/TxWitnessed'
   /transactions/{transactionHash}:
     get:
       summary: Get information about a transaction.
       description: >-
-        `txType` field of the result object will denote the type of transaction: "money" or "publication".
-        The corresponding key in the object will contain the rest of information about the transaction.
+        `txType` field of the result object will denote the type of transaction:
+        "money" or "publication". The corresponding key in the object will
+        contain the rest of information about the transaction.
       operationId: getTransaction
-      produces:
-      - application/json
       parameters:
-      - in: path
-        name: transactionHash
-        description: Hash of the transaction being requested.
-        required: true
-        type: string
-        format: byte
+        - in: path
+          name: transactionHash
+          description: Hash of the transaction being requested.
+          required: true
+          schema:
+            type: string
+            format: byte
       responses:
         200:
           description: Successful operation
-          schema:
-            allOf:
-            - $ref: "#/definitions/GeneralizedTransactionInfo"
-            - $ref: "#/definitions/AndBlockInfo"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/GeneralizedTransactionInfo'
+                  - $ref: '#/components/schemas/AndBlockInfo'
         400:
           description: Invalid input
-          schema:
-            $ref: "#/definitions/ErrResponse"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
         404:
           description: Transaction not found
-          schema:
-            $ref: "#/definitions/ErrResponse"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
   /transactions/async:
     post:
       summary: Submit a formed transaction asynchronously.
       operationId: submitTxAsync
-      produces:
-      - application/json
-      parameters:
-      - in: body
-        name: txWitnessed
-        schema:
-          $ref: "#/definitions/TxWitnessed"
       responses:
         202:
           description: Transaction accepted. Returns transaction id.
-          schema:
-            $ref: "#/definitions/Hash"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Hash'
+      requestBody:
+        $ref: '#/components/requestBodies/TxWitnessed'
 
   /publications:
     get:
@@ -275,334 +307,343 @@ paths:
         Return a batch of `count` most recent publications.
         If `nextId` key is present in the result, it can be passed as `from` parameter to get the next batch.
       operationId: getEducatorPublications
-      produces:
-      - application/json
       parameters:
-      - in: query
-        name: from
-        description: >-
-          Get a batch of publications starting with the specified one.
-          If not specified, get the most recent publications.
-        type: string
-        format: byte
-      - in: query
-        name: count
-        description: The amount of publications returned.
-        default: 100
-        maximum: 100
-        type: integer
-        format: int32
-      - in: query
-        name: educator
-        description: Return only publications of the given author.
-        type: string
-        format: byte
+        - in: query
+          name: from
+          description: >-
+            Get a batch of publications starting with the specified one.
+            If not specified, get the most recent publications.
+          schema:
+            type: string
+            format: byte
+        - in: query
+          name: count
+          description: The amount of publications returned.
+          schema:
+            default: 100
+            maximum: 100
+            type: integer
+            format: int32
+        - in: query
+          name: educator
+          description: Return only publications of the given author.
+          schema:
+            type: string
+            format: byte
       responses:
         200:
           description: Successful operation
-          schema:
-            type: object
-            properties:
-              transactions:
-                type: array
-                items:
-                  allOf:
-                  - $ref: "#/definitions/PublicationInfo"
-                  - $ref: "#/definitions/AndBlockInfo"
-              nextId:
-                $ref: "#/definitions/Hash"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  transactions:
+                    type: array
+                    items:
+                      allOf:
+                        - $ref: '#/components/schemas/PublicationInfo'
+                        - $ref: '#/components/schemas/AndBlockInfo'
+                  nextId:
+                    $ref: '#/components/schemas/Hash'
 
-definitions:
-  Hash:
-    type: string
-    format: byte
-    description: Hex-encoded hash value.
-  Address:
-    type: string
-    format: byte
-  Coin:
-    type: integer
-    format: int64
-  BlockInfo:
-    type: object
-    properties:
-      headerHash:
-        $ref: "#/definitions/Hash"
-      nextHash:
-        $ref: "#/definitions/Hash"
-      merkleRootHash:
-        $ref: "#/definitions/Hash"
-      header:
-        $ref: "#/definitions/BlockHeader"
-      isGenesis:
-        type: boolean
-      since:
-        type: integer
-        format: int64
-        description: Microseconds since UNIX epoch start
-      size:
-        type: integer
-        format: int64
-        description: Size in bytes
-      transactionCount:
-        type: integer
-        format: int32
-  BlockHeader:
-    type: object
-    properties:
-      signature:
-        type: string
-        format: byte
-      issuer:
-        type: string
-        format: byte
-      difficulty:
-        type: integer
-        format: int64
-      slotId:
-        type: integer
-        format: int64
-      prevHash:
-        $ref: "#/definitions/Hash"
-      totalOutput:
-        $ref: "#/definitions/Coin"
-      totalFees:
-        $ref: "#/definitions/Coin"
-  AccountInfo:
-    type: object
-    properties:
-      balances:
-        type: object
-        properties:
-          confirmed:
-            type: integer
-            format: int32
-            description: Balance according to current chain.
-          total:
-            type: integer
-            format: int32
-            description: Balance derived from both chain and transactions which are not yet in blocks.
-      currentNonce:
-        type: integer
-        format: int32
-  GeneralizedTransactionInfo:
-    type: object
-    discriminator: txType
-    properties:
-      txType:
-        type: string
-        enum:
-        - money
-        - publication
-      txId:
-        $ref: "#/definitions/Hash"
-      outValue:
-        $ref: "#/definitions/Coin"
-      money:
-        $ref: "#/definitions/TransactionInfo"
-      publication:
-        $ref: "#/definitions/PublicationInfo"
-  TransactionInfo:
-    type: object
-    properties:
-      txId:
-        $ref: "#/definitions/Hash"
-      outValue:
-        $ref: "#/definitions/Coin"
-      money:
-        type: object
-        properties:
-          inAcc:
-            type: object
-            properties:
-              addr:
-                $ref: "#/definitions/Address"
-              nonce:
-                type: integer
-                format: int32
-          inValue:
-            $ref: "#/definitions/Coin"
-          outs:
-            type: array
-            items:
-              type: object
-              properties:
-                address:
-                  $ref: "#/definitions/Address"
-                value:
-                  $ref: "#/definitions/Coin"
-  PublicationInfo:
-    type: object
-    properties:
-      txId:
-        $ref: "#/definitions/Hash"
-      publication:
-        type: object
-        properties:
-          author:
-            $ref: "#/definitions/Address"
-          feesAmount:
-            $ref: "#/definitions/Coin"
-          header:
-            $ref: "#/definitions/PrivateBlockHeader"
-  AndBlockInfo:
-    type: object
-    properties:
-      block:
-        $ref: "#/definitions/BlockInfo"
-  TransactionList:
-    type: object
-    properties:
-      transactions:
-        type: array
-        items:
-          allOf:
-          - $ref: "#/definitions/TransactionInfo"
-          - $ref: "#/definitions/AndBlockInfo"
-  GeneralizedTransactionList:
-    type: object
-    properties:
-      transactions:
-        type: array
-        items:
-          allOf:
-          - $ref: "#/definitions/GeneralizedTransactionInfo"
-          - $ref: "#/definitions/AndBlockInfo"
-  BlockTransactionList:
-    type: object
-    properties:
-      transactions:
-        type: array
-        items:
-          $ref: "#/definitions/GeneralizedTransactionInfo"
-  TxInAcc:
-    type: object
-    description: Transaction source account info.
-    properties:
-      nonce:
-        type: integer
-        format: int32
-        description: Current account nonce, received in /accounts/{address} endpoint.
-      addr:
-        $ref: "#/definitions/Address"
-  TxOut:
-    type: object
-    description: Transaction output.
-    properties:
-      outAddr:
-        $ref: "#/definitions/Address"
-      outValue:
-        $ref: "#/definitions/Coin"
-  Tx:
-    type: object
-    description: Transaction content.
-    properties:
-      inAcc:
-        $ref: "#/definitions/TxInAcc"
-      inValue:
-        $ref: "#/definitions/Coin"
-      outs:
-        type: array
-        items:
-          $ref: "#/definitions/TxOut"
-  TxWitness:
-    type: object
-    properties:
-      sig:
-        type: string
-        description: Evaluated as 'signEd25519(sourceSecretKey, blake2bHash(Tx) + sourcePublicKey)', and passed in hex-encoded form to the endpoint.
-      pk:
-        type: string
-        description: Hex-encoded public key of the source account.
-  TxWitnessed:
-    type: object
-    properties:
-      tx:
-        $ref: "#/definitions/Tx"
-      witness:
-        $ref: "#/definitions/TxWitness"
-  AtgDelta:
-    type: array
-    items:
+components:
+  requestBodies:
+    TxWitnessed:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/TxWitnessed'
+  schemas:
+    Hash:
+      type: string
+      format: byte
+      description: Hex-encoded hash value.
+    Address:
+      type: string
+      format: byte
+    Coin:
+      type: integer
+      format: int64
+    BlockInfo:
       type: object
       properties:
-        subjectId:
+        headerHash:
+          $ref: '#/components/schemas/Hash'
+        nextHash:
+          $ref: '#/components/schemas/Hash'
+        merkleRootHash:
+          $ref: '#/components/schemas/Hash'
+        header:
+          $ref: '#/components/schemas/BlockHeader'
+        isGenesis:
+          type: boolean
+        since:
           type: integer
-        status:
+          format: int64
+          description: Microseconds since UNIX epoch start
+        size:
+          type: integer
+          format: int64
+          description: Size in bytes
+        transactionCount:
+          type: integer
+          format: int32
+    BlockHeader:
+      type: object
+      properties:
+        signature:
+          type: string
+          format: byte
+        issuer:
+          type: string
+          format: byte
+        difficulty:
+          type: integer
+          format: int64
+        slotId:
+          type: integer
+          format: int64
+        prevHash:
+          $ref: '#/components/schemas/Hash'
+        totalOutput:
+          $ref: '#/components/schemas/Coin'
+        totalFees:
+          $ref: '#/components/schemas/Coin'
+    AccountInfo:
+      type: object
+      properties:
+        balances:
+          type: object
+          properties:
+            confirmed:
+              type: integer
+              format: int32
+              description: Balance according to current chain.
+            total:
+              type: integer
+              format: int32
+              description: >-
+                Balance derived from both chain and transactions which are not
+                yet in blocks.
+        currentNonce:
+          type: integer
+          format: int32
+    GeneralizedTransactionInfo:
+      type: object
+      discriminator:
+        propertyName: txType
+      properties:
+        txType:
           type: string
           enum:
-            - removed
-            - added
-  PrivateBlockHeader:
-    type: object
-    properties:
-      prevBlock:
-        $ref: "#/definitions/Hash"
-      bodyProof:
+            - money
+            - publication
+        txId:
+          $ref: '#/components/schemas/Hash'
+        outValue:
+          $ref: '#/components/schemas/Coin'
+        money:
+          $ref: '#/components/schemas/TransactionInfo'
+        publication:
+          $ref: '#/components/schemas/PublicationInfo'
+    TransactionInfo:
+      type: object
+      properties:
+        txId:
+          $ref: '#/components/schemas/Hash'
+        outValue:
+          $ref: '#/components/schemas/Coin'
+        money:
+          type: object
+          properties:
+            inAcc:
+              type: object
+              properties:
+                addr:
+                  $ref: '#/components/schemas/Address'
+                nonce:
+                  type: integer
+                  format: int32
+            inValue:
+              $ref: '#/components/schemas/Coin'
+            outs:
+              type: array
+              items:
+                type: object
+                properties:
+                  address:
+                    $ref: '#/components/schemas/Address'
+                  value:
+                    $ref: '#/components/schemas/Coin'
+    PublicationInfo:
+      type: object
+      properties:
+        txId:
+          $ref: "#/components/schemas/Hash"
+        publication:
+          type: object
+          properties:
+            author:
+              $ref: '#/components/schemas/Address'
+            feesAmount:
+              $ref: '#/components/schemas/Coin'
+            header:
+              $ref: '#/components/schemas/PrivateBlockHeader'
+    AndBlockInfo:
+      type: object
+      properties:
+        block:
+          $ref: '#/components/schemas/BlockInfo'
+    TransactionList:
+      type: object
+      properties:
+        transactions:
+          type: array
+          items:
+            allOf:
+              - $ref: '#/components/schemas/TransactionInfo'
+              - $ref: '#/components/schemas/AndBlockInfo'
+    GeneralizedTransactionList:
+      type: object
+      properties:
+        transactions:
+          type: array
+          items:
+            allOf:
+            - $ref: '#/components/schemas/GeneralizedTransactionInfo'
+            - $ref: "#/components/schemas/AndBlockInfo"
+    BlockTransactionList:
+      type: object
+      properties:
+        transactions:
+          type: array
+          items:
+            $ref: '#/components/schemas/GeneralizedTransactionInfo'
+    TxInAcc:
+      type: object
+      description: Transaction source account info.
+      properties:
+        nonce:
+          type: integer
+          format: int32
+          description: Current account nonce, received in /accounts/{address} endpoint.
+        addr:
+          $ref: '#/components/schemas/Address'
+    TxOut:
+      type: object
+      description: Transaction output.
+      properties:
+        outAddr:
+          $ref: '#/components/schemas/Address'
+        outValue:
+          $ref: '#/components/schemas/Coin'
+    Tx:
+      type: object
+      description: Transaction content.
+      properties:
+        inAcc:
+          $ref: '#/components/schemas/TxInAcc'
+        inValue:
+          $ref: '#/components/schemas/Coin'
+        outs:
+          type: array
+          items:
+            $ref: '#/components/schemas/TxOut'
+    TxWitness:
+      type: object
+      properties:
+        sig:
+          type: string
+          description: >-
+            Evaluated as 'signEd25519(sourceSecretKey, blake2bHash(Tx) +
+            sourcePublicKey)', and passed in hex-encoded form to the endpoint.
+        pk:
+          type: string
+          description: Hex-encoded public key of the source account.
+    TxWitnessed:
+      type: object
+      properties:
+        tx:
+          $ref: '#/components/schemas/Tx'
+        witness:
+          $ref: '#/components/schemas/TxWitness'
+    AtgDelta:
+      type: array
+      items:
         type: object
         properties:
-          root:
-            $ref: "#/definitions/Hash"
-          transactionsNum:
+          subjectId:
             type: integer
-            format: int32
-      atgDelta:
-        $ref: "#/definitions/AtgDelta"
-  ErrResponse:
-    type: object
-    required:
-      - error
-    properties:
-      error:
-        type: string
-        enum:
-          - InvalidFormat
+          status:
+            type: string
+            enum:
+              - removed
+              - added
+    PrivateBlockHeader:
+      type: object
+      properties:
+        prevBlock:
+          $ref: '#/components/schemas/Hash'
+        bodyProof:
+          type: object
+          properties:
+            root:
+              $ref: '#/components/schemas/Hash'
+            transactionsNum:
+              type: integer
+              format: int32
+        atgDelta:
+          $ref: "#/components/schemas/AtgDelta"
+    ErrResponse:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          enum:
+            - InvalidFormat
+            - BlockNotFound
+            - TransactionNotFound
+            - PrivateBlockNotFound
+          description: |-
+            Error type:
+              * `InvalidFormat` - Failed to deserialise one of parameters.
 
-          - BlockNotFound
-          - TransactionNotFound
-          - PrivateBlockNotFound
-        description: >-
-          Error type:
-            * `InvalidFormat` - Failed to deserialise one of parameters.
-
-            * `BlockNotFound` - Specified block does not exist.
-            * `TransactionNotFound` - Specified transaction does not exist.
-            * `PrivateBlockNotFound` - Specified private block does not exist.
-
-  TxValidationError:
-    type: object
-    required:
-      - error
-    properties:
-      error:
-        type: string
-        enum:
-          - InvalidFormat
-          - MTxNoOutputs
-          - MTxDuplicatedOutputs
-          - InsuffucientFees
-          - AuthorDoesNotExist
-          - SignatureIsCorrupted
-          - NotASingletonSelfUpdate
-          - NonceMustBeIncremented
-          - PaymentMustBePositive
-          - ReceiverMustIncreaseBalance
-          - SumMustBeNonNegative
-          - CannotAffordFees
-          - BalanceCannotBecomeNegative
-        description: >-
-          Error type:
-            * `InvalidFormat` - Failed to deserialise one of parameters.
-            * `MTxNoOutputs` - Transaction has no outputs.
-            * `MTxDuplicatedOutputs` - Transaction has duplicated outputs.
-            * `InsufficientFees` - Input of transaction is too small to provide appropriate fees amount.
-            * `SignatureIsCorrupted` - Bad signature provided.
-            * `NotASingletonSelfUpdate` - Cannot send money to yourself more than once in transaction.
-            * `NonceMustBeIncremented` - Bad nonce for source account is used. Should be exactly "currentNonce" returned by /accounts/{address} endpoint.
-            * `SumMustBeNonNegative` - Sum of payments plus fee must be less or equal to amount of money you spend.
-            * `CannotAffordFees` - User balance is too small to afford transaction outputs and fees.
-            * `BalanceCannotBecomeNegative` - User balance is too small to afford transaction outputs.
-
-externalDocs:
-  description: Find out more about Swagger
-  url: 'http://swagger.io'
+              * `BlockNotFound` - Specified block does not exist.
+              * `TransactionNotFound` - Specified transaction does not exist.
+              * `PrivateBlockNotFound` - Specified private block does not exist.
+    TxValidationError:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          enum:
+            - InvalidFormat
+            - MTxNoOutputs
+            - MTxDuplicatedOutputs
+            - InsuffucientFees
+            - AuthorDoesNotExist
+            - SignatureIsCorrupted
+            - NotASingletonSelfUpdate
+            - NonceMustBeIncremented
+            - PaymentMustBePositive
+            - ReceiverMustIncreaseBalance
+            - SumMustBeNonNegative
+            - CannotAffordFees
+            - BalanceCannotBecomeNegative
+          description: |-
+            Error type:
+              * `InvalidFormat` - Failed to deserialise one of parameters.
+              * `MTxNoOutputs` - Transaction has no outputs.
+              * `MTxDuplicatedOutputs` - Transaction has duplicated outputs.
+              * `InsufficientFees` - Input of transaction is too small to provide appropriate fees amount.
+              * `SignatureIsCorrupted` - Bad signature provided.
+              * `NotASingletonSelfUpdate` - Cannot send money to yourself more than once in transaction.
+              * `NonceMustBeIncremented` - Bad nonce for source account is used. Should be exactly "currentNonce" returned by /accounts/{address} endpoint.
+              * `SumMustBeNonNegative` - Sum of payments plus fee must be less or equal to amount of money you spend.
+              * `CannotAffordFees` - User balance is too small to afford transaction outputs and fees.
+              * `BalanceCannotBecomeNegative` - User balance is too small to afford transaction outputs.


### PR DESCRIPTION
### Description

OpenAPI 3.0.0 addresses some shortcomings of Swagger 2.0
and makes it easier to specify precise API workings.

This is one-to-one conversion of all existing API specs
using https://openapi-converter.herokuapp.com/ tool.

### YT issue

Somewhat related to https://issues.serokell.io/issue/DSCP-264

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [ ] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [ ] I have checked the [sample config](../docs/config-full-sample.yaml) and [launch scripts](/../../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [ ] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](/README.md) as well as subproject READMEs for all related executables).
- [ ] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](/../../tree/master/specs/disciplina) API specs.
  - Any [related documentation](/../../tree/master/docs/api-types.md).
- [ ] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [ ] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [ ] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
