### PR TITLE
[DSCP-372] Switch witness tests to tasty-discovery

### DIFF
--- a/faucet/tests/Test/Dscp/Faucet/CLI.hs
+++ b/faucet/tests/Test/Dscp/Faucet/CLI.hs
@@ -4,6 +4,6 @@ import Dscp.Faucet.CLI
 import Dscp.Util.Test
 
 spec_FaucetCli :: Spec
-spec_FaucetCli = describe "Educator CLI interface" $
+spec_FaucetCli = describe "Faucet CLI interface" $
     it "should not yield any default values if no CLI params are provided" $
         (runCliArgs faucetConfigParser [] <*> pure mempty) `shouldBe` Just mempty

--- a/witness/package.yaml
+++ b/witness/package.yaml
@@ -76,7 +76,7 @@ tests:
 
     build-tools:
       - tasty-discover
-      - hspec-discover
+
     dependencies:
       - AVL
       - containers
@@ -90,6 +90,8 @@ tests:
       - loot-config
       - loot-log
       - memory
+      - tasty
+      - tasty-hspec
       - text-format
       - QuickCheck
 

--- a/witness/tests/Main.hs
+++ b/witness/tests/Main.hs
@@ -1,5 +1,1 @@
-import Spec (spec)
-import Test.Hspec (hspec)
-
-main :: IO ()
-main = hspec spec
+{-# OPTIONS_GHC -F -pgmF tasty-discover -optF --tree-display -optF --treat-pending-as=success #-}

--- a/witness/tests/Spec.hs
+++ b/witness/tests/Spec.hs
@@ -1,1 +1,0 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Spec #-}

--- a/witness/tests/Test/Dscp/Witness/Block/Block.hs
+++ b/witness/tests/Test/Dscp/Witness/Block/Block.hs
@@ -1,4 +1,4 @@
-module Test.Dscp.Witness.Block.BlockSpec where
+module Test.Dscp.Witness.Block.Block where
 
 import Control.Lens (has)
 import qualified Data.List as L
@@ -76,8 +76,8 @@ submitSpoiledChain isExpectedError chain spoilBlock = do
         mapM_ submitBlock (init chain)
         throwsMatching isExpectedError $ submitBlock badLastBlock
 
-spec :: Spec
-spec = describe "Block validation + application" $ do
+spec_Block_validation_with_application :: Spec
+spec_Block_validation_with_application = do
   describe "Block header" $ do
     it "Good block is fine" $ witnessProperty $ do
         let blocks = makeBlocksChain 1

--- a/witness/tests/Test/Dscp/Witness/CLI.hs
+++ b/witness/tests/Test/Dscp/Witness/CLI.hs
@@ -1,9 +1,9 @@
-module Test.Dscp.Witness.CLISpec where
+module Test.Dscp.Witness.CLI where
 
 import Dscp.Util.Test
 import Dscp.Witness.CLI
 
-spec :: Spec
-spec = describe "Witness node CLI interface" $
+spec_WitnessCliParamsNoDefaults :: Spec
+spec_WitnessCliParamsNoDefaults = describe "Witness node CLI interface" $
     it "should not yield any default values if no CLI params are provided" $
         (runCliArgs witnessConfigParser [] <*> pure mempty) `shouldBe` Just mempty

--- a/witness/tests/Test/Dscp/Witness/Explorer/Explorer.hs
+++ b/witness/tests/Test/Dscp/Witness/Explorer/Explorer.hs
@@ -1,4 +1,4 @@
-module Test.Dscp.Witness.Explorer.ExplorerSpec where
+module Test.Dscp.Witness.Explorer.Explorer where
 
 import Data.Default (def)
 import qualified Data.Map.Strict as M
@@ -127,8 +127,8 @@ spoilFairCV (FairCV cv) = do
                 return (hhash, proof')
             return (addr, subCv')
 
-spec :: Spec
-spec = describe "Explorer" $ do
+spec_Explorer :: Spec
+spec_Explorer = describe "Explorer" $ do
     describe "getTransaction" $ do
         it "Returns existing tx fine" . once $ witnessProperty $ do
             tx <- createAndSubmitTxGen selectGenesisSecret

--- a/witness/tests/Test/Dscp/Witness/Serialise.hs
+++ b/witness/tests/Test/Dscp/Witness/Serialise.hs
@@ -1,11 +1,11 @@
-module Test.Dscp.Witness.SerialiseSpec where
+module Test.Dscp.Witness.Serialise where
 
 import Dscp.Core
 import Dscp.Util.Test
 import Dscp.Witness
 
-spec :: Spec
-spec = do
+spec_Serialise :: Spec
+spec_Serialise = do
     describe "Witness datatypes JSON serialisation" $ do
         aesonRoundtripProp @(BlocksOrMempool ())
         aesonRoundtripProp @(Detailed Tx)

--- a/witness/tests/Test/Dscp/Witness/Tx/Fee.hs
+++ b/witness/tests/Test/Dscp/Witness/Tx/Fee.hs
@@ -12,9 +12,9 @@ testFeeCoefficients =
     FeeCoefficients{fcMinimal = Coin 10, fcMultiplier = 0.1}
 
 spec_Transaction_fees :: Spec
-spec_Transaction_fees = do
+spec_Transaction_fees =
     it "fixFees always converges for money tx and linear coefs" . property $
-      \outs sk ->
-        let tw = fixFees (LinearFeePolicy testFeeCoefficients) $ \fees ->
-                   signTx sk $ createTx sk 0 outs fees
-        in tw `seq` ()
+        \outs sk ->
+            let tw = fixFees (LinearFeePolicy testFeeCoefficients) $ \fees ->
+                    signTx sk $ createTx sk 0 outs fees
+            in tw `seq` ()

--- a/witness/tests/Test/Dscp/Witness/Tx/Fee.hs
+++ b/witness/tests/Test/Dscp/Witness/Tx/Fee.hs
@@ -1,4 +1,4 @@
-module Test.Dscp.Witness.Tx.FeeSpec where
+module Test.Dscp.Witness.Tx.Fee where
 
 import Dscp.Core
 import Dscp.Util.Test
@@ -11,8 +11,8 @@ testFeeCoefficients :: FeeCoefficients
 testFeeCoefficients =
     FeeCoefficients{fcMinimal = Coin 10, fcMultiplier = 0.1}
 
-spec :: Spec
-spec = describe "Transaction fees" $ do
+spec_Transaction_fees :: Spec
+spec_Transaction_fees = do
     it "fixFees always converges for money tx and linear coefs" . property $
       \outs sk ->
         let tw = fixFees (LinearFeePolicy testFeeCoefficients) $ \fees ->

--- a/witness/tests/Test/Dscp/Witness/Tx/MoneyTx.hs
+++ b/witness/tests/Test/Dscp/Witness/Tx/MoneyTx.hs
@@ -1,4 +1,4 @@
-module Test.Dscp.Witness.Tx.MoneyTxSpec where
+module Test.Dscp.Witness.Tx.MoneyTx where
 
 import Control.Lens (makeLenses, makeLensesWith, traversed)
 import qualified Data.List as L
@@ -93,8 +93,8 @@ makeTxsChain n steps dat
 applyTx :: (HasWitnessConfig, WithinWriteSDLock) => TxWitnessed -> WitnessTestMode' ()
 applyTx tw = void $ addTxToMempool (GMoneyTxWitnessed tw)
 
-spec :: Spec
-spec = describe "Money tx expansion + validation" $ do
+spec_Money_tx_application :: Spec
+spec_Money_tx_application = do
     it "Correct tx is fine" $ witnessProperty $ do
         txData <- pick genSafeTxData
         let tx = makeTx properSteps txData

--- a/witness/tests/Test/Dscp/Witness/Tx/PublicationTx.hs
+++ b/witness/tests/Test/Dscp/Witness/Tx/PublicationTx.hs
@@ -1,7 +1,4 @@
-{-# LANGUAGE PartialTypeSignatures #-}
-{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
-
-module Test.Dscp.Witness.Tx.PublicationTxSpec where
+module Test.Dscp.Witness.Tx.PublicationTx where
 
 import Control.Lens (forOf, _last)
 import qualified GHC.Exts as Exts
@@ -48,8 +45,8 @@ submitPub
     => PublicationTxWitnessed -> m ()
 submitPub = addTxToMempool . GPublicationTxWitnessed
 
-spec :: Spec
-spec = describe "Publication tx expansion + validation" $ do
+spec_Publication_tx_application :: Spec
+spec_Publication_tx_application = do
     it "First correct tx in chain is fine" $ witnessProperty $ do
         author <- pick selectAuthor
         pub :| [] <- pick $ genPublicationChain 1 author


### PR DESCRIPTION
### Description

Replace hspec discovery with tasty discovery. DSL for specs definitions is still hspec.

WIP: on every second launch I get `lost signal due to full pipe: 11` errors.

### YT issue

https://issues.serokell.io/issue/DSCP-372

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [ ] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [ ] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [ ] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [ ] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [ ] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
