### PR TITLE
[DSCP-301] Add endpoint showing educator status

### DIFF
--- a/educator/src/Dscp/Educator/Web/Bot/Handlers.hs
+++ b/educator/src/Dscp/Educator/Web/Bot/Handlers.hs
@@ -11,7 +11,6 @@ import Dscp.Educator.Web.Bot.Setting
 import Dscp.Educator.Web.Student
 import Dscp.Educator.Web.Types
 
-
 initializeBot
     :: BotWorkMode ctx m
     => EducatorBotParams -> (HasBotSetting => m a) -> m a

--- a/educator/src/Dscp/Educator/Web/Bot/Setting.hs
+++ b/educator/src/Dscp/Educator/Web/Bot/Setting.hs
@@ -24,10 +24,8 @@ import qualified Data.Set as S
 import Data.Time.Clock (getCurrentTime)
 import Fmt ((+|), (+||), (|+), (||+))
 import qualified GHC.Exts as Exts
-import Loot.Base.HasLens (HasCtx)
-import Loot.Log (ModifyLogName, MonadLogging, logError, logInfo, modifyLogName)
+import Loot.Log (ModifyLogName, logError, logInfo, modifyLogName)
 import Time.Units (Microsecond, Time, threadDelay)
-import UnliftIO (MonadUnliftIO)
 import UnliftIO.Async (async)
 
 import Dscp.Core
@@ -35,6 +33,7 @@ import Dscp.Crypto.Impl
 import Dscp.DB.SQLite
 import Dscp.Educator.Web.Bot.Params
 import Dscp.Educator.Web.Student.Types
+import Dscp.Educator.Web.Types
 import Dscp.Util
 import Dscp.Util.Test
 
@@ -109,7 +108,6 @@ mkBotSetting params =
   botGen = detGenG (ebpSeed params)
 
   bsCourses =
