### PR TITLE
[DSCP-369] Make `addTxToMempool` not check whether tx is present

### DIFF
--- a/educator/src/Dscp/Educator/Workers.hs
+++ b/educator/src/Dscp/Educator/Workers.hs
@@ -65,7 +65,5 @@ privateBlockPublishingWorker =
                 txw <- makePublicationTx block
                 logInfo $ fmt $ nameF "Created new private block" (build txw)
                 -- TODO [DSCP-299] Be more insistent
-                isNew <- writingSDLock "add pub to mempool" $
-                          addTxToMempool (GPublicationTxWitnessed txw)
-                unless isNew $
-                    logWarning "Private block was already present"
+                writingSDLock "add pub to mempool" $
+                    addTxToMempool (GPublicationTxWitnessed txw)

--- a/witness/src/Dscp/Witness/Mempool/Logic.hs
+++ b/witness/src/Dscp/Witness/Mempool/Logic.hs
@@ -57,15 +57,11 @@ addTxToMempool
     :: forall ctx m
     .  (MempoolCtx ctx m, WithinWriteSDLock)
     => GTxWitnessed
-    -> m Bool
+    -> m ()
 addTxToMempool tx = do
     Mempool pool conf <- view (lensOf @MempoolVar)
-    writeToMempool @ctx pool $ do
-        txsWithUndos <- gets Pool.msTxs
-        let isNew = tx `notElem` map fst txsWithUndos
-        when isNew $
-            Pool.processTxAndInsertToMempool conf tx
-        return isNew
+    writeToMempool @ctx pool $
+        Pool.processTxAndInsertToMempool conf tx
 
 -- | See all mempool transactions.
 readTxsMempool :: (MempoolCtx ctx m, WithinReadSDLock) => m [GTxWitnessed]

--- a/witness/src/Dscp/Witness/Workers/Worker.hs
+++ b/witness/src/Dscp/Witness/Workers/Worker.hs
@@ -164,12 +164,11 @@ makeRelay (RelayState input pipe failedTxs) =
         whenJust hasFailed $ \(_, e) ->
             throwM e
 
-        isNew <- writingSDLock "add to mempool" $
-                     addTxToMempool @ctx tx
-                        `onAnException` \e -> addFailedTx (tx, e)
+        writingSDLock "add to mempool" $
+            addTxToMempool @ctx tx
+                `onAnException` \e -> addFailedTx (tx, e)
 
-        when isNew $
-            atomically $ STM.writeTBQueue pipe tx
+        atomically $ STM.writeTBQueue pipe tx
 
     addFailedTx entry@(tx, _) =
         atomically $ STM.modifyTVar failedTxs $ HashMap.insert (hash tx) entry

--- a/witness/tests/Test/Dscp/Witness/Explorer/ExplorerSpec.hs
+++ b/witness/tests/Test/Dscp/Witness/Explorer/ExplorerSpec.hs
@@ -24,8 +24,7 @@ createAndSubmitTx genSecret = do
     account <- lift . runSdReadM $ fromMaybe def <$> getMempoolAccountMaybe (skAddress sk)
 
     let txw = createTxw (fcMoney feeConfig) sk (aNonce account) outs
-    isNew <- lift $ addTxToMempool (GMoneyTxWitnessed txw)
-    unless isNew $ error "Duplicated transaction???"
+    lift $ addTxToMempool (GMoneyTxWitnessed txw)
     return $ twTx txw
 
 -- | Generate valid publication and put it into mempool.
@@ -48,8 +47,7 @@ createAndSubmitPub genSecret = do
             , ptHeader
             }
     let txw = signPubTx sk tx
-    isNew <- lift $ addTxToMempool (GPublicationTxWitnessed txw)
-    unless isNew $ error "Duplicated transaction???"
+    lift $ addTxToMempool (GPublicationTxWitnessed txw)
     return tx
 
 -- | Dump all mempool transactions into a new block.

--- a/witness/tests/Test/Dscp/Witness/Tx/MoneyTxSpec.hs
+++ b/witness/tests/Test/Dscp/Witness/Tx/MoneyTxSpec.hs
@@ -239,8 +239,6 @@ spec = describe "Money tx expansion + validation" $ do
                 mapM_ applyTx txs
 
         it "Two same transactions" $ witnessProperty $ do
-            _ <- stop $ pendingWith "[DSCP-369] Make addTxToMempool do not check transaction presence"
-
             txData <- pick genSafeTxData
             let tx = makeTx properSteps txData
             lift $ do


### PR DESCRIPTION
This makes sense as soon as validation fits better for such check.
Actually, we already have this check both for money and publication transactions.

### Description

<!-- PR description goes here -->

### YT issue

https://issues.serokell.io/issue/DSCP-369

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
