### PR TITLE
[DSCP-310]  Make Coin a Fixed fraction value instead of an integral value

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,12 +5,12 @@ demo: &demo
       money:
         type: linear
         coeffs:
-          minimal: 10
+          minimal: 0.000010
           multiplier: 0.1
       publication:
         type: linear
         coeffs:
-          minimal: 10
+          minimal: 0.000010
           multiplier: 1
     genesis: &demo-genesis
       genesisSeed: "GromakNaRechke"

--- a/core/package.yaml
+++ b/core/package.yaml
@@ -46,6 +46,7 @@ library:
     - random
     - reflection
     - safe-exceptions >= 0.1.4
+    - scientific
     - serialise
     - serokell-util
     - servant

--- a/core/src/Dscp/Core/Aeson.hs
+++ b/core/src/Dscp/Core/Aeson.hs
@@ -7,6 +7,8 @@ import Data.Aeson (FromJSON (..), FromJSONKey (..), ToJSON (..), ToJSONKey, Valu
 import Data.Aeson.Options (defaultOptions)
 import Data.Aeson.TH (deriveFromJSON, deriveJSON)
 import Data.Typeable (gcast)
+import Data.Fixed (Micro, Fixed(MkFixed), showFixed)
+import qualified Data.Text as T
 
 import Dscp.Core.Config
 import Dscp.Core.Fees
@@ -86,8 +88,12 @@ instance FromJSON Governance where
 -- Standalone derivations for newtypes
 ---------------------------------------------------------------------------
 
-deriving instance ToJSON Coin
-deriving instance FromJSON Coin
+instance ToJSON Coin where
+    toJSON (Coin c) = String $ T.pack $
+                      showFixed True (MkFixed $ fromIntegral c :: Micro)
+
+instance FromJSON Coin where
+    parseJSON = withText "Coin" $ leftToFail . parseCoin
 
 deriving instance ToJSON Nonce
 deriving instance FromJSON Nonce

--- a/wallet/exec/Glue.hs
+++ b/wallet/exec/Glue.hs
@@ -20,7 +20,7 @@ import Control.Monad.Component (ComponentM, buildComponent_)
 import Data.Text (pack)
 import Data.Tree (Tree (..))
 import Data.Unique
-import Dscp.Core (TxOut (..), addrFromText, coinToInteger)
+import Dscp.Core (TxOut (..), addrFromText, coinToInteger, unsafeMkCoin)
 import Dscp.Util (toHex)
 import NType (AllConstrained, Elem, KnownSpine)
 
@@ -181,7 +181,7 @@ knitFaceToUI walletStateRef UiFace{..} WalletFace{..} KnitFace{..} =
                   let diff = coinToInteger total - coinToInteger confirmed
                       sign = if diff < 0 then " - " else " + "
                       pending = if diff == 0 then ""
-                                else sign <> pretty (abs diff) <> " pending \
+                                else sign <> pretty (unsafeMkCoin $ abs diff) <> " pending \
                                      \= " <> pretty total
                   in Right $ pretty confirmed <> pending
                 _ -> Left "Unrecognized return value"

--- a/wallet/src/Dscp/Wallet/Knit.hs
+++ b/wallet/src/Dscp/Wallet/Knit.hs
@@ -39,7 +39,7 @@ instance
   ) => ComponentInflate components Wallet where
   componentInflate = \case
       ValueAddress a -> ExprLit $ toLit (LitAddress a)
-      ValueCoin c -> ExprLit $ toLit (LitNumber . fromIntegral . coinToInteger $ c)
+      ValueCoin c -> ExprLit $ toLit (LitNumber . (/1000000) . fromIntegral . coinToInteger $ c)
       ValueTx txId inAddr inValue outs -> componentInflate . ValueList $
         [ toValue . ValueString . toHex $ txId
         , toValue . ValueAddress $ inAddr
@@ -249,7 +249,7 @@ tyCoin :: (Elem components Core, Elem components Wallet) => TyProjection compone
 tyCoin = TyProjection "Coin" (\v -> fromValueCoin v <|> fromValueNumber v)
   where
     fromValueCoin = preview _ValueCoin <=< fromValue
-    fromValueNumber = return . Coin <=< toBoundedInteger <=< preview _ValueNumber <=< fromValue
+    fromValueNumber = return . Coin <=< toBoundedInteger . (*1000000) <=< preview _ValueNumber <=< fromValue
 
 tyTxOut :: Elem components Wallet => TyProjection components TxOut
 tyTxOut = TyProjection "TxOut" (preview _ValueTxOut <=< fromValue)

--- a/witness/src/Dscp/Snowdrop/Types.hs
+++ b/witness/src/Dscp/Snowdrop/Types.hs
@@ -39,6 +39,7 @@ import Fmt (build, (+|), (|+))
 import qualified Text.Show
 
 import Dscp.Core.Foundation (Address, Nonce)
+import Dscp.Core (unsafeMkCoin)
 
 -- | Transaction type for publication.
 data PublicationTxTypeId
@@ -117,7 +118,7 @@ instance Buildable AccountException where
             "Duplicated transaction outputs"
         InsufficientFees{..} ->
             "Amount of money left for fees in transaction is not enough, \
-             \expected " +| aeExpectedFees |+ ", got " +| aeActualFees |+ ""
+             \expected " +| unsafeMkCoin aeExpectedFees |+ ", got " +| unsafeMkCoin aeActualFees |+ ""
         SignatureIsMissing ->
             "Transaction has no correct signature"
         SignatureIsCorrupted ->
@@ -137,14 +138,14 @@ instance Buildable AccountException where
         ReceiverMustIncreaseBalance ->
             "One of receivers' balance decreased or didn't change"
         SumMustBeNonNegative{..} ->
-            "Tx input value (" +| aeSent |+ ") is not greater than \
-            \sum of outputs (" +| aeReceived |+ ") plus fees (" +| aeFees |+ ")"
+            "Tx input value (" +| unsafeMkCoin aeSent |+ ") is not greater than \
+            \sum of outputs (" +| unsafeMkCoin aeReceived |+ ") plus fees (" +| unsafeMkCoin aeFees |+ ")"
         CannotAffordFees{..} ->
-            "Tx sender can not afford fees: sending " +| aeOutputsSum |+ " \
-            \and fees are " +| aeFees |+ ", while balance is " +| aeBalance |+ ""
+            "Tx sender can not afford fees: sending " +| unsafeMkCoin aeOutputsSum |+ " \
+            \and fees are " +| unsafeMkCoin aeFees |+ ", while balance is " +| unsafeMkCoin aeBalance |+ ""
         BalanceCannotBecomeNegative{..} ->
-            "Balance can not become negative: spending " +| aeSpent |+ ", \
-            \while balance is " +| aeBalance |+ ""
+            "Balance can not become negative: spending " +| unsafeMkCoin aeSpent |+ ", \
+            \while balance is " +| unsafeMkCoin aeBalance |+ ""
         AccountInternalError s ->
             fromString $ "Expander failed internally: " <> s
 


### PR DESCRIPTION
### Description

These commits make DSCP token correspond the ERC-20 standard. A representation of the data type changes to `E-6` format in Buildable and ToJson instances. Wallet's Knit parsing adjusts the changes. Since the commits coin amount value is a string in terms of witness-api and configuration. So the config yaml file is adjusted as well.

### YT issue

https://issues.serokell.io/issue/DSCP-310

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [ ] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [ ] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [ ] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [ ] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
