### PR TITLE
[DSCP-370] use new loot-log (based on co-log) for logging

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -40,64 +40,31 @@ demo: &demo
     db:
       path: "/var/db/dscp-witness"
       clean: false
-
     logging:
-      defaultName: "witness"
-      config:
-        syslog: &demo-witness-syslog
-          loggers-tree:
-            witness:
-              withPERROR: true
-              min-level: Debug
-              sub-loggers:
-                network:
-                  min-level: Info
-                web:
-                  min-level: Info
-        warper: &demo-witness-warper
-          filePrefix: "run/tmp/witness/logs"
-          loggerTree:
-            handlers:
-              - file: node.log
-            severity: Info+
-            witness:
-              severity: Debug+
-              network:
-                severity: Info+
-              web:
-                severity: Info+
-            init:
-              log:
-                severity: Debug+
+      default-name: "witness"
+      backends:
+      - type: stderr
+      - type: syslog
+        app-name: "witness"
+      min-level: Debug
 
   educator:
     logging:
-      defaultName: "educator"
-      config:
-        warper:
-          <<: *demo-witness-warper
-          filePrefix: "run/tmp/educator/logs"
-        syslog:
-          <<: *demo-witness-syslog
+      default-name: "educator"
+      backends:
+      - type: stderr
+      - type: syslog
+        app-name: "educator"
+      min-level: Debug
 
   faucet:
     logging:
-      defaultName: "faucet"
-      config:
-        warper:
-          filePrefix: "run/tmp/faucet/logs"
-          loggerTree:
-            handlers:
-              - file: node.log
-            severity: Info+
-            init:
-              log:
-                severity: Debug+
-        syslog:
-          loggers-tree:
-            faucet:
-              withPERROR: true
-              min-level: Debug
+      default-name: "faucet"
+      backends:
+      - type: stderr
+      - type: syslog
+        app-name: "faucet"
+      min-level: Debug
 
 singleton:
   <<: *demo

--- a/core/package.yaml
+++ b/core/package.yaml
@@ -15,6 +15,7 @@ library:
     - bytestring
     - bytestring
     - base58-bytestring
+    - co-log-sys
     - containers
     - componentm
     - crypto-api
@@ -29,7 +30,6 @@ library:
     - hashable
     - hspec
     - jose
-    - log-warper
     - loot-base
     - loot-config
     - loot-log

--- a/core/src/Dscp/Resource/Logging.hs
+++ b/core/src/Dscp/Resource/Logging.hs
@@ -4,26 +4,20 @@
 
 module Dscp.Resource.Logging
     ( LoggingParams(..)
-    , LoggingConfig (..)
     , basicLoggingParams
     , allocLogging
     , noLogging
     ) where
 
-import Control.Applicative ((<|>))
-import Control.Monad.Component (ComponentM, buildComponent)
-import Data.Aeson (FromJSON (..), ToJSON, encode, toJSON, withObject, (.:), (.:?))
-import Data.Aeson.Options (defaultOptions)
-import Data.Aeson.TH (deriveFromJSON)
+import Colog.Syslog (Collector (..), Facility (User), SyslogConfig (..))
+import Control.Monad.Component (ComponentM)
+import Data.Aeson (FromJSON (..), ToJSON (..), Value (Object), (.:), (.=),
+                   encode, object, withObject)
 import Fmt ((+|), (|+))
-import Loot.Log (Level (Debug), Logging (..), Name, NameSelector (CallstackName, GivenName),
-                 logInfo, modifyLogName)
+import Loot.Log (BackendConfig (..), LogConfig (..), Logging (..), Name,
+                 NameSelector (..), Severity (Debug, Info), allocateLogging,
+                 fromLogAction, logDebug, modifyLogName)
 import Loot.Log.Rio (LoggingIO)
-import Loot.Log.Syslog (SyslogConfig (..), defaultLoggerConfig, loggerName, minLevel, prepareSyslog,
-                        stopLoggers, withPERROR)
-import Loot.Log.Warper (LoggerConfig, prepareLogWarper)
-import System.Wlog (productionB, removeAllHandlers, showTidB)
-import qualified Text.Show
 
 import Dscp.Rio (runRIO)
 
@@ -33,95 +27,53 @@ import Dscp.Rio (runRIO)
 
 -- | Contains all parameters required for hierarchical logger initialization.
 data LoggingParams = LoggingParams
