### PR TITLE
[DSCP-345] syslog backend for logging

### DIFF
--- a/core/src/Dscp/Resource/Logging.hs
+++ b/core/src/Dscp/Resource/Logging.hs
@@ -4,18 +4,21 @@
 
 module Dscp.Resource.Logging
     ( LoggingParams(..)
+    , LoggingType (..)
     , allocLogging
     , noLogging
     ) where
 
 import Control.Monad.Component (ComponentM, buildComponent)
-import Data.Aeson (FromJSON (..), encode)
+import Data.Aeson (FromJSON (..), ToJSON, encode, withText)
 import Data.Aeson.Options (defaultOptions)
 import Data.Aeson.TH (deriveFromJSON)
 import Fmt ((+|), (|+))
-import Loot.Log (Logging (..), Name, NameSelector (CallstackName, GivenName), logInfo,
-                 modifyLogName)
+import Loot.Log (Logging (..), Name, NameSelector (CallstackName, GivenName),
+                 logInfo, logWarning, modifyLogName, Level(Debug))
 import Loot.Log.Rio (LoggingIO)
+import Loot.Log.Syslog (SyslogConfig(..), loggerName, withPERROR, minLevel,
+    stopLoggers, syslogConfigFromFile, defaultLoggerConfig, prepareSyslog)
 import Loot.Log.Warper (LoggerConfig, prepareLogWarper)
 import System.Wlog (debugPlus, lcTree, ltSeverity, maybeLogsDirB, parseLoggerConfig, productionB,
                     removeAllHandlers, showTidB)
@@ -28,7 +31,9 @@ import Dscp.Rio (runRIO)
 
 -- | Contains all parameters required for hierarchical logger initialization.
 data LoggingParams = LoggingParams
