### PR TITLE
[DSCP-335] Make explorer take mempool into consideration

### DIFF
--- a/core/src/Dscp/Util/Test.hs
+++ b/core/src/Dscp/Util/Test.hs
@@ -33,8 +33,9 @@ import Test.Hspec as T
 import Test.Hspec.QuickCheck as T (modifyMaxSuccess)
 import Test.QuickCheck as T (Arbitrary (..), Fixed (..), Gen, Property, Testable (..), conjoin,
                              cover, elements, expectFailure, forAll, frequency, infiniteList,
-                             infiniteListOf, ioProperty, label, listOf, listOf1, oneof, property,
-                             sublistOf, suchThat, suchThatMap, vectorOf, (.&&.), (===), (==>))
+                             infiniteListOf, ioProperty, label, listOf, listOf1, once, oneof,
+                             property, sublistOf, suchThat, suchThatMap, vectorOf, (.&&.), (===),
+                             (==>))
 import Test.QuickCheck (shuffle, sized)
 import qualified Test.QuickCheck as Q
 import Test.QuickCheck.Arbitrary.Generic as T (genericArbitrary, genericShrink)
@@ -187,6 +188,10 @@ counterexample desc prop = Q.counterexample (toString desc) prop
 -- | Generate smaller amounts of data.
 pickSmall :: (Monad m, Show a) => Gen a -> PropertyM m a
 pickSmall = pick . Q.resize 5
+
+-- | Decrease required number of successful runs of the test case.
+divideMaxSuccessBy :: Int -> SpecWith a -> SpecWith a
+divideMaxSuccessBy times = modifyMaxSuccess $ max 1 . (`div` times)
 
 ----------------------------------------------------------------------------
 -- CLI interface testing

--- a/specs/disciplina/witness/api/witness.yaml
+++ b/specs/disciplina/witness/api/witness.yaml
@@ -610,6 +610,7 @@ components:
             - InvalidFormat
             - MTxNoOutputs
             - MTxDuplicatedOutputs
+            - TransactionAlreadyExists
             - InsuffucientFees
             - AuthorDoesNotExist
             - SignatureIsCorrupted
@@ -625,6 +626,7 @@ components:
               * `InvalidFormat` - Failed to deserialise one of parameters.
               * `MTxNoOutputs` - Transaction has no outputs.
               * `MTxDuplicatedOutputs` - Transaction has duplicated outputs.
+              * `TransactionAlreadyExists` - Exactly the same transaction has been registered. Rarely this error may be transient, i.e. backend may fail to apply the transaction.
               * `InsufficientFees` - Input of transaction is too small to provide appropriate fees amount.
               * `SignatureIsCorrupted` - Bad signature provided.
               * `NotASingletonSelfUpdate` - Cannot send money to yourself more than once in transaction.

--- a/witness/src/Dscp/Snowdrop/AccountValidation.hs
+++ b/witness/src/Dscp/Snowdrop/AccountValidation.hs
@@ -12,6 +12,7 @@ module Dscp.Snowdrop.AccountValidation
        , requirePart
        , assertSigned
        , assertExists
+       , nothingToLocalError
        , check
        ) where
 
@@ -169,6 +170,11 @@ assertExists ::
     -> ERoComp e id value ctx a
 assertExists thing message =
     maybe (throwLocalError message) pure =<< queryOne thing
+
+nothingToLocalError
+    :: HasReview e e1
+    => e1 -> Maybe a -> ERoComp e id value ctx a
+nothingToLocalError err mThing = maybe (throwLocalError err) pure mThing
 
 validateSaneDeparture
   :: forall ctx

--- a/witness/src/Dscp/Snowdrop/Configuration.hs
+++ b/witness/src/Dscp/Snowdrop/Configuration.hs
@@ -36,6 +36,7 @@ module Dscp.Snowdrop.Configuration
     , Exceptions (..)
     , _AccountError
     , _PublicationError
+    , _LogicError
 
     , TxIds (..)
 
@@ -230,12 +231,12 @@ data Values
     = TipValueVal        (TipValue HeaderHash)
     | BlundVal            SBlund
     | AccountOutVal       Account
-    | TxVal               TxData
+    | TxVal               TxItself
     | TxBlockVal          TxBlockRef
     | TxOfVal             LastTx
     | TxHeadVal           TxNext
     | PrivateBlockTxVal   T.PublicationTxId
-    | PublicationVal      PublicationData
+    | PublicationVal      PublicationItself
     | PublicationOfVal    LastPublication
     | PublicationHeadVal  PublicationNext
     | NextBlockOfVal      NextBlock
@@ -245,12 +246,12 @@ data Values
 type instance SValue  TipKey               = TipValue HeaderHash
 type instance SValue (BlockRef HeaderHash) = SBlund
 type instance SValue  AccountId            = Account
-type instance SValue  T.TxId               = TxData
+type instance SValue  T.TxId               = TxItself
 type instance SValue  TxBlockRefId         = TxBlockRef
 type instance SValue  TxsOf                = LastTx
 type instance SValue  TxHead               = TxNext
 type instance SValue  T.PrivateHeaderHash  = T.PublicationTxId
-type instance SValue  T.PublicationTxId    = PublicationData
+type instance SValue  T.PublicationTxId    = PublicationItself
 type instance SValue  PublicationsOf       = LastPublication
 type instance SValue  PublicationHead      = PublicationNext
 type instance SValue  NextBlockOf          = NextBlock

--- a/witness/src/Dscp/Snowdrop/Configuration.hs
+++ b/witness/src/Dscp/Snowdrop/Configuration.hs
@@ -17,8 +17,8 @@ module Dscp.Snowdrop.Configuration
     , publicationIdsPrefix
     , publicationOfPrefix
     , publicationHeadPrefix
-    , publicationBlockIdsPrefix
     , txPrefix
+    , txBlockPrefix
     , txOfPrefix
     , txHeadPrefix
     , nextBlockPrefix
@@ -148,8 +148,8 @@ blockIdxPrefix = Prefix 10
 publicationIdsPrefix :: Prefix
 publicationIdsPrefix = Prefix 11
 
-publicationBlockIdsPrefix :: Prefix
-publicationBlockIdsPrefix = Prefix 12
+txBlockPrefix :: Prefix
+txBlockPrefix = Prefix 12
 
 privateBlockTxPrefix :: Prefix
 privateBlockTxPrefix = Prefix 13