-    -- using 'courseEx' here helps to keep examples in swagger doc working
     [ (Course 0  , "Patakology", [])
     , (Course 1  , "Learning!", [])
     -- [Note: examples-in-bot]
@@ -178,12 +176,7 @@ botSetting = given
 ---------------------------------------------------------------------
 
 type BotWorkMode ctx m =
-    ( MonadIO m
-    , MonadCatch m
-    , MonadUnliftIO m
-    , MonadLogging m
-    , ModifyLogName m
-    , HasCtx ctx m '[SQLiteDB]
+    ( MonadEducatorWeb ctx m
     )
 
 botLog :: ModifyLogName m => m a -> m a

--- a/educator/src/Dscp/Educator/Web/Educator/API.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/API.hs
@@ -22,7 +22,8 @@ import Dscp.Educator.Web.Educator.Types
 import Dscp.Educator.Web.Types
 
 data EducatorApiEndpoints route = EducatorApiEndpoints
-    { eGetStudents             :: route :- GetStudents
+    { eGetStatus               :: route :- GetStatus
+    , eGetStudents             :: route :- GetStudents
     , eAddStudent              :: route :- AddStudent
     , eDeleteStudent           :: route :- DeleteStudent
     , eAddStudentCourse        :: route :- AddStudentCourse
@@ -54,6 +55,14 @@ educatorAPI = Proxy
 
 protectedEducatorAPI :: Proxy ProtectedEducatorAPI
 protectedEducatorAPI = Proxy
+
+---------------------------------------------------------------------------
+-- General
+---------------------------------------------------------------------------
+
+type GetStatus
+    = "status"
+    :> Get '[DSON] EducatorInfo
 
 ---------------------------------------------------------------------------
 -- Students

--- a/educator/src/Dscp/Educator/Web/Educator/Handlers.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Handlers.hs
@@ -26,9 +26,12 @@ educatorApiHandlers
 educatorApiHandlers =
     EducatorApiEndpoints
     {
+      eGetStatus =
+        getEducatorStatus
+
       -- Students
 
-      eGetStudents = \mCourse _mIsEnrolled _onlyCount ->
+    , eGetStudents = \mCourse _mIsEnrolled _onlyCount ->
         invoke $ educatorGetStudents mCourse
 
     , eAddStudent = \(NewStudent student) ->

--- a/educator/src/Dscp/Educator/Web/Educator/Types.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Types.hs
@@ -13,6 +13,7 @@ module Dscp.Educator.Web.Educator.Types
     , NewStudentAssignment (..)
 
       -- * Responses
+    , EducatorInfo (..)
     , CourseEducatorInfo (..)
     , AssignmentEducatorInfo (..)
     , SubmissionEducatorInfo (..)
@@ -27,12 +28,13 @@ module Dscp.Educator.Web.Educator.Types
 import Control.Lens (from)
 import Data.Aeson.Options (defaultOptions)
 import Data.Aeson.TH (deriveJSON)
-import Fmt (build, (+|), (|+), listF)
+import Fmt (build, listF, (+|), (|+))
 
 import Dscp.Core
 import Dscp.Crypto
 import Dscp.Educator.Web.Types
-import Dscp.Util.Servant (ForResponseLog (..), buildShortResponseList, buildLongResponseList)
+import Dscp.Util.Servant (ForResponseLog (..), buildLongResponseList, buildShortResponseList)
+import Dscp.Witness.Web.Types
 
 data NewStudent = NewStudent
     { nsAddr :: Student
@@ -63,6 +65,11 @@ data NewStudentCourse = NewStudentCourse
 data NewStudentAssignment = NewStudentAssignment
     { nsaAssignmentHash :: Hash Assignment
     }
+
+data EducatorInfo = EducatorInfo
+    { eiAddress  :: Address
+    , eiBalances :: BlocksOrMempool Coin
+    } deriving (Show, Eq, Ord, Generic)
 
 data CourseEducatorInfo = CourseEducatorInfo
     { ciId       :: Course
@@ -192,6 +199,12 @@ instance Buildable (SubmissionEducatorInfo) where
       ", assignment hash = " +| siAssignmentHash |+
       " }"
 
+instance Buildable (ForResponseLog EducatorInfo) where
+    build (ForResponseLog EducatorInfo{..})=
+      "{ address = " +| eiAddress |+
+      ", balances = " +| eiBalances |+
+      " }"
+
 instance Buildable (ForResponseLog CourseEducatorInfo) where
     build (ForResponseLog CourseEducatorInfo{..}) =
       "{ course id = " +| ciId |+
@@ -226,6 +239,7 @@ deriveJSON defaultOptions ''NewGrade
 deriveJSON defaultOptions ''NewAssignment
 deriveJSON defaultOptions ''NewStudentCourse
 deriveJSON defaultOptions ''NewStudentAssignment
+deriveJSON defaultOptions ''EducatorInfo
 deriveJSON defaultOptions ''CourseEducatorInfo
 deriveJSON defaultOptions ''AssignmentEducatorInfo
 deriveJSON defaultOptions ''SubmissionEducatorInfo

--- a/educator/src/Dscp/Educator/Web/Logic.hs
+++ b/educator/src/Dscp/Educator/Web/Logic.hs
@@ -2,11 +2,22 @@
 
 module Dscp.Educator.Web.Logic
     ( commonGetProofs
+    , getEducatorStatus
     ) where
 
+import Data.Default (def)
+import Dscp.Core
 import Dscp.DB.SQLite
+import Dscp.Educator.Launcher.Mode
+import Dscp.Educator.Web.Educator.Types
 import Dscp.Educator.Web.Types
+import Dscp.Resource.Keys
+import Dscp.Snowdrop.Mode
+import Dscp.Snowdrop.Types
 import Dscp.Util.Aeson
+import Dscp.Witness.Logic.Getters
+import Dscp.Witness.SDLock
+import Dscp.Witness.Web.Types
 
 commonGetProofs
     :: MonadEducatorWebQuery m
@@ -19,3 +30,22 @@ commonGetProofs filters = do
         | (mtree, indicedTxs) <- rawProofs
         , let bpiTxs = map snd indicedTxs
         ]
+
+getEducatorStatus
+    :: MonadEducatorWeb ctx m
+    => m EducatorInfo
+getEducatorStatus = do
+    sk <- ourSecretKeyData @EducatorNode
+    let address = skAddress sk
+
+    -- TODO [DSCP-367]: to replace with one-liner
+    accounts <- readingSDLock $ do
+        blockAccount <- runSdReadM $ getAccountMaybe address
+        poolAccount  <- runSdReadM $ getMempoolAccountMaybe address
+        return $ fromMaybe def <$>
+                 BlocksOrMempool{ bmConfirmed = blockAccount, bmTotal = poolAccount }
+
+    return EducatorInfo
+        { eiAddress = address
+        , eiBalances = Coin . fromIntegral . aBalance <$> accounts
+        }

--- a/educator/src/Dscp/Educator/Web/Types.hs
+++ b/educator/src/Dscp/Educator/Web/Types.hs
@@ -42,16 +42,18 @@ import Fmt (build, (+|), (+||), (|+), (||+))
 import Loot.Base.HasLens (HasCtx)
 import Loot.Log (MonadLogging)
 import Servant (FromHttpApiData (..))
-import UnliftIO (MonadUnliftIO)
 
 import Dscp.Core
 import Dscp.Crypto
 import Dscp.DB.SQLite.Instances ()
 import Dscp.DB.SQLite.Types
+import Dscp.Educator.Launcher.Marker
+import Dscp.Resource.Keys
 import Dscp.Util.Aeson (CustomEncoding, HexEncoded)
 import Dscp.Util.Servant (ForResponseLog (..), buildForResponse, buildLongResponseList,
                           buildShortResponseList)
 import Dscp.Util.Type (type (==))
+import Dscp.Witness.Launcher.Context
 
 type MonadEducatorWebQuery m =
     ( MonadIO m
@@ -60,10 +62,8 @@ type MonadEducatorWebQuery m =
     )
 
 type MonadEducatorWeb ctx m =
-    ( MonadUnliftIO m
-    , MonadCatch m
-    , MonadLogging m
-    , HasCtx ctx m '[SQLiteDB]
+    ( WitnessWorkMode ctx m
+    , HasCtx ctx m '[SQLiteDB, KeyResources EducatorNode]
     )
 
 ---------------------------------------------------------------------------

--- a/educator/tests/Test/Dscp/Educator/Bot/Endpoints.hs
+++ b/educator/tests/Test/Dscp/Educator/Bot/Endpoints.hs
@@ -5,6 +5,7 @@ import Dscp.Crypto
 import Dscp.Educator.Web.Bot
 import Dscp.Educator.Web.Student
 import Dscp.Util.Test
+import Dscp.Witness.Config
 import Test.QuickCheck.Monadic (pick)
 
 import Test.Dscp.Educator.Mode
@@ -16,7 +17,7 @@ studentSK :: SecretKey
 studentSK = studentSKEx
 
 testMakeBotHandlers
-    :: TestEducatorM ~ m
+    :: (TestEducatorM ~ m, HasWitnessConfig)
     => Text -> m (StudentApiHandlers m)
 testMakeBotHandlers seed =
     initializeBot

--- a/multi-educator/src/Dscp/MultiEducator/Launcher/Mode.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Launcher/Mode.hs
@@ -56,6 +56,7 @@ import qualified Dscp.Witness as W
 type MultiEducatorWorkMode ctx m =
     ( Basic.BasicWorkMode m
 
+    , HasWitnessConfig
     , HasMultiEducatorConfig
 
     , MonadReader ctx m
@@ -66,8 +67,6 @@ type MultiEducatorWorkMode ctx m =
     -- the full educator context in multiToNormal from other lenses
     , HasLens' ctx MultiEducatorResources
     , HasLens' ctx W.WitnessVariables
-
-    , MonadThrow m
     )
 
 -- | Set of typeclasses which define capabilities both of Educator and Witness.

--- a/specs/disciplina/educator/api/educator.yaml
+++ b/specs/disciplina/educator/api/educator.yaml
@@ -21,6 +21,8 @@ servers:
 security:
   - EducatorAuth: []
 tags:
+  - name: General
+    description: General information about the educator
   - name: Students
     description: Methods for working with students and their data
   - name: Courses
@@ -34,6 +36,40 @@ tags:
   - name: Proofs
     description: Methods for working with proofs
 paths:
+  /status:
+    get:
+      tags:
+        - General
+      summary: Get information about the educator.
+      operationId: getStudents
+      responses:
+        200:
+          description: Returns educator status.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - address
+                  - balances
+                properties:
+                  address:
+                    $ref: '#/components/schemas/Address'
+                  balances:
+                    type: object
+                    properties:
+                      confirmed:
+                        type: integer
+                        format: int32
+                        description: Balance according to current chain.
+                      total:
+                        type: integer
+                        format: int32
+                        description: >-
+                          Balance derived from both chain and transactions which are not
+                          yet in blocks.
+        401:
+          $ref: '#/components/responses/Unauthorized'
   /students:
     get:
       tags:

--- a/witness/src/Dscp/Witness/Logic/Getters.hs
+++ b/witness/src/Dscp/Witness/Logic/Getters.hs
@@ -122,16 +122,16 @@ resolveNext = SD.queryOne . NextBlockOf . headerHash >=> pure . map unNextBlock
 -- TODO [DSCP-367] Unite these two below
 -- | Safely get an account.
 getAccountMaybe
-    :: WitnessWorkMode ctx m
+    :: (WitnessWorkMode ctx m, WithinReadSDLock)
     => Address -> SdReadM 'ChainOnly m (Maybe Account)
 getAccountMaybe =
-    lift . runStateSdMLocked . SD.queryOne . AccountId
+    lift . runStateSdM . SD.queryOne . AccountId
 
 -- | Safely get an account taking mempool into consideration.
 getMempoolAccountMaybe
-    :: WitnessWorkMode ctx m
+    :: (WitnessWorkMode ctx m, WithinReadSDLock)
     => Address -> SdReadM 'ChainAndMempool m (Maybe Account)
-getMempoolAccountMaybe addr = readingSDLock $ liftSdM $ SD.queryOne (AccountId addr)
+getMempoolAccountMaybe addr = liftSdM $ SD.queryOne (AccountId addr)
 
 -- | Get a list of all transactions for a given account
 getAccountTxs

--- a/witness/src/Dscp/Witness/Web/Logic.hs
+++ b/witness/src/Dscp/Witness/Web/Logic.hs
@@ -84,7 +84,7 @@ toAccountInfo
 toAccountInfo account txs = do
     transactions <- mapM (mapM (fetchBlockInfo . fmap @WithBlock unGTxWitnessed)) txs
     pure AccountInfo
-        { aiBalances = Coin . fromIntegral . aBalance <$> account
+        { aiBalances = leftToPanic . coinFromInteger . aBalance <$> account
         , aiCurrentNonce = nonce
         , aiTransactionCount = fromIntegral nonce
         , aiTransactions = transactions
@@ -193,7 +193,7 @@ getHashType someHash = fmap (fromMaybe HashIsUnknown) . runMaybeT . asum $
     isAddress = is
         (const HashIsAddress)
         addrFromText
-        (runSdReadMLocked @'ChainAndMempool . getMempoolAccountMaybe)
+        (\x -> runSdReadMLocked @'ChainAndMempool $ getMempoolAccountMaybe x)
     isTx = is
         (distinguishTx . unGTxWitnessed)
         fromHex

--- a/witness/src/Dscp/Witness/Web/Types.hs
+++ b/witness/src/Dscp/Witness/Web/Types.hs
@@ -34,7 +34,7 @@ data BlocksOrMempool a = BlocksOrMempool
       -- ^ Only looking at blocks
     , bmTotal     :: a
       -- ^ From blocks + mempool
-    } deriving (Eq, Show, Functor, Generic)
+    } deriving (Eq, Ord, Show, Functor, Generic)
 
 -- | Paginated list of something.
 -- Parameter @d@ is required to tell name of entities for JSON encoding,


### PR DESCRIPTION
### Description

Add a way to fetch educator's info directly via Educator API.

### YT issue

https://issues.serokell.io/issue/DSCP-301

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
