### PR TITLE
[DSCP-351] improve keygen commands

### DIFF
--- a/core/src/Dscp/Util.hs
+++ b/core/src/Dscp/Util.hs
@@ -23,6 +23,7 @@ module Dscp.Util
        , nothingToError
        , nothingToFail
        , nothingToPanic
+       , (<?:>)
 
          -- * Either conversions
        , leftToThrow
@@ -173,6 +174,11 @@ nothingToFail e = maybe (fail $ toString e) pure
 
 nothingToPanic :: Text -> Maybe a -> a
 nothingToPanic e = fromMaybe (error e)
+
+-- | Like '?:' from Universum, for monads.
+infixr 2 <?:>
+(<?:>) :: Functor f => f (Maybe a) -> a -> f a
+a <?:> b = fromMaybe b <$> a
 
 -----------------------------------------------------------
 -- Either conversions

--- a/scripts/launch/node.sh
+++ b/scripts/launch/node.sh
@@ -68,7 +68,7 @@ if [[ $node == "educator" ]]; then
         exit 2
     fi
     echo $educator_keyfile_seed \
-        | dscp-keygen --seed --command "keyfile" \
+        | dscp-keygen --seed keyfile \
         > "${tmp_files}/educator.key"
     chmod 0600 ${tmp_files}/educator.key
 fi

--- a/scripts/test/student-submissions-spam.sh
+++ b/scripts/test/student-submissions-spam.sh
@@ -32,6 +32,6 @@ fi
 
 for (( i=1; i<=$requests_num; i++ )) do
     echo $student_secret_seed \
-        | dscp-keygen --seed --command student-submission:$run_seed-$i \
+        | dscp-keygen --seed student-submission --sub-seed=$run_seed-$i \
         | http --check-status POST $educator_node/api/student/v1/submissions
 done

--- a/tools/README.md
+++ b/tools/README.md
@@ -49,84 +49,68 @@ This is a small tool to manipulate with secret key. Along with generating new on
 
 Main usage pattern is
 ```bash
-echo <input with secret> | dscp-keygen <input-type-option> --command <command>
+echo <input with secret> | dscp-keygen <input-type-option> <command> <command-arguments>
 ```
 
-Input defines which secret key will be used as base for further operations.
-It can be specified directly, as encrypted key with password, as path to keyfile or be generated from scratch, depending on `input-type-option` option.
+Input defines which secret key will be used as a base for further operations.
+It can be specified directly, as encrypted key with a password, as a path to the keyfile or be generated from scratch, depending on `input-type-option` option.
 
-Execute `dscp-keygen --help` for the list of available 'input-type' options.
+Execute `dscp-keygen --help` for the list of available 'input-type' options and to see available commands.
 
-Command stands for data to be derived from the base secret key. Commands have options (not mandatory), which vary how data will be displayed.
+Each command stands for data to be derived from the base secret key. For the description and list of arguments for each command execute `dscp-keygen <command> --help`.
 
-List of options types:
-
-* View - determines how to display raw data, can be `raw`, `base64` or `hex`.
-* Prettiness - for large outputs, whether to use pretty multiline output.
-  Can be `pretty` or `one-line`
-* Password - password used to generate secret key.
-
-Following commands are supported:
-
-* `secret[:<view=base64>]` - display secret itself.
-* `public[:<view=hex>]` - display public key.
-* `address` - address, base58bitcoin.
-* `esecret[:<password="">[:<view=hex>]]` - display encrypted secret key.
-* `keyfile[:<password="">[:<prettiness=pretty>]]` - display keyfile.
-* `educator-auth:endpointName` - produce JWT token for educator node from given educator secret key and name of accessed endpoint.
-* `student-submission[:<seed="">]` - produce JSON request for `POST /api/student/v1/submissions` endpoint.
+Note, that name of the command argument sometimes collides with options related to the input (e.g. `--password` may relate to a secret on input or to a secret on output).
+In such cases, all the options before the command name are considered related to the input, and options after the command name - to the output.
 
 ### Examples
