### PR TITLE
[DSCP-371] Fix bad JSON structure for transaction types

### DIFF
--- a/specs/disciplina/witness/api/witness.yaml
+++ b/specs/disciplina/witness/api/witness.yaml
@@ -445,42 +445,36 @@ components:
           $ref: '#/components/schemas/Hash'
         outValue:
           $ref: '#/components/schemas/Coin'
-        money:
+        inAcc:
           type: object
           properties:
-            inAcc:
-              type: object
-              properties:
-                addr:
-                  $ref: '#/components/schemas/Address'
-                nonce:
-                  type: integer
-                  format: int32
-            inValue:
-              $ref: '#/components/schemas/Coin'
-            outs:
-              type: array
-              items:
-                type: object
-                properties:
-                  address:
-                    $ref: '#/components/schemas/Address'
-                  value:
-                    $ref: '#/components/schemas/Coin'
+            addr:
+              $ref: '#/components/schemas/Address'
+            nonce:
+              type: integer
+              format: int32
+        inValue:
+          $ref: '#/components/schemas/Coin'
+        outs:
+          type: array
+          items:
+            type: object
+            properties:
+              address:
+                $ref: '#/components/schemas/Address'
+              value:
+                $ref: '#/components/schemas/Coin'
     PublicationInfo:
       type: object
       properties:
         txId:
           $ref: "#/components/schemas/Hash"
-        publication:
-          type: object
-          properties:
-            author:
-              $ref: '#/components/schemas/Address'
-            feesAmount:
-              $ref: '#/components/schemas/Coin'
-            header:
-              $ref: '#/components/schemas/PrivateBlockHeader'
+        author:
+          $ref: '#/components/schemas/Address'
+        feesAmount:
+          $ref: '#/components/schemas/Coin'
+        header:
+          $ref: '#/components/schemas/PrivateBlockHeader'
     AndBlockInfo:
       type: object
       properties:

--- a/specs/disciplina/witness/api/witness.yaml
+++ b/specs/disciplina/witness/api/witness.yaml
@@ -430,23 +430,14 @@ components:
           type: integer
           format: int32
     GeneralizedTransactionInfo:
-      type: object
+      oneOf:
+      - $ref: '#/components/schemas/TransactionInfo'
+      - $ref: '#/components/schemas/PublicationInfo'
       discriminator:
         propertyName: txType
-      properties:
-        txType:
-          type: string
-          enum:
-            - money
-            - publication
-        txId:
-          $ref: '#/components/schemas/Hash'
-        outValue:
-          $ref: '#/components/schemas/Coin'
-        money:
-          $ref: '#/components/schemas/TransactionInfo'
-        publication:
-          $ref: '#/components/schemas/PublicationInfo'
+        mapping:
+          money: '#/components/schemas/TransactionInfo'
+          publication: '#/components/schemas/PublicationInfo'
     TransactionInfo:
       type: object
       properties:

--- a/witness/src/Dscp/Witness/Web/Types.hs
+++ b/witness/src/Dscp/Witness/Web/Types.hs
@@ -173,27 +173,25 @@ instance FromJSON (Detailed a) => FromJSON (WithBlockInfo a) where
         return $ WithBlockInfo block item
 
 instance ToJSON (Detailed Tx) where
-    toJSON (Detailed tx) = object $
-        [ "txId" .= toTxId tx
-        , "money" .= tx
-        , case sumCoins . map txOutValue . txOuts $ tx of
-            Right c  -> "outValue" .= c
-            Left err -> "outValue" .= err
-        ]
+    toJSON (Detailed tx) = mergeObjects extraFields (toJSON tx)
+      where
+        extraFields = object
+            [ "txId" .= toTxId tx
+            , case sumCoins . map txOutValue . txOuts $ tx of
+                  Right c  -> "outValue" .= c
+                  Left err -> "outValue" .= err
+            ]
 
 instance FromJSON (Detailed Tx) where
-    parseJSON = withObject "detailed tx" $ \o ->
-        Detailed <$> o .: "money"
+    parseJSON = fmap Detailed . parseJSON
 
 instance ToJSON (Detailed PublicationTx) where
-    toJSON (Detailed pTx) = object $
-        [ "txId" .= toPtxId pTx
-        , "publication" .= pTx
-        ]
+    toJSON (Detailed pTx) = mergeObjects extraFields (toJSON pTx)
+        where
+          extraFields = object [ "txId" .= toPtxId pTx ]
 
 instance FromJSON (Detailed PublicationTx) where
-    parseJSON = withObject "detailed pub tx" $ \o ->
-        Detailed <$> o .: "publication"
+    parseJSON = fmap Detailed . parseJSON
 
 instance ToJSON (Detailed GTx) where
     toJSON (Detailed gtx) = mergeObjects (object [ "txType" .= txType]) txObj


### PR DESCRIPTION
### Description

- Transaction IDs are not duplicated anymore
- No more nested `money` and `publication` objects; there is only `money` and `publication` tags to distinguish between `PublicationTx` and `Tx`

Corresponding PR containing changes in frontend code: https://github.com/DisciplinaOU/disciplina-explorer-frontend/pull/7

Tested together with frontend code on test cluster.

### YT issue

https://issues.serokell.io/issue/DSCP-371

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
