### PR TITLE
[DSCP-285] Fix `loop in publication` test case

### DIFF
--- a/educator/tests/Test/Dscp/Educator/Web/Educator/Queries.hs
+++ b/educator/tests/Test/Dscp/Educator/Web/Educator/Queries.hs
@@ -61,7 +61,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
                               \(CourseEducatorInfo courseId desc subjs) ->
                                   (Just courseId, desc, subjs)
             return $
-                cover (length coursesDetails > 1) 50 "enough courses" $
+                cover (length coursesDetails > 1) 10 "enough courses" $
                 sort coursesBone === sort coursesBone'
 
     describe "getCourses" $ do

--- a/witness/src/Dscp/Snowdrop/Expanders.hs
+++ b/witness/src/Dscp/Snowdrop/Expanders.hs
@@ -122,7 +122,7 @@ seqExpandersPublicationTx feesReceiverAddr (Fees minFee) =
             let (prevHashM :: Maybe PrivateHeaderHash) =
                     prevHash <$ guard (prevHash /= genesisHeaderHash)
 
-            headerWasEarlier <- queryOneExists (PublicationHead phHash)
+            headerWasEarlier <- queryOneExists (PublicationHead ptAuthor phHash)
             let headerIsLast = prevHash == phHash
             when (headerWasEarlier || headerIsLast) $
                 throwLocalError PublicationLocalLoop
@@ -165,9 +165,9 @@ seqExpandersPublicationTx feesReceiverAddr (Fees minFee) =
             let change = if isJust maybePub then Upd else New
             pure $ mkDiffCS $ Map.fromList $
                 [ PublicationsOf  ptAuthor ==> change (LastPublication phHash)
-                , PublicationHead phHash   ==> New    (PublicationNext prevHashM)
                 , PublicationIds  ptxId    ==> New    (PublicationData ptwTx (hash ptwTx))
                 , PrivateBlockTx  phHash   ==> New    (PrivateBlockTxVal ptxId)
+                , PublicationHead ptAuthor phHash ==> New (PublicationNext prevHashM)
                 ] ++ feesChanges
 
 ----------------------------------------------------------------------------

--- a/witness/src/Dscp/Snowdrop/PublicationValidation.hs
+++ b/witness/src/Dscp/Snowdrop/PublicationValidation.hs
@@ -64,7 +64,7 @@ preValidatePublication =
         let phHash = hash privHeader
 
         -- Getting actual changes
-        let hd  = proj =<< inj (PublicationHead phHash)   `Map.lookup` changes
+        let hd  = proj =<< inj (PublicationHead authorId phHash) `Map.lookup` changes
         let box = proj =<< inj (PublicationsOf  authorId) `Map.lookup` changes
 
         () <- mconcat

--- a/witness/src/Dscp/Snowdrop/Storage/Types.hs
+++ b/witness/src/Dscp/Snowdrop/Storage/Types.hs
@@ -95,16 +95,16 @@ newtype LastPublication = LastPublication
     } deriving (Eq, Ord, Show, Generic)
 
 -- | Once 'LastPublication' is known, you can walk the chain of
--- | `PublicationHead bh ~> PublicationNext bh`,
+-- | `PublicationHead author bh ~> PublicationNext bh`,
 -- | (which is `(blockHash, Maybe blockHash)`)
 -- | where phead contains block hash and pnext has prev block hash.
-newtype PublicationHead
-    = PublicationHead PrivateHeaderHash
+data PublicationHead
+    = PublicationHead Address PrivateHeaderHash
     deriving (Eq, Ord, Show, Generic)
 
 instance Buildable PublicationHead where
-    build (PublicationHead blk) =
-        "PublicationHead { " +| blk |+  " }"
+    build (PublicationHead author blk) =
+        "PublicationHead { block " +| blk |+ ", author " +| author |+ " }"
 
 data PublicationNext
     = PublicationNext (Maybe PrivateHeaderHash)


### PR DESCRIPTION
### Description

**Should work after DSCP-335 is merged.**

*Problem:* in rare cases two educators can create identical private block headers
(e.g. if they are empty and the first ones in the chain, then all fields will match).
This leads to data with the same keys being put into storage.

*Solution:* add 'author' field to the key along with the 'headerHash' field.

*Possible alternative solutions:*
* Forbid empty private blocks in validation. In tests generate all different merkle
signatures, assuming that all `PrivateTx`s are different (and they are since they
contain timestamp).

### YT issue

https://issues.serokell.io/issue/DSCP-285

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [ ] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [ ] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [ ] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [ ] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [ ] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