-
-_Reminder: no option after `:` is mandatory._
 
 * Generate secret key:
 
 ```bash
-echo 1000 | dscp-keygen --seed --command secret
+echo 1000 | dscp-keygen --seed secret
 ```
 
 * Generate truly random secret:
 
 ```bash
-cat /dev/urandom | head -c 32 | dscp-keygen --seed --command secret
+cat /dev/urandom | head -c 32 | dscp-keygen --seed secret
 ```
 
 * Generate key file with password:
 
 ```bash
-echo 1000 | dscp-keygen --seed --command keyfile:password > secret.key
+echo 1000 | dscp-keygen --seed keyfile --password=qwerty123 > secret.key
 chmod 660 secret.key
 ```
 
 * Read key file:
 
 ```base
-cat secret.key | dscp-keygen --keyfile --password qwerty123 --command secret
+cat secret.key | dscp-keygen --keyfile --password qwerty123 secret
 ```
 
 * Produce public key:
 
 ```base
-echo '9JsCkzFH/W7SbgvgokeJTsckJs/uoAPWWwC40Y6UfFo=' | dscp-keygen --secret  --command "public:hex"
+echo '9JsCkzFH/W7SbgvgokeJTsckJs/uoAPWWwC40Y6UfFo=' | dscp-keygen --secret public --hex
 ```
 
 * Produce address:
 
 ```base
-echo '9JsCkzFH/W7SbgvgokeJTsckJs/uoAPWWwC40Y6UfFo=' | dscp-keygen --secret --command "address"
+echo '9JsCkzFH/W7SbgvgokeJTsckJs/uoAPWWwC40Y6UfFo=' | dscp-keygen --secret address
 ```
 
 * Encrypt secret key:
 
 ```base
-echo '9JsCkzFH/W7SbgvgokeJTsckJs/uoAPWWwC40Y6UfFo=' | dscp-keygen --secret --command "esecret:12345678"
+echo '9JsCkzFH/W7SbgvgokeJTsckJs/uoAPWWwC40Y6UfFo=' | dscp-keygen --secret esecret --password=12345678
 ```
 
 * Produce JWT token to authenticate in Educator or Student API:
 
 ```base
-echo '9JsCkzFH/W7SbgvgokeJTsckJs/uoAPWWwC40Y6UfFo=' | dscp-keygen --secret --command "educator-auth:/api/student/v1/courses"
+echo '9JsCkzFH/W7SbgvgokeJTsckJs/uoAPWWwC40Y6UfFo=' | dscp-keygen --secret educator-auth /api/student/v1/courses
 ```
 You can later append token with
 1. `-H "Authorization: Bearer <token>"` for `curl`
@@ -136,10 +120,9 @@ You can later append token with
 
 ```base
 echo 456 \
-    | dscp-keygen --seed --command student-submission:3656234 \
+    | dscp-keygen --seed student-submission --sub-seed=3656234 \
     | http POST :8090/api/student/v1/submissions
 ```
-(_Reminder: option of `student-submission` command is seed which allows to generate unique submissions._)
 
 See [example of use](/scripts/test/student-submissions-spam.sh).
 

--- a/tools/src/keygen/KeygenCommands.hs
+++ b/tools/src/keygen/KeygenCommands.hs
@@ -1,5 +1,7 @@
 module KeygenCommands
-    ( KeygenCommand
+    ( View (..)
+    , Pretty (..)
+    , KeygenCommand (..)
     , parseKeygenCommand
     , keygenCommandExecutor
     ) where
@@ -30,6 +32,7 @@ data View
     = RawView
     | HexView
     | Base64View
+    deriving (Show)
 
 -- | Parse 'View' from command option.
 readView :: Text -> Either Text View
@@ -54,6 +57,7 @@ readPassPhrase pp = first show . mkPassPhrase $ encodeUtf8 pp
 
 -- | Whether to use pretty multiline output.
 newtype Pretty = Pretty Bool
+    deriving (Show)
 
 readPrettyOption :: Text -> Either Text Pretty
 readPrettyOption = \case
@@ -94,6 +98,7 @@ data KeygenCommand
     | PrintKeyFile PassPhrase Pretty
     | PrintEducatorAuthToken Text
     | PrintStudentSubmission (Seed Text)
+    deriving (Show)
 
 -- | Parse a command.
 parseKeygenCommand :: Text -> Either Text KeygenCommand

--- a/tools/src/keygen/KeygenOptions.hs
+++ b/tools/src/keygen/KeygenOptions.hs
@@ -5,16 +5,16 @@ module KeygenOptions
        , keygenConfigParser
        ) where
 
