### PR TITLE
[DSCP-285] Make genesis header hash depend on educator it relates to

### DIFF
--- a/core/src/Dscp/Core/Foundation/Educator.hs
+++ b/core/src/Dscp/Core/Foundation/Educator.hs
@@ -81,6 +81,7 @@ module Dscp.Core.Foundation.Educator
     ) where
 
 import Control.Lens (Getter, makeLenses, to)
+import qualified Data.ByteArray as BA
 import Data.Time.Clock (UTCTime)
 import Fmt (build, genericF, mapF, (+|), (|+))
 
@@ -336,16 +337,18 @@ instance Buildable PrivateBlockHeader where
         "; atg:" +| _pbhAtgDelta |+ " }"
 
 -- | Genesis hash, serves as previous block reference for the first block.
+-- Different for each educator.
 -- TODO: move to 'Genesis' module when it is formed somehow. Also, should
 -- private genesis hash actually make some sense?
-genesisHeaderHash :: PrivateHeaderHash
-genesisHeaderHash = unsafeHash ("pvaforever" :: ByteString)
+genesisHeaderHash :: Address -> PrivateHeaderHash
+genesisHeaderHash (Address addr) =
+    unsafeHash ("pvaforever" <> BA.convert addr :: ByteString)
 
 -- | Get previous block header, if previous block exists,
 -- 'Nothing' otherwise.
-getPrevBlockRefMaybe :: PrivateBlockHeader -> Maybe PrivateHeaderHash
-getPrevBlockRefMaybe PrivateBlockHeader {..} =
-    if _pbhPrevBlock == genesisHeaderHash
+getPrevBlockRefMaybe :: PrivateBlockHeader -> Address -> Maybe PrivateHeaderHash
+getPrevBlockRefMaybe PrivateBlockHeader {..} address =
+    if _pbhPrevBlock == genesisHeaderHash address
     then Nothing
     else Just _pbhPrevBlock
 

--- a/educator/tests/Test/Dscp/Educator/BlockValidation.hs
+++ b/educator/tests/Test/Dscp/Educator/BlockValidation.hs
@@ -6,10 +6,7 @@ import qualified Data.Map.Strict as M
 import System.IO.Unsafe (unsafePerformIO)
 import Test.Hspec
 
-import Dscp.Core (ATGDelta (..), Course (..), gB, ssSubmission, ssWitness, swKey, swSig)
-import Dscp.Core.Foundation.Educator (PrivateBlock (..), PrivateBlockBody (..),
-                                      PrivateBlockHeader (..), PrivateTx (..), genesisHeaderHash,
-                                      ptSignedSubmission)
+import Dscp.Core
 import Dscp.Crypto (AbstractPK (..), AbstractSK (..), PublicKey, SecretKey, fromFoldable,
                     getMerkleRoot, hash)
 import Dscp.Educator.BlockValidation (BlockValidationFailure (..), SubmissionValidationFailure (..),
@@ -86,6 +83,7 @@ spec_ValidateBlock = describe "Validate private block" $ do
                                         , bvfActualMerkleSig = _pbhBodyProof (_pbHeader block)
                                         }]
   where
+    educatorAddr = mkAddr $ mkPubKey 'z'
     getTxKey tx = tx^.ptSignedSubmission.ssWitness.swKey
     getTxSig tx = tx^.ptSignedSubmission.ssWitness.swSig
     hashTxSub tx = tx^.ptSignedSubmission.ssSubmission.to hash
@@ -94,7 +92,7 @@ spec_ValidateBlock = describe "Validate private block" $ do
         , _pbBody = mkBlockBody txs
         }
     mkBlockHeader txs = PrivateBlockHeader
