### PR TITLE
[DSCP-389] Remove `instance Data AccountException`

### DIFF
--- a/specs/disciplina/witness/api/witness.yaml
+++ b/specs/disciplina/witness/api/witness.yaml
@@ -608,8 +608,8 @@ components:
           type: string
           enum:
             - InvalidFormat
-            - MTxNoOutputs
-            - MTxDuplicatedOutputs
+            - NoOutputs
+            - DuplicatedOutputs
             - TransactionAlreadyExists
             - InsuffucientFees
             - AuthorDoesNotExist
@@ -620,12 +620,12 @@ components:
             - ReceiverMustIncreaseBalance
             - SumMustBeNonNegative
             - CannotAffordFees
-            - BalanceCannotBecomeNegative
+            - InsufficientBalance
           description: |-
             Error type:
               * `InvalidFormat` - Failed to deserialise one of parameters.
-              * `MTxNoOutputs` - Transaction has no outputs.
-              * `MTxDuplicatedOutputs` - Transaction has duplicated outputs.
+              * `NoOutputs` - Transaction has no outputs.
+              * `DuplicatedOutputs` - Transaction has duplicated outputs.
               * `TransactionAlreadyExists` - Exactly the same transaction has been registered. Rarely this error may be transient, i.e. backend may fail to apply the transaction.
               * `InsufficientFees` - Input of transaction is too small to provide appropriate fees amount.
               * `SignatureIsCorrupted` - Bad signature provided.
@@ -633,4 +633,4 @@ components:
               * `NonceMustBeIncremented` - Bad nonce for source account is used. Should be exactly "currentNonce" returned by /accounts/{address} endpoint.
               * `SumMustBeNonNegative` - Sum of payments plus fee must be less or equal to amount of money you spend.
               * `CannotAffordFees` - User balance is too small to afford transaction outputs and fees.
-              * `BalanceCannotBecomeNegative` - User balance is too small to afford transaction outputs.
+              * `InsufficientBalance` - User balance is too small to afford transaction outputs.

--- a/witness/src/Dscp/Snowdrop/Expanders.hs
+++ b/witness/src/Dscp/Snowdrop/Expanders.hs
@@ -248,7 +248,7 @@ seqExpandersBalanceTx feesReceiverAddr (Fees minimalFees) =
         -- before we can add next changeset entry, we have to check our transaction is new
         txAlreadyExists <- queryOneExists txId
         when txAlreadyExists $
-            throwLocalError $ TransactionAlreadyExists (pretty txId)
+            throwLocalError $ TransactionAlreadyExists txId
 
         let miscChanges = txId ==> New (TxItself tw)
 

--- a/witness/src/Dscp/Snowdrop/Instances.hs
+++ b/witness/src/Dscp/Snowdrop/Instances.hs
@@ -2,7 +2,6 @@ module Dscp.Snowdrop.Instances () where
 
 import Data.Aeson.Options (defaultOptions)
 import Data.Aeson.TH (deriveJSON)
-import Data.Data (toConstr)
 import Servant (err400, err403, err404, err500)
 
 import Dscp.Core.Aeson ()
@@ -21,8 +20,28 @@ deriveJSON defaultOptions ''LogicException
 -- Instances for exceptions
 ----------------------------------------------------------------------------
 
+{- NOTE: everything in this module directly affects the witness API, keep 'witness.yaml'
+document updated.
+-}
+
 instance HasErrorTag AccountException where
-    errorTag = show . toConstr
+    errorTag = \case
+        MTxNoOutputs{}                -> "NoOutputs"
+        MTxDuplicateOutputs{}         -> "DuplicatedOutputs"
+        TransactionAlreadyExists{}    -> "TransactionAlreadyExists"
+        InsufficientFees{}            -> "InsufficientFees"
+        SignatureIsMissing{}          -> "SignatureIsMissing"
+        SignatureIsCorrupted{}        -> "SignatureIsCorrupted"
+        TransactionIsCorrupted{}      -> "TransactionIsCorrupted"
+        NotASingletonSelfUpdate{}     -> "NotASingletonSelfUpdate"
+        NonceMustBeIncremented{}      -> "NonceMustBeIncremented"
+        PaymentMustBePositive{}       -> "PaymentMustBePositive"
+        ReceiverOnlyGetsMoney{}       -> "ReceiverOnlyGetsMoney"
+        ReceiverMustIncreaseBalance{} -> "ReceiverMustIncreaseBalance"
+        SumMustBeNonNegative{}        -> "SumMustBeNonNegative"
+        CannotAffordFees{}            -> "CannotAffordFees"
+        BalanceCannotBecomeNegative{} -> "InsufficientBalance"
+        AccountInternalError{}        -> "InternalError"
 
 instance ToServantErr AccountException where
     toServantErrNoBody = \case

--- a/witness/src/Dscp/Snowdrop/Types.hs
+++ b/witness/src/Dscp/Snowdrop/Types.hs
@@ -33,7 +33,6 @@ module Dscp.Snowdrop.Types
     ) where
 
 import Control.Lens (makePrisms)
-import Data.Data (Data)
 import Data.Default (Default (..))
 import Data.Text.Buildable (Buildable (..))
 import Fmt (build, (+|), (|+))
@@ -85,14 +84,11 @@ instance Buildable PublicationException where
 data AccountTxTypeId = AccountTxTypeId deriving (Eq, Ord, Show, Generic)
 
 -- | Type for possible failures during transaction validation.
---
--- NOTE: this exception is thrown by witness API, keep 'witness.yaml' doc
--- updated.
 data AccountException
     = MTxNoOutputs
     | MTxDuplicateOutputs
     | TransactionAlreadyExists
-      { taeTxId :: Text }
+      { taeTxId :: TxId }
     | InsufficientFees
       { aeExpectedFees :: Integer, aeActualFees :: Integer }
     | SignatureIsMissing
@@ -114,7 +110,7 @@ data AccountException
     | BalanceCannotBecomeNegative
       { aeSpent :: Integer, aeBalance :: Integer }
     | AccountInternalError String
-    deriving (Eq, Ord, Data)
+    deriving (Eq, Ord)
 
 makePrisms ''AccountException
 


### PR DESCRIPTION
### Description

It's inconvenient, as soon as far not any type implements `Data` and thus can be put
in one of `AccountException` constructors. Also, names of constructors are not that
beautiful to include them into public API as is.

<!-- PR description goes here -->

### YT issue

https://issues.serokell.io/issue/DSCP-389

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