-    { lpDefaultName :: !Name
+    { lpLoggingType :: !(Maybe LoggingType)
+    -- ^ Logger system that will be use (Syslog if nothing is specified)
+    , lpDefaultName :: !Name
     -- ^ Logger name which will be used by default
     , lpDebug       :: !Bool
     -- ^ When configuration file is not specified, this turns on
@@ -39,15 +44,17 @@ data LoggingParams = LoggingParams
     -- ^ Path to logger configuration
     } deriving (Show, Eq)
 
+data LoggingType
+    = Warper
+    | Syslog
+    deriving (Eq, Show, Read)
+
 ----------------------------------------------------------------------------
 -- Other
 ----------------------------------------------------------------------------
 
-readLoggerConfig :: MonadIO m => Maybe FilePath -> m LoggerConfig
-readLoggerConfig = maybe (pure productionB) parseLoggerConfig
-
-getRealLoggerConfig :: MonadIO m => LoggingParams -> m LoggerConfig
-getRealLoggerConfig LoggingParams{..} = do
+getWarperLoggerConfig :: MonadIO m => LoggingParams -> m LoggerConfig
+getWarperLoggerConfig LoggingParams{..} = do
     let tree = mempty & ltSeverity .~ Just debugPlus -- (bool infoPlus debugPlus lpDebug)
     let cfgBuilder =
             (productionB <>
@@ -56,22 +63,54 @@ getRealLoggerConfig LoggingParams{..} = do
             & lcTree .~ tree
     cfg <- readLoggerConfig lpConfigPath
     pure $ cfg <> cfgBuilder
+  where
+    readLoggerConfig :: MonadIO m => Maybe FilePath -> m LoggerConfig
+    readLoggerConfig = maybe (pure productionB) parseLoggerConfig
+
+getSyslogLoggerConfig :: MonadIO m => LoggingParams -> m (SyslogConfig, Maybe Text)
+getSyslogLoggerConfig LoggingParams{..} =
+    case lpConfigPath of
+        Nothing -> return (fallbackLogConfig, Just "No configuration file specified")
+        Just filePath -> syslogConfigFromFile filePath >>= \case
+            Right config -> return (config, Nothing)
+            Left e -> return (fallbackLogConfig, Just $ show e)
+  where
+    fallbackLogConfig = SyslogConfig [fallbackLoggerConfig]
+    fallbackLoggerConfig = defaultLoggerConfig
+        & loggerName .~ show lpDefaultName
+        & withPERROR .~ True
+        & minLevel %~ if lpDebug then const Debug else id
 
 allocLogging :: LoggingParams -> ComponentM LoggingIO
 allocLogging params = buildComponent "logging" pre fin
   where
-    pre = do
-        config <- getRealLoggerConfig params
-        (config', logging) <-
-            prepareLogWarper config (GivenName $ lpDefaultName params)
-        printCfg logging config
-        printCfg logging config'
-        return logging
-    printCfg logging finalConfig =
+    selectedType = fromMaybe Syslog $ lpLoggingType params -- Syslog is default
+
+    pre = case selectedType of
+        Warper -> do
+            config <- getWarperLoggerConfig params
+            (config', logging) <-
+                prepareLogWarper config (GivenName $ lpDefaultName params)
+            printCfg logging config' Nothing
+            return logging
+        Syslog -> do
+            (config, warning) <- getSyslogLoggerConfig params
+            logging <- prepareSyslog config (GivenName $ lpDefaultName params)
+            printCfg logging config warning
+            return logging
+
+    fin _ = case selectedType of
+        Warper -> removeAllHandlers
+        Syslog -> stopLoggers
+
+    printCfg :: (ToJSON c) => LoggingIO -> c -> Maybe Text-> IO ()
+    printCfg logging finalConfig warning =
         runRIO logging $ modifyLogName (<> "init" <> "log") $ do
             let configText = decodeUtf8 (encode finalConfig) :: Text
             logInfo $ "Logging config: "+|configText|+""
-    fin _ = removeAllHandlers
+            whenJust warning $ \message -> logWarning $
+                "Problem with configuration loading: "+|message|+". Defaults \
+                \will be used."
 
 ---------------------------------------------------------------------------
 -- JSON instances
@@ -79,6 +118,12 @@ allocLogging params = buildComponent "logging" pre fin
 
 instance FromJSON Name where
     parseJSON = fmap fromString . parseJSON
+
+instance FromJSON LoggingType where
+    parseJSON = withText "LoggingType" $ \case
+        "Syslog" -> pure Syslog
+        "Warper" -> pure Warper
+        _ -> fail "Unknown logging type. Available options: Syslog or Warper"
 
 deriveFromJSON defaultOptions ''LoggingParams
 

--- a/core/src/Dscp/Util/Test.hs
+++ b/core/src/Dscp/Util/Test.hs
@@ -224,7 +224,7 @@ testLogging =
     { Log._log = \lvl _ msg ->
         when (lvl >= Log.Warning) $
             throwM $ TestLoggedError lvl msg
-    , Log._logName = return $ error "Loger name requested in test"
+    , Log._logName = return $ error "Logger name requested in test"
     }
 
 ----------------------------------------------------------------------------

--- a/docs/config-full-sample.yaml
+++ b/docs/config-full-sample.yaml
@@ -53,6 +53,8 @@ sample:
   witness:
     # Logging config for witness node
     logging:
+      # Logging type, optional, can be Warper (for `log-warper`) or Syslog (default)
+      loggingType: Syslog
       # Default logger name (displayed in logs in the beginnings of lines)
       defaultName: "witness"
       # Whether or not to enable debug logs
@@ -60,7 +62,7 @@ sample:
       # Directory where to put logs (optional)
       directory: "/var/log/dscp-witness"
       # Path to logger YAML config (optional)
-      configPath: "./run/log-config.yaml"
+      configPath: "./run/syslog-config.yaml"
 
     # RocksDB parameters
     db:
@@ -187,6 +189,7 @@ sample:
   faucet:
     # Logging config for faucet. See option `witness.logging`.
     logging:
+      loggingType: Warper
       defaultName: "faucet"
       debug: false
       directory: "/var/log/dscp-faucet"

--- a/faucet/src/Dscp/Faucet/Config.hs
+++ b/faucet/src/Dscp/Faucet/Config.hs
@@ -71,7 +71,7 @@ type HasFaucetConfig = Given FaucetConfigRec
 
 defaultFaucetConfig :: FaucetConfigRecP
 defaultFaucetConfig = mempty
-    & sub #faucet . option #logging ?~ LoggingParams "faucet" False Nothing Nothing
+    & sub #faucet . option #logging ?~ LoggingParams Nothing "faucet" False Nothing Nothing
     & sub #faucet . option #keys ?~ BaseKeyParams Nothing False Nothing
     & sub #faucet . option #dryRun ?~ DryRun False
 

--- a/run/syslog-config.yaml
+++ b/run/syslog-config.yaml
@@ -1,0 +1,14 @@
+loggers-tree:
+    witness:
+        withPERROR: true
+        min-level: Debug
+        sub-loggers:
+            network:
+                min-level: Info
+
+            web:
+                min-level: Info
+
+    init.log:
+        withPERROR: true
+        min-level: Debug

--- a/scripts/launch/node.sh
+++ b/scripts/launch/node.sh
@@ -100,7 +100,8 @@ witness_params="
 --witness-listen $witness_web_addr
 --comm-n 0
 --metrics-server 127.0.0.1:8125
---log-config run/log-config.yaml
+--log-config run/syslog-config.yaml
+--log-type Syslog
 "
 
 # parameters for faucet
@@ -114,7 +115,8 @@ faucet_params="
 --faucet-keyfile $files/faucet.key
 --faucet-gen-key
 --log-dir $tmp_files/logs
---log-config run/log-config.yaml
+--log-config run/syslog-config.yaml
+--log-type Syslog
 "
 
 # bot parameters

--- a/stack.yaml
+++ b/stack.yaml
@@ -44,7 +44,7 @@ extra-deps:
   commit: 2dd6b4ffdc4edb86b477273ee3c8416a1520f4e1
 
 - git: https://github.com/serokell/lootbox.git
-  commit: 9442232a992860abde6fad452eaaa74b0a6dc793
+  commit: d80183142db2dc07eb580662722b0e541fc48a5f
   subdirs:
     - code/base
     - code/config

--- a/witness/src/Dscp/CommonCLI.hs
+++ b/witness/src/Dscp/CommonCLI.hs
@@ -51,12 +51,18 @@ default config values are provided in respective `*.Config` modules.
 
 logParamsParser :: Log.Name -> Parser LoggingParams
 logParamsParser lpDefaultName = do
+    lpLoggingType <- logTypeParser
     lpDebug <- logDebugParser
     -- [Note default-cli-params]
     lpConfigPath <- Just <$> logConfigParser
     lpDirectory <- logDirParser
     return LoggingParams {..}
   where
+    logTypeParser = optional $ option auto $
+        long "log-type" <>
+        metavar "[Syslog | Warper]" <>
+        help "Logging type to use (Syslog or Warper). If not specified, \
+             \Syslog will be used."
     logDebugParser = switch $
         long "debug" <>
         help "Switch default logging level from Info to Debug"

--- a/witness/src/Dscp/Witness/Config.hs
+++ b/witness/src/Dscp/Witness/Config.hs
@@ -57,7 +57,7 @@ instance HasWitnessConfig => Given CoreConfigRec where
 
 defaultWitnessConfig :: WitnessConfigRecP
 defaultWitnessConfig = mempty
-    & sub #witness . option #logging ?~ LoggingParams "witness" False Nothing Nothing
+    & sub #witness . option #logging ?~ LoggingParams Nothing "witness" False Nothing Nothing
     & sub #witness . option #db ?~ RocksDBParams "witness-db"
     & sub #witness . option #keys ?~ Basic (BaseKeyParams Nothing False Nothing)
     & sub #witness . option #api ?~ Nothing


### PR DESCRIPTION
### Description

This adds syslog backend for logging.

NOTE: it is labeled WIP because it relies on a [yet unmerged branch](https://github.com/serokell/lootbox/tree/pasqu4le/lbt42-syslog-backend-for-loot-log) of `loot-box` made for issue [LTB-42](https://issues.serokell.io/issue/LTB-42)

There is now a new configuration option: `log-type` that defaults to `Syslog` but can be set to `Warper`. A new logging configuration file, that mimics the still-present warper one as much as possible, has been added: `run/syslog-config.yaml`.

### YT issue

https://issues.serokell.io/issue/DSCP-345

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [X] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [X] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [X] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [X] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [X] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [X] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [X] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [X] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