@@ -163,8 +163,8 @@ blockPrefixes = S.fromList
     , publicationIdsPrefix
     , publicationOfPrefix
     , publicationHeadPrefix
-    , publicationBlockIdsPrefix
     , txPrefix
+    , txBlockPrefix
     , txOfPrefix
     , txHeadPrefix
     , nextBlockPrefix
@@ -176,14 +176,14 @@ data Ids
     = TipKeyIds           TipKey
     | BlockRefIds        (BlockRef  HeaderHash)
     | AccountInIds        AccountId
-    | TxIds               T.GTxId
+    | TxIds               T.TxId
+    | TxBlockIds          TxBlockRefId
     | TxOfIds             TxsOf
     | TxHeadIds           TxHead
     | PrivateBlockTx      T.PrivateHeaderHash
     | PublicationIds      T.PublicationTxId
     | PublicationOfIds    PublicationsOf
     | PublicationHeadIds  PublicationHead
-    | PublicationBlockIds PublicationBlock
     | NextBlockOfIds      NextBlockOf
     | BlockIdxIds         T.Difficulty
     deriving (Eq, Ord, Show, Generic)
@@ -193,14 +193,14 @@ instance Buildable Ids where
         TipKeyIds           t            -> build t
         BlockRefIds        (BlockRef  r) -> "block ref " +| hashF r
         AccountInIds       (AccountId a) -> build a
-        TxIds               gTxId        -> build gTxId
+        TxIds               ti           -> build ti
+        TxBlockIds          ri           -> build ri
         TxOfIds             t            -> build t
         TxHeadIds           th           -> build th
         PrivateBlockTx      h            -> build h
         PublicationIds      i            -> build i
         PublicationOfIds    p            -> build p
         PublicationHeadIds  ph           -> build ph
-        PublicationBlockIds pb           -> build pb
         NextBlockOfIds      hh           -> build hh
         BlockIdxIds         d            -> build d
 
@@ -209,6 +209,7 @@ instance IdSumPrefixed Ids where
     idSumPrefix (BlockRefIds         _) = blockPrefix
     idSumPrefix (AccountInIds        _) = accountPrefix
     idSumPrefix (TxIds               _) = txPrefix
+    idSumPrefix (TxBlockIds          _) = txBlockPrefix
     idSumPrefix (TxOfIds             _) = txOfPrefix
     idSumPrefix (TxHeadIds           _) = txHeadPrefix
     idSumPrefix (PrivateBlockTx      _) = privateBlockTxPrefix
@@ -217,7 +218,6 @@ instance IdSumPrefixed Ids where
     idSumPrefix (PublicationHeadIds  _) = publicationHeadPrefix
     idSumPrefix (NextBlockOfIds      _) = nextBlockPrefix
     idSumPrefix (BlockIdxIds         _) = blockIdxPrefix
-    idSumPrefix (PublicationBlockIds _) = publicationBlockIdsPrefix
 
 instance HasReview Ids (BlockRef (CurrentBlockRef HeaderHash)) where
     inj (BlockRef (CurrentBlockRef h)) = BlockRefIds (BlockRef h)
@@ -230,14 +230,14 @@ data Values
     = TipValueVal        (TipValue HeaderHash)
     | BlundVal            SBlund
     | AccountOutVal       Account
-    | TxVal               TxBlockRef
+    | TxVal               TxData
+    | TxBlockVal          TxBlockRef
     | TxOfVal             LastTx
     | TxHeadVal           TxNext
     | PrivateBlockTxVal   T.PublicationTxId
     | PublicationVal      PublicationData
     | PublicationOfVal    LastPublication
     | PublicationHeadVal  PublicationNext
-    | PublicationBlockVal PublicationBlockRef
     | NextBlockOfVal      NextBlock
     | BlockIdxVal         HeaderHash
     deriving (Eq, Show, Generic)
@@ -245,14 +245,14 @@ data Values
 type instance SValue  TipKey               = TipValue HeaderHash
 type instance SValue (BlockRef HeaderHash) = SBlund
 type instance SValue  AccountId            = Account
-type instance SValue  T.GTxId              = TxBlockRef
+type instance SValue  T.TxId               = TxData
+type instance SValue  TxBlockRefId         = TxBlockRef
 type instance SValue  TxsOf                = LastTx
 type instance SValue  TxHead               = TxNext
 type instance SValue  T.PrivateHeaderHash  = T.PublicationTxId
 type instance SValue  T.PublicationTxId    = PublicationData
 type instance SValue  PublicationsOf       = LastPublication
 type instance SValue  PublicationHead      = PublicationNext
-type instance SValue  PublicationBlock     = PublicationBlockRef
 type instance SValue  NextBlockOf          = NextBlock
 type instance SValue  T.Difficulty         = HeaderHash
 

--- a/witness/src/Dscp/Snowdrop/Expanders.hs
+++ b/witness/src/Dscp/Snowdrop/Expanders.hs
@@ -167,7 +167,7 @@ seqExpandersPublicationTx feesReceiverAddr (Fees minFee) =
             pure $ mkDiffCS $ Map.fromList $
                 [ PublicationsOf  ptAuthor ==> change (LastPublication phHash)
                 , PublicationHead phHash   ==> New    (PublicationNext prevHashM)
-                , PublicationIds  ptxId    ==> New    (PublicationData ptw)
+                , PublicationIds  ptxId    ==> New    (PublicationItself ptw)
                 , PrivateBlockTx  phHash   ==> New    (PrivateBlockTxVal ptxId)
                 ] ++ feesChanges
 
@@ -248,7 +248,7 @@ seqExpandersBalanceTx feesReceiverAddr (Fees minimalFees) =
         when txAlreadyExists $
             throwLocalError $ TransactionAlreadyExists (pretty txId)
 
-        let miscChanges = txId ==> New (TxData tw)
+        let miscChanges = txId ==> New (TxItself tw)
 
         miscChanges2 <- forM (inAddr : map txOutAddr outOther) $ \txAddr ->
             queryOne (TxsOf txAddr) >>= return . \case
@@ -302,7 +302,7 @@ seqExpandersBalanceTx feesReceiverAddr (Fees minimalFees) =
     -- Account prefixes are used during the computation to access current balance
     inP  = Set.fromList [accountPrefix, txOfPrefix]
     -- Expander returns account changes only
-    outP = Set.fromList [accountPrefix, txHeadPrefix, txOfPrefix]
+    outP = Set.fromList [accountPrefix, txPrefix, txHeadPrefix, txOfPrefix]
 
 --------------------------------------------------------------------------
 -- Utils