-import Options.Applicative (Parser, ReadM, auto, flag', help, long, metavar, option, str)
+import Options.Applicative (Parser, auto, command, flag', fullDesc, help, hsubparser, info, long,
+                            metavar, noIntersperse, option, progDesc, short, strArgument, strOption,
+                            value)
 
 import Dscp.CommonCLI
+import Dscp.Crypto
 import Dscp.Util
 
 import KeygenCommands
 import KeygenSecret
-
-keygenCommandReadM :: ReadM KeygenCommand
-keygenCommandReadM = leftToFail . parseKeygenCommand =<< str
 
 -- | Parser for all possble ways to give secret key.
 secretDataTypeParser :: Parser SecretDataType
@@ -43,21 +43,106 @@ secretDataTypeParser = asum
   where
     passphraseParser = optional . option passphraseReadM $
         long "password" <>
+        short 'p' <>
         metavar "TEXT" <>
-        help "Password from given key passed in input. If no password is \
-             \specified, secret key is assumed to have no password."
+        help "Password from the key passed in input."
+
+viewParser :: Parser (Maybe View)
+viewParser = optional $ asum
+    [ flag' RawView $
+          long "raw" <>
+          help "Display output as is"
+    , flag' HexView $
+          long "hex" <>
+          help "Display output in hex"
+    , flag' HexView $
+          long "base16" <>
+          help "Display output in hex"
+    , flag' Base64View $
+          long "base64" <>
+          help "Display output in base64"
+    ]
+
+prettinessParser :: Parser (Maybe Pretty)
+prettinessParser = optional $ asum
+    [ flag' (Pretty True) $
+          long "pretty" <>
+          help "Format output in pretty way"
+    , flag' (Pretty False) $
+          long "one-line" <>
+          help "Print output in one line"
+    ]
+
+signedEndpointNameParser :: Parser Text
+signedEndpointNameParser = strArgument $
+    metavar "ENDPOINT" <>
+    help "Exact name of the signed endpoint."
+
+submissionSeedParser :: Parser (Seed Text)
+submissionSeedParser = strOption $
+    long "sub-seed" <>
+    metavar "TEXT" <>
+    help "Seed used to generate a submission."
 
 keygenCommandParser :: Parser KeygenCommand
-keygenCommandParser = option keygenCommandReadM $
-    long "command" <>
-    metavar "TEXT" <>
-    help "Which output should be produced. See README.md for details"
+keygenCommandParser = hsubparser $ mconcat
+    [ command "secret" $ info
+        (PrintSecretKey . fromMaybe Base64View <$> viewParser)
+        (fullDesc <>
+         progDesc "Display the secret itself. In base64 by default.")
+
+    , command "public" $ info
+        (PrintPublicKey . fromMaybe HexView <$> viewParser)
+        (fullDesc <>
+         progDesc "Display the public key corresponding to the secret. In hex by default.")
+
+    , command "address" $ info
+        (pure PrintAddress)
+        (fullDesc <>
+         progDesc "Display the address derivative from the secret.")
+
+    , command "esecret" $ info
+        (PrintEncryptedSecretKey <$> passphraseParser <*> (viewParser <?:> Base64View))
+        (fullDesc <>
+         noIntersperse <>
+         -- needed since --password may be both an option or a command argument otherwise
+         progDesc "Display secret key encrypted. Note that if no password is given, an \
+                  \encrypted secret will be produced anyway (which is ~twice as long as \
+                  \an unencrypted secret.")
+
+    , command "keyfile" $ info
+        (PrintKeyFile <$> passphraseParser <*> (prettinessParser <?:> Pretty True))
+        (fullDesc <>
+         noIntersperse <>
+         progDesc "Display keyfile content. You will probably want to redirect the output \
+                  \of this command to the file.")
+
+    , command "educator-auth" $ info
+        (PrintEducatorAuthToken <$> signedEndpointNameParser)
+        (fullDesc <>
+         progDesc "Create a JWT signature for authentication in Educator/Student API. \
+                  \You have to provide the name of signed endpoint, for instance \
+                  \`/api/student/v1/submissions`")
+
+    , command "student-submission" $ info
+        (PrintStudentSubmission <$> submissionSeedParser)
+        (fullDesc <>
+         progDesc "Generate a submission in JSON format which can be put to \
+                  \the `POST /submissions` endpoint of Student API.")
+    ]
+  where
+    passphraseParser = option passphraseReadM $
+        long "password" <>
+        short 'p' <>
+        metavar "TEXT" <>
+        help "Password to encrypt the secret with." <>
+        value emptyPassPhrase
 
 -- | All parameters.
 data KeygenConfig = KeygenConfig
     { kcSecretDataType :: !SecretDataType
     , kcKeygenCommand  :: !KeygenCommand
-    }
+    } deriving (Show)
 
 -- | Parse all parameters.
 keygenConfigParser :: Parser KeygenConfig

--- a/tools/src/keygen/KeygenSecret.hs
+++ b/tools/src/keygen/KeygenSecret.hs
@@ -24,11 +24,13 @@ parseBytesWith :: Show a => Show b => FromByteArray a => (a -> Maybe b) -> ByteS
 parseBytesWith interpret =
     asum . map ((interpret =<<) . eitherToMaybe) . sequence bytestringDecoders
 
+-- | How to interpret given input into a secret key.
 data SecretDataType
     = PlainSecret (Maybe PassPhrase)
     | KeyfileSecret (Maybe PassPhrase)
     | CommSecret Integer
     | SecretFromSeed
+    deriving (Show)
 
 parseInputWithSecret :: SecretDataType -> ByteString -> Maybe SecretKey
 parseInputWithSecret = \case

--- a/tools/src/keygen/Main.hs
+++ b/tools/src/keygen/Main.hs
@@ -24,7 +24,7 @@ main = do
 getKeygenConfig :: IO KeygenConfig
 getKeygenConfig =
     execParser $
-        info (helper <*> versionOption <*> keygenConfigParser ) $
+        info (helper <*> versionOption <*> keygenConfigParser) $
         fullDesc <>
-        progDesc "Disciplina keygen. Can be used for producing secret key \
+        progDesc "Disciplina keygen. Can be used for producing a secret key \
                  \and its derivative data."


### PR DESCRIPTION
### Description

Improves keygen interface. Adds help messages for each command of the keygen.

For instance:
`dscp-keygen --seed --command "address:hex"` -> `dscp-keygen --seed address --hex`.

### YT issue

https://issues.serokell.io/issue/DSCP-351

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [ ] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [ ] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
