### PR TITLE
[DSCP-361] fix corrupted syslog output on stderr

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -43,6 +43,9 @@ extra-deps:
 - git: https://github.com/serokell/rocksdb-haskell.git
   commit: 2dd6b4ffdc4edb86b477273ee3c8416a1520f4e1
 
+- git: https://github.com/pasqu4le/hslogger.git
+  commit: 28d5f0cf220a1b7162eaa1535e72e6cad2362ee4
+
 - git: https://github.com/serokell/lootbox.git
   commit: d80183142db2dc07eb580662722b0e541fc48a5f
   subdirs:


### PR DESCRIPTION
### Description

This PR solves the problem of scrambled text in stderr output by `loot-log`'s Syslogger, by using a fork of `hslogger` that does this is in a thread-safe way.

NOTE: there is a yet unmerged branch on `lootbox` for this as well, but this PR does not use it, nor does not need it.

### YT issue

https://issues.serokell.io/issue/DSCP-361

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [X] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [X] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [X] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [X] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [X] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [X] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [X] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [X] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