-    { lpConfig      :: !LoggingConfig
+    { lpConfig      :: !LogConfig
     -- ^ Logger configuration that will be used
     , lpDefaultName :: !Name
     -- ^ Logger name which will be used by default
     } deriving (Show, Eq)
 
--- Orphan instances required by tests, based on ToJSON for simplicity
-instance Show LoggerConfig where
-    show = decodeUtf8 . encode
-
-instance Eq LoggerConfig where
-    a == b = toJSON a == toJSON b
-
-instance Eq SyslogConfig where
-    a == b = toJSON a == toJSON b
-
--- | Contains the configuration for a logging type
-data LoggingConfig
-    = Warper LoggerConfig
-    | Syslog SyslogConfig
-    deriving (Show, Eq)
-
--- | Creates a basic 'LoggingParams': a slightly modified syslog default
+-- | Creates a basic 'LoggingParams'
 basicLoggingParams :: Name -> Bool -> LoggingParams
 basicLoggingParams lpDefaultName debug = LoggingParams {..}
   where
-    lpConfig = Syslog $ SyslogConfig [simpleLoggerConfig]
-    simpleLoggerConfig = defaultLoggerConfig
-        & loggerName .~ show lpDefaultName
-        & withPERROR .~ True
-        & minLevel %~ if debug then const Debug else id
+    syslogConfig = SyslogConfig AutoLocal User (show lpDefaultName)
+    backends = [StdErr, Syslog syslogConfig]
+    minSeverity = if debug then Debug else Info
+    lpConfig = LogConfig {..}
 
 ----------------------------------------------------------------------------
 -- Other
 ----------------------------------------------------------------------------
 
 allocLogging :: LoggingParams -> ComponentM LoggingIO
-allocLogging LoggingParams{..} = buildComponent "logging" pre fin
-  where
-    givenName = GivenName lpDefaultName
-    pre = case lpConfig of
-        Warper config -> do
-            (config', logging) <-
-                prepareLogWarper (config <> productionB <> showTidB) givenName
-            printCfg logging config'
-            return logging
-        Syslog config -> do
-            logging <- prepareSyslog config givenName
-            printCfg logging config
-            return logging
-
-    fin _ = case lpConfig of
-        Warper _ -> removeAllHandlers
-        Syslog _ -> stopLoggers
-
-    printCfg :: (ToJSON c) => LoggingIO -> c -> IO ()
-    printCfg logging finalConfig =
-        runRIO logging $ modifyLogName (<> "init" <> "log") $ do
-            let configText = decodeUtf8 (encode finalConfig) :: Text
-            logInfo $ "Logging config: "+|configText|+""
+allocLogging LoggingParams{..} = do
+    logging <- allocateLogging lpConfig (GivenName lpDefaultName)
+    liftIO $ runRIO logging $ modifyLogName (<> "init" <> "log") $ do
+        let configText = decodeUtf8 (encode lpConfig) :: Text
+        logDebug $ "Logging config: "+|configText|+""
+    return logging
 
 ---------------------------------------------------------------------------
 -- JSON instances
 ---------------------------------------------------------------------------
 
-instance FromJSON Name where
-    parseJSON = fmap fromString . parseJSON
+instance FromJSON LoggingParams where
+    parseJSON = withObject "LoggingParams" $ \v -> LoggingParams
+        <$> parseJSON (Object v)
+        -- short-circuiting: avoids adding a "config" key and parses a LogConfig directly
+        <*> v .: "default-name"
 
--- | 'LoggingConfig' has a quite flexible 'FromJSON' implementation:
--- It accepts 3 subsection: a "use" selector, "syslog" and "warper" configurations
--- If only one of the configs is defined it will be used, "use" is not necessary
--- If both are defined and "use" is not specified, "syslog" will be used
--- If "use" has a value of "syslog" or "warper", this chosen config will be used
-instance FromJSON LoggingConfig where
-    parseJSON = withObject "LoggingConfig" $ \v -> do
-        let readConf val = case val :: Text of
-                "syslog" -> Syslog <$> v .: "syslog"
-                "warper" -> Warper <$> v .: "warper"
-                name     -> fail . toString $ "unknown logging selection: " <> name
-        maybe (readConf "syslog" <|> readConf "warper") readConf =<< v .:? "use"
-
-deriveFromJSON defaultOptions ''LoggingParams
-
+instance ToJSON LoggingParams where
+    toJSON LoggingParams {..} = object
+        [ "default-name" .= lpDefaultName
+        -- short-circuiting: the next 2 pairs actually belong to the 'LogConfig'
+        , "backends"     .= backends lpConfig
+        , "min-severity" .= minSeverity lpConfig
+        ]
 ---------------------------------------------------------------------------
 -- Misc
 ---------------------------------------------------------------------------
 
 noLogging :: Monad m => Logging m
-noLogging = Logging
-    { _log = \_ _ _ -> pass
-    , _logName = pure CallstackName
-    }
+noLogging = fromLogAction CallstackName mempty

--- a/core/src/Dscp/Util/Test.hs
+++ b/core/src/Dscp/Util/Test.hs
@@ -207,7 +207,7 @@ runCliArgs p = getParseResult . execParserPure defaultPrefs (info p mempty)
 
 -- | When warning or error are logged, this exception is thrown.
 data TestLoggedError = TestLoggedError
-    { tleLvl :: Log.Level
+    { tleLvl :: Log.Severity
     , tleMsg :: Text
     }
 
@@ -226,7 +226,7 @@ instance Buildable TestLoggedError where
 testLogging :: Log.Logging IO
 testLogging =
     Log.Logging
-    { Log._log = \lvl _ msg ->
+    { Log._log = \(Log.Message lvl _ msg) ->
         when (lvl >= Log.Warning) $
             throwM $ TestLoggedError lvl msg
     , Log._logName = return $ error "Logger name requested in test"

--- a/stack.yaml
+++ b/stack.yaml
@@ -34,7 +34,7 @@ extra-deps:
   commit: 333a2b2cf113e115ea2ec450dc706d3f47ee54e4
 
 - git: https://github.com/serokell/blockchain-util.git
-  commit: acf7fb3ad3a96739beb7282e01e89f1ff44db3af # volhovm/dscp193
+  commit: 9a28a192c55cb61735ffc0c899fbd80815e1dd2c # volhovm/dscp193
   subdirs:
     - snowdrop-core
     - snowdrop-util
@@ -44,11 +44,24 @@ extra-deps:
 - git: https://github.com/serokell/rocksdb-haskell.git
   commit: 2dd6b4ffdc4edb86b477273ee3c8416a1520f4e1
 
-- git: https://github.com/pasqu4le/hslogger.git
-  commit: 28d5f0cf220a1b7162eaa1535e72e6cad2362ee4
+# Required by lootbox (loot-log)
+- git: https://github.com/kowainik/co-log.git
+  commit: 41cc915e42628c9cc4eea28db2ecdf11bd0e413e
+  subdirs:
+  - co-log-core
+  - co-log
+
+- git: https://github.com/serokell/co-log-sys.git
+  commit: 4d3edc99a073e51830dce0dd0efd35b65f9fb5b5
+
+# Required by co-log and co-log-core
+- contravariant-1.5
+- relude-0.3.0
+- typerep-map-0.3.0
+- primitive-0.6.4.0
 
 - git: https://github.com/serokell/lootbox.git
-  commit: 63bed09c8b1013b3485edb54f2b70096ef70a337
+  commit: b66d53bf42e88d44184046f3450ab2f01bd9c8b6
   subdirs:
     - code/base
     - code/config

--- a/witness/src/Dscp/Util/Servant.hs
+++ b/witness/src/Dscp/Util/Servant.hs
@@ -39,7 +39,7 @@ import Data.Time.Clock.POSIX (getPOSIXTime)
 import Fmt (blockListF, (+|), (|+), Builder)
 import GHC.IO.Unsafe (unsafePerformIO)
 import GHC.TypeLits (KnownSymbol, symbolVal)
-import Loot.Log (Level (Info))
+import Loot.Log (Severity (Info))
 import Serokell.Util ()
 import Serokell.Util.ANSI (Color (..), colorizeDull)
 import Servant.API ((:<|>) (..), (:>), Capture, Description, JSON, NoContent, QueryFlag, QueryParam,
@@ -131,7 +131,7 @@ data LoggingApi config api
 data LoggingApiRec config api
 
 newtype ServantLogConfig = ServantLogConfig
-    { clcLog :: Level -> Text -> IO ()
+    { clcLog :: Severity -> Text -> IO ()
     }
 
 -- | Used to incrementally collect info about passed parameters.
@@ -349,7 +349,7 @@ applyServantLogging configP methodP paramsInfo showResponse action = do
         return $ do
             endTime <- liftIO getPOSIXTime
             return . show $ endTime - startTime
-    log :: Level -> Text -> Handler ()
+    log :: Severity -> Text -> Handler ()
     log = liftIO ... clcLog $ reflect configP
     eParamLogs :: Either Text Text
     eParamLogs = case paramsInfo of

--- a/witness/src/Dscp/Web/Server.hs
+++ b/witness/src/Dscp/Web/Server.hs
@@ -10,7 +10,7 @@ module Dscp.Web.Server
 
 import Control.Lens (views)
 import Loot.Base.HasLens (HasLens', lensOf)
-import Loot.Log (Logging, MonadLogging, Name, NameSelector (..))
+import Loot.Log (Logging, Message (..), MonadLogging, Name, NameSelector (..))
 import qualified Loot.Log.Internal as Log
 import Network.HTTP.Client.TLS (newTlsManager)
 import qualified Network.Wai.Handler.Warp as Warp
@@ -46,7 +46,7 @@ buildServantLogConfig modifyName = do
                        _           -> mempty
         name = modifyName origName
     return ServantLogConfig
-        { clcLog = \level text -> logger level name text
+        { clcLog = \severity text -> logger $ Message severity name text
         }
 
 ----------------------------------------------------------------------------


### PR DESCRIPTION
### Description

This PR modifies logging to be based on `co-log`, this required the creation of a syslog backend for `co-log` (`co-log-sys`) and an updated version of `loot-log` and `snowdrop-util` that make use of it.

NOTE: this PR is labeled as a WIP because it depends a yet unmerged branch of `lootbox` and an updated branch of `blockchain-util`.

### YT issue

https://issues.serokell.io/issue/DSCP-370

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
