### PR TITLE
[SRK-3] Eliminate need in specifying YT ticket in PR

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -2,10 +2,6 @@
 
 <!-- PR description goes here -->
 
-### YT issue
-
-https://issues.serokell.io/issue/DSCP-
-
 ### Checklist
 
 Hint: a perfect PR has all the checkmarks set.


### PR DESCRIPTION
### Description

What about using a script which renders a ticket id into YT link on itself?
One for Tampermonkey: https://gist.github.com/Martoon-00/9566df26317e2aecfa5af9f763662829

![screenshot from 2018-11-12 21-00-18](https://user-images.githubusercontent.com/5394217/48368851-e2093480-e6c5-11e8-9403-5bfecaae5810.png)

### YT issue

https://issues.serokell.io/issue/SRK-3

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
