### PR TITLE
[DSCP-374] Fix serialisation of Bool-isomorphic types in educator APIs

### DIFF
--- a/educator/src/Dscp/Educator/Web/Types.hs
+++ b/educator/src/Dscp/Educator/Web/Types.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE GADTs      #-}
-{-# LANGUAGE StrictData #-}
+{-# LANGUAGE GADTs         #-}
+{-# LANGUAGE StrictData    #-}
 {-# LANGUAGE TypeOperators #-}
 
 -- | Common datatypes for educator and student HTTP APIs
@@ -32,25 +32,26 @@ module Dscp.Educator.Web.Types
        ) where
 
 import Control.Lens (Iso', from, iso, makePrisms)
+import Data.Aeson (FromJSON, ToJSON)
 import Data.Aeson.Options (defaultOptions)
 import Data.Aeson.TH (deriveJSON)
+import Data.Singletons.Bool (SBoolI)
 import Data.Time.Clock (UTCTime)
 import Database.SQLite.Simple (FromRow (..), field)
-import Servant (FromHttpApiData (..))
-import Data.Singletons.Bool (SBoolI)
-import UnliftIO (MonadUnliftIO)
-import Loot.Log (MonadLogging)
+import Fmt (build, (+|), (+||), (|+), (||+))
 import Loot.Base.HasLens (HasCtx)
-import Fmt (build, (+|), (|+), (+||), (||+))
+import Loot.Log (MonadLogging)
+import Servant (FromHttpApiData (..))
+import UnliftIO (MonadUnliftIO)
 
-import Dscp.DB.SQLite.Types
-import Dscp.Util.Type (type (==))
 import Dscp.Core
 import Dscp.Crypto
 import Dscp.DB.SQLite.Instances ()
+import Dscp.DB.SQLite.Types
 import Dscp.Util.Aeson (CustomEncoding, HexEncoded)
-import Dscp.Util.Servant (ForResponseLog (..), buildForResponse,
-                          buildShortResponseList, buildLongResponseList)
+import Dscp.Util.Servant (ForResponseLog (..), buildForResponse, buildLongResponseList,
+                          buildShortResponseList)
+import Dscp.Util.Type (type (==))
 
 type MonadEducatorWebQuery m =
     ( MonadIO m
@@ -210,10 +211,18 @@ assignmentTypeRaw = iso forth back . from _IsFinal
 -- JSON instances
 ---------------------------------------------------------------------------
 
-deriveJSON defaultOptions ''IsEnrolled
-deriveJSON defaultOptions ''IsFinal
-deriveJSON defaultOptions ''IsGraded
-deriveJSON defaultOptions ''HasProof
+deriving instance ToJSON IsEnrolled
+deriving instance FromJSON IsEnrolled
+
+deriving instance ToJSON IsFinal
+deriving instance FromJSON IsFinal
+
+deriving instance ToJSON IsGraded
+deriving instance FromJSON IsGraded
+
+deriving instance ToJSON HasProof
+deriving instance FromJSON HasProof
+
 deriveJSON defaultOptions ''GradeInfo
 deriveJSON defaultOptions ''StudentInfo
 deriveJSON defaultOptions ''BlkProofInfo

--- a/specs/disciplina/educator/api/educator.yaml
+++ b/specs/disciplina/educator/api/educator.yaml
@@ -753,7 +753,7 @@ components:
     StudentCourse:
       type: object
       required:
-        - course
+        - courseId
       properties:
         course:
           $ref: '#/components/schemas/Id'


### PR DESCRIPTION
### Description

Previous way serialized them as objects instead of as booleans, which was indeed weird and
didn't correspond to the documentation.

### YT issue

https://issues.serokell.io/issue/SRK-8

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