-        { _pbhPrevBlock = genesisHeaderHash
+        { _pbhPrevBlock = genesisHeaderHash educatorAddr
         , _pbhBodyProof = mkBodyProof txs
         , _pbhAtgDelta = mkATGDelta
         }

--- a/educator/tests/Test/Dscp/Educator/Mode.hs
+++ b/educator/tests/Test/Dscp/Educator/Mode.hs
@@ -55,7 +55,7 @@ runTestSQLiteM action =
     withEducatorConfig testEducatorConfig $
     withWitnessConfig (rcast testEducatorConfig) $
     runRIO _tecLogging $ do
-        _tecWitnessKeys <- genStore (Just $ CommitteeParamsOpen 0)
+        _tecWitnessKeys <- mkCommitteeStore (CommitteeParamsOpen 0)
         _tecWitnessDb <- PureDB.plugin <$> liftIO PureDB.newCtxVar
         _tecWitnessVariables <- mkTestWitnessVariables (_tecWitnessKeys ^. krPublicKey)
                                                        _tecWitnessDb

--- a/witness/src/Dscp/Resource/Keys/Functions.hs
+++ b/witness/src/Dscp/Resource/Keys/Functions.hs
@@ -5,8 +5,8 @@
 module Dscp.Resource.Keys.Functions
     ( toKeyfileContent
     , fromKeyfileContent
-    , genRandomStore
     , genStore
+    , mkCommitteeStore
     , readStore
     , linkStore
     , toSecretJson
@@ -66,23 +66,18 @@ storePath BaseKeyParams{..} appDir nodeNameP =
     defPath = appDir </> (nodeNameP |+ ".key")
 
 -- | Generate key resources randomly.
-genRandomStore :: MonadIO m => m (KeyResources n)
-genRandomStore =
-    KeyResources . secretKeyDataFromPair <$> runSecureRandom keyGen
+genStore :: MonadIO m => m (KeyResources n)
+genStore = KeyResources . secretKeyDataFromPair <$> runSecureRandom keyGen
 
--- | Generate key resources with respect to given committe parameters if
--- specified, otherwise randomly.
-genStore ::
-       (HasCoreConfig, MonadThrow m, MonadIO m, MonadLogging m)
-    => Maybe CommitteeParams
+-- | Generate key resources with respect to given committe parameters.
+mkCommitteeStore ::
+       (HasCoreConfig, MonadThrow m, MonadLogging m)
+    => CommitteeParams
     -> m (KeyResources n)
-genStore comParamsM = do
+mkCommitteeStore comParams = do
     _krSecretKeyData <-
-        case comParamsM of
-          Nothing -> do
-              logInfo "Generating random key"
-              secretKeyDataFromPair <$> runSecureRandom keyGen
-          Just (CommitteeParamsOpen i) -> do
+        case comParams of
+          CommitteeParamsOpen i -> do
               logInfo "Creating open committee key"
               sec <- case gcGovernance (giveL @CoreConfig @GenesisConfig) of
                          GovCommittee (CommitteeOpen{..}) -> do
@@ -95,7 +90,7 @@ genStore comParamsM = do
                                        "config specifies: " <> show x
               let sk = committeeDerive sec i
               pure (mkSecretKeyData sk)
-          Just (CommitteeParamsClosed {..}) -> do
+          CommitteeParamsClosed {..} -> do
               logInfo "Creating closed committee key"
               let addrs = case gcGovernance (giveL @CoreConfig @GenesisConfig) of
                               GovCommittee (CommitteeClosed a) -> a
@@ -158,7 +153,7 @@ createStore ::
     -> m (KeyResources n)
 createStore path pp = do
      logInfo $ "Creating new "+|nodeNameP|+" secret key under "+||path||+""
-     store <- genRandomStore
+     store <- genStore
      writeStore path pp store
      return store
   where

--- a/witness/src/Dscp/Resource/Keys/Functions.hs
+++ b/witness/src/Dscp/Resource/Keys/Functions.hs
@@ -5,6 +5,7 @@
 module Dscp.Resource.Keys.Functions
     ( toKeyfileContent
     , fromKeyfileContent
+    , genRandomStore
     , genStore
     , readStore
     , linkStore
@@ -63,6 +64,11 @@ storePath BaseKeyParams{..} appDir nodeNameP =
     fromMaybe defPath bkpPath
   where
     defPath = appDir </> (nodeNameP |+ ".key")
+
+-- | Generate key resources randomly.
+genRandomStore :: MonadIO m => m (KeyResources n)
+genRandomStore =
+    KeyResources . secretKeyDataFromPair <$> runSecureRandom keyGen
 
 -- | Generate key resources with respect to given committe parameters if
 -- specified, otherwise randomly.
@@ -146,14 +152,13 @@ createStore ::
        , MonadCatch m
        , MonadLogging m
        , Buildable (Proxy n)
-       , HasCoreConfig
        )
     => FilePath
     -> PassPhrase
     -> m (KeyResources n)
 createStore path pp = do
      logInfo $ "Creating new "+|nodeNameP|+" secret key under "+||path||+""
-     store <- genStore Nothing
+     store <- genRandomStore
      writeStore path pp store
      return store
   where

--- a/witness/src/Dscp/Resource/Keys/Types.hs
+++ b/witness/src/Dscp/Resource/Keys/Types.hs
@@ -14,6 +14,7 @@ module Dscp.Resource.Keys.Types
 
     , ourSecretKey
     , ourPublicKey
+    , ourAddress
     , ourSecretKeyData
     ) where
 
@@ -24,6 +25,7 @@ import Data.Aeson.TH (deriveJSON)
 import Loot.Base.HasLens (HasLens', lensOf)
 
 import Dscp.Core.Aeson ()
+import Dscp.Core.Foundation.Address
 import Dscp.Core.Foundation.Witness
 import Dscp.Core.Governance (CommitteeSecret (..))
 import Dscp.Crypto (Encrypted, PassPhrase, PublicKey, SecretKey)
@@ -132,6 +134,12 @@ ourPublicKey
        (HasLens' ctx (KeyResources node), MonadReader ctx m)
     => m PublicKey
 ourPublicKey = view $ lensOf @(KeyResources node) . krSecretKeyData . to skPublic
+
+ourAddress
+    :: forall node ctx m.
+       (HasLens' ctx (KeyResources node), MonadReader ctx m)
+    => m Address
+ourAddress = view $ lensOf @(KeyResources node) . krSecretKeyData . to skAddress
 
 ourSecretKeyData
     :: forall node ctx m.

--- a/witness/src/Dscp/Snowdrop/Expanders.hs
+++ b/witness/src/Dscp/Snowdrop/Expanders.hs
@@ -121,7 +121,7 @@ seqExpandersPublicationTx feesReceiverAddr (Fees minFee) =
             let phHash = hash ptHeader
             let prevHash = ptHeader ^. pbhPrevBlock
             let (prevHashM :: Maybe PrivateHeaderHash) =
-                    prevHash <$ guard (prevHash /= genesisHeaderHash)
+                    prevHash <$ guard (prevHash /= genesisHeaderHash ptAuthor)
 
             headerWasEarlier <- queryOneExists (PublicationHead phHash)
             let headerIsLast = prevHash == phHash

--- a/witness/src/Dscp/Snowdrop/PublicationValidation.hs
+++ b/witness/src/Dscp/Snowdrop/PublicationValidation.hs
@@ -54,7 +54,7 @@ preValidatePublication =
 
         let prevHash = privHeader ^. pbhPrevBlock
         let (prevHashM :: Maybe PrivateHeaderHash) =
-                prevHash <$ guard (prevHash /= genesisHeaderHash)
+                prevHash <$ guard (prevHash /= genesisHeaderHash authorId)
 
         -- Checking that prevBlockHash matches the one from storage.
         lastPub <- queryOne (PublicationsOf authorId)

--- a/witness/src/Dscp/Witness/Launcher/Resource.hs
+++ b/witness/src/Dscp/Witness/Launcher/Resource.hs
@@ -24,7 +24,7 @@ import Dscp.DB.CanProvideDB as Rocks
 import Dscp.DB.CanProvideDB.Rocks as RealRocks
 import Dscp.Resource.AppDir
 import Dscp.Resource.Class (AllocResource (..), buildComponentR)
-import Dscp.Resource.Keys (KeyResources (..), genStore, linkStore)
+import Dscp.Resource.Keys
 import Dscp.Resource.Network (NetLogging (..), NetServResources, withNetLogging)
 import Dscp.Resource.Rocks ()
 import Dscp.Util.HasLens
@@ -55,7 +55,7 @@ getWitnessKeyResources
     -> AppDir
     -> m (KeyResources WitnessNode)
 getWitnessKeyResources (Basic bkp) appDir = linkStore bkp appDir
-getWitnessKeyResources (Committee cp) _   = genStore (Just cp)
+getWitnessKeyResources (Committee cp) _   = mkCommitteeStore cp
 
 instance AllocResource (KeyResources WitnessNode) where
     type Deps (KeyResources WitnessNode) = (WitnessConfigRec, AppDir)

--- a/witness/src/Dscp/Witness/Logic/Getters.hs
+++ b/witness/src/Dscp/Witness/Logic/Getters.hs
@@ -193,5 +193,5 @@ getPrivateTipHash
     :: HasWitnessConfig
     => Address -> SdM_ chgacc PrivateHeaderHash
 getPrivateTipHash educator =
-    maybe genesisHeaderHash unLastPublication <$>
+    maybe (genesisHeaderHash educator) unLastPublication <$>
     SD.queryOne (PublicationsOf educator)

--- a/witness/src/Dscp/Witness/Logic/Traversals.hs
+++ b/witness/src/Dscp/Witness/Logic/Traversals.hs
@@ -326,7 +326,7 @@ educatorPublicationsSource educator = \case
         C.yield $ WithBlock mblock ptx
 
         let prevHash = _pbhPrevBlock (ptHeader ptx)
-        unless (prevHash == genesisHeaderHash) $
+        unless (prevHash == genesisHeaderHash educator) $
             lift2xSdM (prevHash `assertExists` noPrivHeader prevHash)
             >>= loadChain
 

--- a/witness/tests/Test/Dscp/Witness/Mode.hs
+++ b/witness/tests/Test/Dscp/Witness/Mode.hs
@@ -40,7 +40,7 @@ type WitnessTestMode' = RIO TestWitnessCtx
 runWitnessTestMode :: WitnessTestMode' a -> IO a
 runWitnessTestMode action =
     withWitnessConfig testWitnessConfig $ runRIO testLogging $ do
-        _twcKeys <- genStore (Just $ CommitteeParamsOpen 0)
+        _twcKeys <- mkCommitteeStore (CommitteeParamsOpen 0)
         _twcDb   <- PureDB.plugin <$> liftIO PureDB.newCtxVar
         _twcVars <- mkTestWitnessVariables (_twcKeys ^. krPublicKey) _twcDb
         let _twcLogging = testLogging

--- a/witness/tests/Test/Dscp/Witness/Tx/PublicationTxSpec.hs
+++ b/witness/tests/Test/Dscp/Witness/Tx/PublicationTxSpec.hs
@@ -25,7 +25,7 @@ genPublicationChain n secret
         let addr = mkAddr (skPublic secret)
         sigs <- vectorUniqueOf (fromIntegral n) arbitrary
         return . Exts.fromList . fix $ \pubTxs ->
-            zip sigs (genesisHeaderHash : map (hash . ptHeader) pubTxs) <&>
+            zip sigs (genesisHeaderHash addr : map (hash . ptHeader) pubTxs) <&>
               \(sig, prevHeaderHash) ->
                 let ptHeader = PrivateBlockHeader
                         { _pbhPrevBlock = prevHeaderHash


### PR DESCRIPTION
### Description

Make genesis header depend on educator's address.

### YT issue

https://issues.serokell.io/issue/DSCP-285

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
