### PR TITLE
[DSCP-293] use PWD as HOME fallback, make getDataDir use getOSAppDir

### DIFF
--- a/wallet/src/Dscp/Wallet/KeyStorage.hs
+++ b/wallet/src/Dscp/Wallet/KeyStorage.hs
@@ -7,13 +7,13 @@ import Data.Aeson (eitherDecode, encode)
 import Data.Aeson.TH (defaultOptions, deriveJSON)
 import Dscp.Core (mkAddr)
 import Dscp.Util.Aeson (Versioned (..))
-import System.Directory (XdgDirectory (..), createDirectoryIfMissing, doesFileExist, getXdgDirectory)
+import System.Directory (createDirectoryIfMissing, doesFileExist)
 import System.FileLock (SharedExclusive (..), withFileLock)
 import System.FilePath.Posix ((</>))
 
 import qualified Data.ByteString.Lazy as LBS
 
-import Dscp.System (appName)
+import Dscp.Resource.AppDir (getOSAppDir)
 import Dscp.Util.Aeson (Base64Encoded, CustomEncoding (..))
 import Dscp.Wallet.Face
 
@@ -32,7 +32,7 @@ deriveJSON defaultOptions ''StorageAccount
 
 getDataDir :: IO FilePath
 getDataDir = do
-    dir <- getXdgDirectory XdgData appName
+    dir <- getOSAppDir
     createDirectoryIfMissing True dir
     return dir
 


### PR DESCRIPTION
### Description

A fallback is needed in case the $HOME environment variable is not set

This update uses $PWD as such fallback.
In the very unlikely case that this is not set either, `.` is used.

Noticing that the original code about this was repeated in twice (and that both needed to be modified in the same way) they were merged in a single place.

### YT issue

https://issues.serokell.io/issue/DSCP-293

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [ ] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [X] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [X] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [X] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [X] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [X] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [X My code complies with the [style guide](../tree/master/docs/code-style.md).
- [X] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