--- a/witness/src/Dscp/Snowdrop/Instances.hs
+++ b/witness/src/Dscp/Snowdrop/Instances.hs
@@ -28,6 +28,7 @@ instance ToServantErr AccountException where
     toServantErrNoBody = \case
         MTxNoOutputs{}                -> err400
         MTxDuplicateOutputs{}         -> err400
+        TransactionAlreadyExists{}    -> err403
         InsufficientFees{}            -> err400
         SignatureIsMissing{}          -> err500
         SignatureIsCorrupted{}        -> err400

--- a/witness/src/Dscp/Snowdrop/Storage/Types.hs
+++ b/witness/src/Dscp/Snowdrop/Storage/Types.hs
@@ -2,8 +2,8 @@ module Dscp.Snowdrop.Storage.Types
     ( TxBlockRefId (..)
     , TxBlockRef (..)
 
-    , TxData (..)
-    , tdTx
+    , TxItself (..)
+    , tiTx
     , TxsOf (..)
     , LastTx (..)
     , TxHead (..)
@@ -14,8 +14,8 @@ module Dscp.Snowdrop.Storage.Types
     , PublicationBlock (..)
     , PublicationHead (..)
     , PublicationNext (..)
-    , PublicationData (..)
-    , pdTx
+    , PublicationItself (..)
+    , piTx
 
     , NextBlockOf (..)
     , NextBlock (..)
@@ -40,15 +40,15 @@ data TxBlockRef = TxBlockRef
     }
     deriving (Eq, Ord, Show, Generic)
 
-newtype TxData = TxData
-    { tdTw :: TxWitnessed
+newtype TxItself = TxItself
+    { tiTw :: TxWitnessed
     } deriving (Eq, Ord, Show, Generic)
 
-tdTx :: TxData -> Tx
-tdTx = twTx . tdTw
+tiTx :: TxItself -> Tx
+tiTx = twTx . tiTw
 
-instance Buildable TxData where
-    build (TxData tx) = "TxData { " +| twTx tx |+ " }"
+instance Buildable TxItself where
+    build (TxItself tx) = "TxItself { " +| twTx tx |+ " }"
 
 -- | Account transaction linked-list storage structure.
 -- |
@@ -121,16 +121,16 @@ data PublicationNext
     deriving (Eq, Ord, Show, Generic)
 
 -- | Publication taken by id.
-newtype PublicationData = PublicationData
-    { pdTw   :: PublicationTxWitnessed
+newtype PublicationItself = PublicationItself
+    { piTw   :: PublicationTxWitnessed
     } deriving (Eq, Ord, Show, Generic)
 
-pdTx :: PublicationData -> PublicationTx
-pdTx = ptwTx . pdTw
+piTx :: PublicationItself -> PublicationTx
+piTx = ptwTx . piTw
 
-instance Buildable PublicationData where
+instance Buildable PublicationItself where
     build pd =
-        "PublicationData {" +| pdTx pd |+ " }"
+        "PublicationItself {" +| piTx pd |+ " }"
 
 -- | Key/value types for nextBlock chain storage
 newtype NextBlockOf = NextBlockOf { unNextBlockOf :: HeaderHash }
@@ -145,7 +145,7 @@ newtype NextBlock = NextBlock { unNextBlock :: HeaderHash }
 
 instance Serialise TxBlockRefId
 instance Serialise TxBlockRef
-instance Serialise TxData
+instance Serialise TxItself
 instance Serialise LastTx
 instance Serialise TxsOf
 instance Serialise TxNext
@@ -155,6 +155,6 @@ instance Serialise PublicationsOf
 instance Serialise PublicationNext
 instance Serialise PublicationHead
 instance Serialise PublicationBlock
-instance Serialise PublicationData
+instance Serialise PublicationItself
 instance Serialise NextBlockOf
 instance Serialise NextBlock

--- a/witness/src/Dscp/Snowdrop/Types.hs
+++ b/witness/src/Dscp/Snowdrop/Types.hs
@@ -17,6 +17,7 @@ module Dscp.Snowdrop.Types
     , AccountException(..)
     , _MTxNoOutputs
     , _MTxDuplicateOutputs
+    , _TransactionAlreadyExists
     , _InsufficientFees
     , _SignatureIsMissing
     , _SignatureIsCorrupted
@@ -38,8 +39,7 @@ import Data.Text.Buildable (Buildable (..))
 import Fmt (build, (+|), (|+))
 import qualified Text.Show
 
-import Dscp.Core (unsafeMkCoin)
-import Dscp.Core.Foundation (Address, Nonce)
+import Dscp.Core
 
 -- | Transaction type for publication.
 data PublicationTxTypeId
@@ -85,6 +85,8 @@ data AccountTxTypeId = AccountTxTypeId deriving (Eq, Ord, Show, Generic)
 data AccountException
     = MTxNoOutputs
     | MTxDuplicateOutputs
+    | TransactionAlreadyExists
+      { taeTxId :: Text }
     | InsufficientFees
       { aeExpectedFees :: Integer, aeActualFees :: Integer }
     | SignatureIsMissing
@@ -116,6 +118,8 @@ instance Buildable AccountException where
             "Transaction has no outputs"
         MTxDuplicateOutputs ->
             "Duplicated transaction outputs"
+        TransactionAlreadyExists{..} ->
+            "Transaction " +| taeTxId |+ " has already been registered"
         InsufficientFees{..} ->
             "Amount of money left for fees in transaction is not enough, \
              \expected " +| unsafeMkCoin aeExpectedFees |+ ", got " +| unsafeMkCoin aeActualFees |+ ""
@@ -133,7 +137,7 @@ instance Buildable AccountException where
         PaymentMustBePositive ->
             "Spent amount of money must be positive"
         ReceiverOnlyGetsMoney ->
-            "Improper changes of receiver account (its is only possible to add \
+            "Improper changes of receiver account (it is only possible to add \
             \tokens)"
         ReceiverMustIncreaseBalance ->
             "One of receivers' balance decreased or didn't change"

--- a/witness/src/Dscp/Witness/Listeners/Listener.hs
+++ b/witness/src/Dscp/Witness/Listeners/Listener.hs
@@ -76,7 +76,7 @@ getBlocksListener =
   where
     respond btq cliId (GetBlocksMsg{..}) = do
         logDebug "getBlocksMsg: received request"
-        res <- runSdMRead $ getBlocksFromTo gbOlder gbNewer
+        res <- runSdMLocked $ getBlocksFromTo gbOlder gbNewer
         let response = either NoBlocksMsg BlocksMsg res
         atomically $ servSend btq cliId response
         logDebug "getBlocksMsg: response sent"
@@ -88,7 +88,7 @@ getTipListener =
   where
     respond btq cliId GetTipMsg = do
         logDebug "getTipMsg: received request"
-        tip <- runSdMRead getTipBlock
+        tip <- runSdMLocked getTipBlock
         atomically $ servSend btq cliId (TipMsg tip)
         logDebug "getTipMsg: response sent"
 

--- a/witness/src/Dscp/Witness/Logic/Apply.hs
+++ b/witness/src/Dscp/Witness/Logic/Apply.hs
@@ -18,7 +18,6 @@ import qualified Snowdrop.Execution as SD
 import qualified Snowdrop.Util as SD
 
 import Dscp.Core
-import Dscp.Crypto
 import Dscp.DB.CanProvideDB (providePlugin)
 import Dscp.Snowdrop
 import qualified Dscp.Snowdrop.Storage.Avlp as Avlp
@@ -66,15 +65,9 @@ applyBlockRaw applyFees toVerify block = do
 
             addTx (idx, gTx) = SD.modifyRwCompChgAccum $ SD.CAMChange $ SD.ChangeSet $
                 M.fromList $
-                    [ ( SD.inj . toGTxId . unGTxWitnessed $ gTx
-                      , SD.New . TxVal $ TxBlockRef (headerHash block) idx
+                    [ ( SD.inj . TxBlockRefId . toGTxId . unGTxWitnessed $ gTx
+                      , SD.New . TxBlockVal $ TxBlockRef (headerHash block) idx
                       )
-                    ] ++
-                    [ ( SD.inj . PublicationBlock $ hash pubTx
-                      , SD.New . SD.inj $ PublicationBlockRef (headerHash block)
-                      )
-                    | GPublicationTxWitnessed pubTxw <- pure gTx
-                    , let pubTx = ptwTx pubTxw
                     ]
           in do
               Avlp.initAVLStorage @AvlHash plugin initAccounts

--- a/witness/src/Dscp/Witness/Logic/Exceptions.hs
+++ b/witness/src/Dscp/Witness/Logic/Exceptions.hs
@@ -2,8 +2,13 @@
 
 module Dscp.Witness.Logic.Exceptions
     ( LogicException (..)
+    , _LEBlockAbsent
+    , _LETxAbsent
+    , _LEPrivateBlockAbsent
+    , _LEMalformed
     ) where
 
+import Control.Lens (makePrisms)
 import Data.Data (Data)
 import qualified Data.Text.Buildable as B
 import qualified Text.Show
@@ -14,6 +19,8 @@ data LogicException
     | LEPrivateBlockAbsent Text
     | LEMalformed Text
     deriving (Eq, Data)
+
+makePrisms ''LogicException
 
 instance Show LogicException where
     show = toString . pretty

--- a/witness/src/Dscp/Witness/Logic/Getters.hs
+++ b/witness/src/Dscp/Witness/Logic/Getters.hs
@@ -163,9 +163,9 @@ getTxMaybe
     :: HasWitnessConfig
     => GTxId -> SdM_ chgacc (Maybe GTxWitnessed)
 getTxMaybe gTxId = runMaybeT $ asum
-    [ fmap (GMoneyTxWitnessed . tdTw) . MaybeT $
+    [ fmap (GMoneyTxWitnessed . tiTw) . MaybeT $
           SD.queryOne (coerce @_ @TxId gTxId)
-    , fmap (GPublicationTxWitnessed . pdTw) . MaybeT $
+    , fmap (GPublicationTxWitnessed . piTw) . MaybeT $
           SD.queryOne (coerce @_ @PublicationTxId gTxId)
     ]
 

--- a/witness/src/Dscp/Witness/Logic/Traversals.hs
+++ b/witness/src/Dscp/Witness/Logic/Traversals.hs
@@ -11,7 +11,9 @@ module Dscp.Witness.Logic.Traversals
     , getBlocksBefore
 
     , txsSource
+    , chainTxsSource
     , accountTxsSource
+    , chainPublicationsSource
     , publicationsSource
     , educatorPublicationsSource
     ) where
@@ -30,8 +32,11 @@ import Dscp.Core
 import Dscp.Snowdrop
 import Dscp.Util
 import Dscp.Witness.Config
+import Dscp.Witness.Launcher.Context
 import Dscp.Witness.Logic.Exceptions
 import Dscp.Witness.Logic.Getters
+import Dscp.Witness.Mempool
+import Dscp.Witness.SDLock
 
 ----------------------------------------------------------------------------
 -- One-direction traversals
@@ -199,18 +204,16 @@ getBlocksBefore depthDiff (headerHash -> newerH) = runExceptT $ do
     pure blocks
 
 -- | Retrieves transactions starting with the given one down the chain.
--- If no transaction is provided, transactions are retrieved starting from the
--- most recent ones.
-txsSource ::
-       HasWitnessConfig
-    => Maybe GTxId
-    -> C.ConduitT () (WithBlock GTxWitnessed) SdM ()
-txsSource = \case
-    Nothing -> lift getTipBlock >>= loadTxs Nothing
+-- If no transaction is provided, transactions are retrieved starting from the tip.
+chainTxsSource
+    :: (WitnessWorkMode ctx m, KnownSdReadMode mode, WithinReadSDLock)
+    => Maybe GTxId -> C.ConduitT () (WithBlock GTxWitnessed) (SdReadM mode m) ()
+chainTxsSource = \case
+    Nothing -> lift2xSdM getTipBlock >>= loadTxs Nothing
     Just gTxId -> do
-        (block, txIdx) <- lift $ do
-            TxBlockRef{..} <- gTxId `assertExists` LETxAbsent ("Can't get block ref for tx " <> show gTxId)
-            block <- nothingToError (SD.inj . LEMalformed $ "Can't get block " <> show tbrBlockRef)
+        (block, txIdx) <- lift2xSdM $ do
+            TxBlockRef{..} <- (TxBlockRefId gTxId) `assertExists` LETxAbsent ("Can't get block ref for tx " <> show gTxId)
+            block <- nothingToLocalError (LEMalformed $ "Can't get block " <> show tbrBlockRef)
                 =<< getBlockMaybe tbrBlockRef
             return (block, tbrTxIdx)
         loadTxs (Just txIdx) block
@@ -219,7 +222,7 @@ txsSource = \case
         -- last txs in the block go first
         C.yieldMany (reverse $ maybe id (take . succ) mIdx txs)
 
-        nextBlock <- lift . runMaybeT $
+        nextBlock <- lift2xSdM . runMaybeT $
             MaybeT (resolvePrevious block) >>= MaybeT . getBlockMaybe
         whenJust nextBlock (loadTxs Nothing)
       where
@@ -228,14 +231,16 @@ txsSource = \case
 
 -- | Get a list of all transactions for a given account.
 accountTxsSource
-    :: HasWitnessConfig
-    => Address -> Maybe GTxId -> C.ConduitT () (WithBlock GTxWitnessed) SdM ()
+    :: (WitnessWorkMode ctx m, KnownSdReadMode mode, WithinReadSDLock)
+    => Address
+    -> Maybe GTxId
+    -> C.ConduitT () (WithBlock GTxWitnessed) (SdReadM mode m) ()
 accountTxsSource address mStart =
-    loadTxs .| C.mapM getTx
+    loadTxs .| C.mapM (liftSdM . getTxWithBlock)
   where
     loadTxs = case mStart of
         Nothing ->
-            lift (SD.queryOne (TxsOf address)) >>=
+            lift2xSdM (SD.queryOne (TxsOf address)) >>=
             loadNextTx . map unLastTx
         Just start ->
             loadNextTx (Just start)
@@ -243,16 +248,57 @@ accountTxsSource address mStart =
         Nothing -> pass
         Just gTxId -> do
             C.yield gTxId
-            lift (SD.queryOne (TxHead address gTxId)) >>=
+            lift2xSdM (SD.queryOne (TxHead address gTxId)) >>=
                 loadNextTx . map unTxNext
 
--- | Retrieves private blocks starting with the given one down the chain.
--- If no transaction is provided, blocks are retrieved starting from the most
--- recent one.
-publicationsSource
-    :: HasWitnessConfig
+-- | Get all mempool transactions.
+mempoolTxsSource
+    :: (WitnessWorkMode ctx m, WithinReadSDLock)
+    => C.ConduitT () GTxWitnessed (SdReadM 'ChainAndMempool m) ()
+mempoolTxsSource = lift (lift $ readTxsMempool) >>= C.yieldMany
+
+-- | Get all transactions, from both chain and mempool, starting from the given one.
+txsSource
+    :: (WitnessWorkMode ctx m, WithinReadSDLock)
+    => Maybe GTxId
+    -> C.ConduitT () (WithBlock GTxWitnessed) (SdReadM 'ChainAndMempool m) ()
+txsSource Nothing = do
+    mempoolTxsSource .| C.map (WithBlock Nothing)
+    chainTxsSource Nothing
+txsSource (Just start) = do
+    lift2xSdM (SD.queryOne $ TxBlockRefId start) >>= \case
+        Just TxBlockRef{} ->
+            chainTxsSource (Just start)
+        Nothing -> do
+            mempoolTxsSource
+                .| C.dropWhile ((/= start) . toGTxwId)
+                .| C.map (WithBlock Nothing)
+                .| ensureHasAtLeastOneTx
+            chainTxsSource Nothing
+  where
+    ensureHasAtLeastOneTx =
+        C.await >>= \case
+            Nothing -> lift2xSdM $ SD.throwLocalError $
+                       LETxAbsent $ "Transaction not found: " <> show start
+            Just tx -> C.leftover tx
+
+-- | Retrieves publication transaction starting with the given one down the chain.
+-- If no transaction is provided, blocks are retrieved starting from the tip.
+chainPublicationsSource
+    :: (WitnessWorkMode ctx m, KnownSdReadMode mode, WithinReadSDLock)
     => Maybe PublicationTxId
-    -> C.ConduitT () (WithBlock PublicationTx) SdM ()
+    -> C.ConduitT () (WithBlock PublicationTx) (SdReadM mode m) ()
+chainPublicationsSource mStart' = do
+    let mStart = coerce @(Maybe PublicationTxId) @(Maybe GTxId) mStart'
+    chainTxsSource mStart
+        .| C.concatMap (mapM @WithBlock $ preview (_GPublicationTxWitnessed . ptwTxL))
+
+-- | Retrieves publication transaction, both from chain and mempool, starting from the
+-- given one.
+publicationsSource
+    :: (WitnessWorkMode ctx m, WithinReadSDLock)
+    => Maybe PublicationTxId
+    -> C.ConduitT () (WithBlock PublicationTx) (SdReadM 'ChainAndMempool m) ()
 publicationsSource mStart' = do
     let mStart = coerce @(Maybe PublicationTxId) @(Maybe GTxId) mStart'
     txsSource mStart
@@ -263,29 +309,29 @@ publicationsSource mStart' = do
 -- If no transaction is provided, blocks are retrieved starting from the most
 -- recent one.
 educatorPublicationsSource
-    :: HasWitnessConfig
+    :: (WitnessWorkMode ctx m, KnownSdReadMode mode, WithinReadSDLock)
     => Address
     -> Maybe PublicationTxId
-    -> C.ConduitT () (WithBlock PublicationTx) SdM ()
+    -> C.ConduitT () (WithBlock PublicationTx) (SdReadM mode m) ()
 educatorPublicationsSource educator = \case
     Nothing -> do
-        mheader <- lift $ SD.queryOne (PublicationsOf educator)
+        mheader <- lift2xSdM $ SD.queryOne (PublicationsOf educator)
         whenJust mheader $ \(LastPublication header) -> do
-            ptxId <- lift $ header `assertExists` noPrivHeader header
+            ptxId <- lift2xSdM $ header `assertExists` noPrivHeader header
             loadChain ptxId
     Just ptxId -> loadChain ptxId
   where
     loadChain ptxId = do
-        PublicationData{ pdTx = ptx } <-
-            lift $ ptxId `assertExists` noPubTxId ptxId
-        mblock <- lift $ do
-            mBlockHash <- SD.queryOne (PublicationBlock ptxId)
-            mapM (getBlock . unPublicationBlockRef) mBlockHash
+        ptx <-
+            lift2xSdM $ fmap pdTx $ ptxId `assertExists` noPubTxId ptxId
+        mblock <- lift2xSdM $ do
+            mBlockHash <- SD.queryOne (TxBlockRefId $ coerce ptxId)
+            mapM (getBlock . tbrBlockRef) mBlockHash
         C.yield $ WithBlock mblock ptx
 
         let prevHash = _pbhPrevBlock (ptHeader ptx)
         unless (prevHash == genesisHeaderHash) $
-            lift (prevHash `assertExists` noPrivHeader prevHash)
+            lift2xSdM (prevHash `assertExists` noPrivHeader prevHash)
             >>= loadChain
 
     noPrivHeader (h :: PrivateHeaderHash) =

--- a/witness/src/Dscp/Witness/Web/Logic.hs
+++ b/witness/src/Dscp/Witness/Web/Logic.hs
@@ -21,16 +21,17 @@ import Fmt ((+|), (|+))
 
 import Dscp.Core
 import Dscp.Snowdrop
-import Dscp.Util (fromHex, nothingToThrow)
+import Dscp.Util (fromHex)
 import Dscp.Util
 import Dscp.Util.Concurrent.NotifyWait
 import Dscp.Witness.Config
 import Dscp.Witness.Launcher.Context (WitnessWorkMode)
 import Dscp.Witness.Logic
+import Dscp.Witness.Mempool
 import qualified Dscp.Witness.Relay as Relay
 import Dscp.Witness.SDLock
-import Dscp.Witness.Web.Error
 import Dscp.Witness.Web.Types
+import qualified Snowdrop.Util as SD
 
 ----------------------------------------------------------------------------
 -- Logic
@@ -49,7 +50,9 @@ submitUserTxAsync :: WitnessWorkMode ctx m => TxWitnessed -> m ()
 submitUserTxAsync tw =
     void . Relay.relayTx $ GMoneyTxWitnessed tw
 
-toBlockInfo :: HasWitnessConfig => Bool -> Block -> SdM BlockInfo
+toBlockInfo
+    :: HasWitnessConfig
+    => Bool -> Block -> SdM_ chgacc BlockInfo
 toBlockInfo includeTxs block = do
     nextHash <- resolveNext hh
     pure BlockInfo
@@ -75,12 +78,12 @@ toBlockInfo includeTxs block = do
     txTotalOutput (GPublicationTx _) = Coin 0
 
 toAccountInfo
-    :: WitnessWorkMode ctx m
+    :: (WitnessWorkMode ctx m, KnownSdReadMode mode, WithinReadSDLock)
     => BlocksOrMempool Account
     -> Maybe [WithBlock GTxWitnessed]
-    -> m AccountInfo
+    -> SdReadM mode m AccountInfo
 toAccountInfo account txs = do
-    transactions <- runSdMRead $ mapM (mapM (fetchBlockInfo . fmap @WithBlock unGTxWitnessed)) txs
+    transactions <- mapM (mapM (liftSdM . fetchBlockInfo . fmap @WithBlock unGTxWitnessed)) txs
     pure AccountInfo
         { aiBalances = Coin . fromIntegral . aBalance <$> account
         , aiCurrentNonce = nonce
@@ -90,7 +93,9 @@ toAccountInfo account txs = do
   where
     nonce = aNonce $ bmTotal account
 
-fetchBlockInfo :: HasWitnessConfig => WithBlock a -> SdM (WithBlockInfo a)
+fetchBlockInfo
+    :: HasWitnessConfig
+    => WithBlock a -> SdM_ chgacc (WithBlockInfo a)
 fetchBlockInfo txWithBlock = do
     blockInfo <- mapM (toBlockInfo False) $ wbBlock txWithBlock
     pure WithBlockInfo
@@ -99,35 +104,37 @@ fetchBlockInfo txWithBlock = do
         }
 
 getBlocks :: WitnessWorkMode ctx m => Maybe Word64 -> Maybe Int -> m BlockList
-getBlocks mSkip mCount = do
-    (eBlocks, totalCount) <- runSdMRead $ do
-        eBlocks <- getBlocksFrom skip count
-        totalCount <- (+ 1) . unDifficulty . hDifficulty <$> getTipHeader
-        return (eBlocks, totalCount)
-    either (throwM . InternalError) (toBlockList totalCount <=< mapM (runSdMRead . toBlockInfo False) . reverse . toList) eBlocks
+getBlocks mSkip mCount = runSdMLocked $ do
+    blocks <- either (SD.throwLocalError . LEBlockAbsent) pure =<<
+               getBlocksFrom skip count
+    totalCount <- (+ 1) . unDifficulty . hDifficulty <$> getTipHeader
+    toBlockList totalCount =<< mapM (toBlockInfo False) (reverse $ toList blocks)
   where
     count = min 100 $ fromMaybe 100 mCount
     skip = fromMaybe 0 mSkip
     toBlockList blTotalCount blBlocks = pure BlockList{..}
 
-getBlockInfo :: WitnessWorkMode ctx m => HeaderHash -> m BlockInfo
-getBlockInfo hh =
-    runSdMRead (getBlockMaybe hh) >>=
-    nothingToThrow (LogicError $ LEBlockAbsent $ "Block " +| hh |+ " not found") >>=
-    runSdMRead . toBlockInfo True
+getBlockInfo
+    :: WitnessWorkMode ctx m
+    => HeaderHash -> m BlockInfo
+getBlockInfo hh = runSdMLocked $
+    getBlockMaybe hh >>=
+    nothingToLocalError (LEBlockAbsent $ "Block " +| hh |+ " not found") >>=
+    toBlockInfo True
 
 getAccountInfo :: WitnessWorkMode ctx m => Address -> Bool -> m AccountInfo
 getAccountInfo address includeTxs = do
     account <- readingSDLock $ do
-        blockAccount <- fromMaybe def <$> getAccountMaybe address
-        poolAccount  <- fromMaybe def <$> getMempoolAccountMaybe address
+        blockAccount <- runSdReadM $ fromMaybe def <$> getAccountMaybe address
+        poolAccount  <- runSdReadM $ fromMaybe def <$> getMempoolAccountMaybe address
         return BlocksOrMempool
               { bmConfirmed = blockAccount
               , bmTotal     = poolAccount }
     txs <- if includeTxs
-        then Just <$> getAccountTxs address
+        then runSdMLocked $ Just <$> getAccountTxs address
         else return Nothing
-    toAccountInfo account txs
+    -- TODO [DSCP-335] What to do with this?
+    runSdReadMLocked @'ChainOnly $ toAccountInfo account txs
 
 toPaginatedList :: (Show a, Show (Id a)) => HasId a => Int -> [a] -> PaginatedList d a
 toPaginatedList count allItems =
@@ -146,32 +153,29 @@ getTransactions
     :: (WitnessWorkMode ctx m)
     => Maybe Int -> Maybe TxId -> Maybe Address -> m TxList
 getTransactions mCount mFrom mAddress = do
-    runSdMRead . C.runConduit $
-        ourTxsSource
+    runSdReadMLocked $ C.runConduit $
+        maybe txsSource accountTxsSource mAddress (coerce mFrom)
             .| C.concatMap (mapM @WithBlock $ preview (_GMoneyTxWitnessed . twTxL))
-            .| C.mapM fetchBlockInfo
+            .| C.mapM (liftSdM . fetchBlockInfo)
             .| sinkTruncate count
   where
-    ourTxsSource = maybe txsSource accountTxsSource mAddress (coerce mFrom)
     count = min 100 $ fromMaybe 100 mCount
 
 getTransactionInfo :: WitnessWorkMode ctx m => GTxId -> m GTxInfo
-getTransactionInfo txId =
-    runSdMRead (getTxMaybe txId) >>=
-    nothingToThrow (LogicError . LETxAbsent $ "Transaction not found " +| txId |+ "") >>=
-    runSdMRead . fetchBlockInfo . fmap @WithBlock unGTxWitnessed
+getTransactionInfo txId = runSdMLocked $
+    getTxWithBlock txId >>=
+    fetchBlockInfo . fmap @WithBlock unGTxWitnessed
 
 getPublications
     :: WitnessWorkMode ctx m
     => Maybe Int -> Maybe PublicationTxId -> Maybe Address -> m PublicationList
 getPublications mCount mFrom mEducator = do
-    runSdMRead . C.runConduit $
-        pubsSource
-            .| C.mapM fetchBlockInfo
+    runSdReadMLocked $ C.runConduit $
+        maybe publicationsSource educatorPublicationsSource mEducator mFrom
+            .| C.mapM (liftSdM . fetchBlockInfo)
             .| sinkTruncate count
   where
     count = min 100 $ fromMaybe 100 mCount
-    pubsSource = maybe publicationsSource educatorPublicationsSource mEducator mFrom
 
 -- | As we can't distinguish between different hashes, we have to check whether an entity exists.
 getHashType :: WitnessWorkMode ctx m => Text -> m HashIs
@@ -186,18 +190,15 @@ getHashType someHash = fmap (fromMaybe HashIsUnknown) . runMaybeT . asum $
     isBlock = is
         (const HashIsBlock)
         (fromHex @HeaderHash)
-        (runSdMRead . getBlockMaybe)
-
+        (runSdMempoolLocked . getBlockMaybe)
     isAddress = is
         (const HashIsAddress)
         addrFromText
-        getAccountMaybe
-
+        (runSdReadMLocked @'ChainAndMempool . getMempoolAccountMaybe)
     isTx = is
-        (distinguishTx . unGTxWitnessed . wbItem)
+        (distinguishTx . unGTxWitnessed)
         fromHex
-        (runSdMRead . getTxMaybe . GTxId)
-
+        (runSdMempoolLocked . getTxMaybe . GTxId)
     distinguishTx = \case
         GMoneyTx _ -> HashIsMoneyTx
         GPublicationTx _ -> HashIsPublicationTx

--- a/witness/tests/Test/Dscp/Witness/Explorer/ExplorerSpec.hs
+++ b/witness/tests/Test/Dscp/Witness/Explorer/ExplorerSpec.hs
@@ -4,8 +4,10 @@ import Data.Default (def)
 
 import Dscp.Core
 import Dscp.Crypto
+import Dscp.Snowdrop.Configuration
 import Dscp.Snowdrop.Mode
 import Dscp.Snowdrop.Types
+import Dscp.Util
 import Dscp.Util.Test
 import Dscp.Witness
 
@@ -75,8 +77,26 @@ getTransactionsPaged chunkSize mAddress = getFrom Nothing
 
 spec :: Spec
 spec = describe "Explorer" $ do
+  describe "getTransaction" $ do
+    it "Returns existing tx fine" . once $ witnessProperty $ do
+        tx <- createAndSubmitTx selectGenesisSecret
+        _ <- lift $ dumpBlock 0
+        res <- lift $ getTransactionInfo (toGTxId $ GMoneyTx tx)
+        return $ wbiItem res === GMoneyTx tx
+
+    it "Mempool txs are taken into account" . once $ witnessProperty $ do
+        tx <- createAndSubmitTx selectGenesisSecret
+        res <- lift $ getTransactionInfo (toGTxId $ GMoneyTx tx)
+        return $ res === WithBlockInfo Nothing (GMoneyTx tx)
+
+    it "Errors on absent tx correctly" . once $ witnessProperty $ do
+        gTxId <- pick arbitrary
+        _ <- lift $ dumpBlock 0
+        lift $ throwsPrism (_LogicError . _LETxAbsent) $
+            getTransactionInfo gTxId
+
   describe "getTransactions" $ do
-    it "Returns all transactions at once just fine" $ witnessProperty $ do
+    it "Returns all transactions at once just fine" . once $ witnessProperty $ do
         n <- pick $ choose (1, 3)
         txs <- replicateM n $ createAndSubmitTx selectGenesisSecret
         _ <- lift $ dumpBlock 0
@@ -106,27 +126,47 @@ spec = describe "Explorer" $ do
               map toTxId txs
             ]
 
-    it "Blocks info is present" $ witnessProperty $ do
-        -- TODO [DSCP-335] Uncomment when mempool is taken into consideration
-        -- And also adjust one similar test below.
-        --
-        -- _ <- createAndSubmitTx selectGenesisSecret
-        -- blockHash <- lift $ dumpBlock 0
-        -- _ <- createAndSubmitTx selectGenesisSecret
+    it "Skipping transactions works fine with mempool" $ witnessProperty $ do
+        chainTxsNum <- pick $ choose (1, 3)
+        chainTxs <- replicateM chainTxsNum $ createAndSubmitTx selectGenesisSecret
+        _ <- lift $ dumpBlock 0
+        memTxsNum <- pick $ choose (0, 3)
+        memTxs <- replicateM memTxsNum $ createAndSubmitTx selectGenesisSecret
 
-        -- res <- lift $ getTransactions Nothing Nothing Nothing
-        -- let tx2 : tx1 : _ = traceShowId $ plItems res
-        -- return $ conjoin
-        --     [ fmap biHeaderHash (wbiBlockInfo tx1) === Just blockHash
-        --     , property $ isNothing (wbiBlockInfo tx2)
-        --     ]
+        let txs = chainTxs <> memTxs
+        mSince <- pick $ elements (Nothing : map (Just . toTxId) txs)
 
+        res <- lift $ getTransactions Nothing mSince Nothing
+        let expected = maybe id (\since -> dropWhile ((/= since) . toTxId)) mSince (reverse txs)
+        let resTop = zipWith const (plItems res) expected
+
+        return $ map (toTxId . wbiItem) resTop
+                 ===
+                 map toTxId expected
+
+    it "Errors nicely when 'since' transaction is absent" $ witnessProperty $ do
+        chainTxsNum <- pick $ choose (1, 5)
+        replicateM_ chainTxsNum $ createAndSubmitTx selectGenesisSecret
+        _ <- lift $ dumpBlock 0
+        memTxsNum <- pick $ choose (0, 3)
+        replicateM_ memTxsNum $ createAndSubmitTx selectGenesisSecret
+
+        since <- pick arbitrary
+
+        lift $ throwsPrism (_LogicError . _LETxAbsent) $
+            getTransactions Nothing (Just since) Nothing
+
+    it "Blocks info is present" . once $ witnessProperty $ do
         _ <- createAndSubmitTx selectGenesisSecret
         blockHash <- lift $ dumpBlock 0
+        _ <- createAndSubmitTx selectGenesisSecret
 
         res <- lift $ getTransactions Nothing Nothing Nothing
-        let tx : _ = plItems res
-        return $ fmap biHeaderHash (wbiBlockInfo tx) === Just blockHash
+        let tx2 : tx1 : _ = plItems res
+        return $ conjoin
+            [ fmap biHeaderHash (wbiBlockInfo tx1) === Just blockHash
+            , property $ isNothing (wbiBlockInfo tx2)
+            ]
 
     it "Filtering on address works fine (when the address is tx input)" $ witnessProperty $ do
         let selectSecret = oneof [selectGenesisSecret, pure testSomeGenesisSecret]
@@ -143,7 +183,7 @@ spec = describe "Explorer" $ do
                  map toTxId expected
 
   describe "getPublications" $ do
-    it "Returns all transactions at once just fine" $ witnessProperty $ do
+    it "Returns all transactions at once just fine" $ once $ witnessProperty $ do
         n <- pick $ choose (1, 3)
         txs <- replicateM n $ createAndSubmitPub (pure testSomeGenesisSecret)
         _ <- lift $ dumpBlock 0
@@ -168,10 +208,25 @@ spec = describe "Explorer" $ do
                  ===
                  map toPtxId expected
 
-    it "Blocks info is present" $ witnessProperty $ do
+    it "Blocks info is present" . once $ witnessProperty $ do
         _ <- createAndSubmitPub selectGenesisSecret
         blockHash <- lift $ dumpBlock 0
+        _ <- createAndSubmitPub selectGenesisSecret
 
         res <- lift $ getPublications Nothing Nothing Nothing
-        let tx : _ = plItems res
-        return $ fmap biHeaderHash (wbiBlockInfo tx) === Just blockHash
+        let tx2 : tx1 : _ = plItems res
+        return $ conjoin
+            [ fmap biHeaderHash (wbiBlockInfo tx1) === Just blockHash
+            , property $ isNothing (wbiBlockInfo tx2)
+            ]
+
+  describe "getHashType" $ do
+    it "Handles (mempool) money transactions correctly" . once $ witnessProperty $ do
+        tx <- createAndSubmitTx selectGenesisSecret
+        res <- lift $ getHashType (toHex $ toTxId tx)
+        return $ res === HashIsMoneyTx
+
+    it "Handles (mempool) pub transactions correctly" . once $ witnessProperty $ do
+        tx <- createAndSubmitPub selectGenesisSecret
+        res <- lift $ getHashType (toHex $ toPtxId tx)
+        return $ res === HashIsPublicationTx

--- a/witness/tests/Test/Dscp/Witness/Tx/MoneyTxSpec.hs
+++ b/witness/tests/Test/Dscp/Witness/Tx/MoneyTxSpec.hs
@@ -237,3 +237,10 @@ spec = describe "Money tx expansion + validation" $ do
                 txs = makeTxsChain 2 properSteps txData
             lift $ throwsPrism (_AccountError . _BalanceCannotBecomeNegative) $
                 mapM_ applyTx txs
+
+        it "Two same transactions" $ witnessProperty $ do
+            txData <- pick genSafeTxData
+            let tx = makeTx properSteps txData
+            lift $ do
+                noThrow $ applyTx tx
+                throwsPrism (_AccountError . _TransactionAlreadyExists) $ applyTx tx

--- a/witness/tests/Test/Dscp/Witness/Tx/MoneyTxSpec.hs
+++ b/witness/tests/Test/Dscp/Witness/Tx/MoneyTxSpec.hs
@@ -239,8 +239,10 @@ spec = describe "Money tx expansion + validation" $ do
                 mapM_ applyTx txs
 
         it "Two same transactions" $ witnessProperty $ do
+            _ <- stop $ pendingWith "[DSCP-369] Make addTxToMempool do not check transaction presence"
+
             txData <- pick genSafeTxData
             let tx = makeTx properSteps txData
             lift $ do
-                noThrow $ applyTx tx
+                applyTx tx
                 throwsPrism (_AccountError . _TransactionAlreadyExists) $ applyTx tx


### PR DESCRIPTION
### Description

Generalizes getters/traversals in witness logic so that they work both in chain-only and chain+mempool modes (depending on caller's needs) and make explorer endpoints (`/transactions`,  `/publications`, `/transactions/{id}`, `/hash/{hash}`) take mempool into consideration.

To make actions which can work in two mentioned modes I introduced a special monad wrapper `SdReadM`, through which one can say exact mode he wishes to launch the action in. Another way would be to use old `SdM_ chgacc` (`chgacc` varies depending on selected mode), but IMO this case occurred to be [ugly](https://github.com/DisciplinaOU/disciplina/commit/1ed5fcb0a2dfb8ea8b3f79c97b3f566c28e13dde) (I can elaborate more on this if needed).

### YT issue

https://issues.serokell.io/issue/DSCP-335

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
