### PR TITLE
[DSCP-261] Validate block's slotId and difficulty

### DIFF
--- a/core/src/Dscp/Core/Arbitrary.hs
+++ b/core/src/Dscp/Core/Arbitrary.hs
@@ -134,6 +134,7 @@ instance Arbitrary Coin where
 deriving instance Arbitrary Nonce
 deriving instance Arbitrary Difficulty
 deriving instance Arbitrary SlotId
+deriving instance Arbitrary BlockMetaTx
 
 instance Arbitrary TxInAcc where
     arbitrary = genericArbitrary

--- a/core/src/Dscp/Util.hs
+++ b/core/src/Dscp/Util.hs
@@ -12,7 +12,6 @@ module Dscp.Util
          -- * Exceptions processing
        , wrapRethrow
        , wrapRethrowIO
-       , onAnException
 
          -- * Error handling
        , assert
@@ -144,10 +143,6 @@ wrapRethrowIO
     :: (Exception e1, Exception e2, MonadCatch m, MonadIO m)
     => (e1 -> e2) -> IO a -> m a
 wrapRethrowIO wrap action = wrapRethrow wrap (liftIO action)
-
--- | Similar to 'onException', but provides exception itself.
-onAnException :: (MonadCatch m, Exception e) => m a -> (e -> m ()) -> m a
-onAnException action onExc = action `catch` \e -> onExc e >> throwM e
 
 -----------------------------------------------------------
 -- Do-or-throw error handlers

--- a/witness/src/Dscp/Snowdrop/BlockMetaValidation.hs
+++ b/witness/src/Dscp/Snowdrop/BlockMetaValidation.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Dscp.Snowdrop.BlockMetaValidation
+       ( validateBlockMeta
+       ) where
+
+import Snowdrop.Core (PreValidator (..), StateTx (..), StateTxType (..), Validator, mkValidator)
+import Snowdrop.Util
+
+import Dscp.Snowdrop.Configuration
+import Dscp.Snowdrop.Types
+
+
+validateBlockMeta
+    :: forall ctx.
+       Validator Exceptions Ids Proofs Values ctx
+validateBlockMeta = mkValidator ty [preValidateBlockMeta]
+  where
+    ty = StateTxType $ getId (Proxy @TxIds) BlockMetaTxTypeId
+
+preValidateBlockMeta
+    :: forall ctx.
+       PreValidator Exceptions Ids Proofs Values ctx
+preValidateBlockMeta =
+    PreValidator $ \_trans@StateTx {..} ->
+        -- Cry, snowdrop, cry.
+
+        pass  -- All the validation has happened in expander.

--- a/witness/src/Dscp/Snowdrop/Expanders.hs
+++ b/witness/src/Dscp/Snowdrop/Expanders.hs
@@ -10,6 +10,8 @@ import Data.Default (Default (..))
 import qualified Data.List as List
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
+import Fmt ((+|), (|+))
+import Serokell.Util (enumerate)
 
 import qualified Snowdrop.Block as SD
 import Snowdrop.Core (ChgAccum, ChgAccumCtx, ERoComp, Expander (..), SeqExpanders (..),
@@ -19,7 +21,8 @@ import Snowdrop.Util
 
 import Dscp.Core
 import Dscp.Crypto as Dscp
-import Dscp.Snowdrop.Configuration hiding (PublicationTxWitness)
+import Dscp.Snowdrop.AccountValidation
+import Dscp.Snowdrop.Configuration
 import qualified Dscp.Snowdrop.Configuration as Conf (Proofs (..))
 import Dscp.Snowdrop.Storage.Types
 import Dscp.Snowdrop.Types
@@ -38,10 +41,25 @@ expandBlock ::
     => Bool
     -> Block
     -> ERoComp Exceptions Ids Values ctx SBlock
-expandBlock applyFees Block{..} = do
+expandBlock applyFees block@Block{..} = do
     let issuer = hIssuer bHeader
     stateTxs <- expandGTxs applyFees issuer (bbTxs bBody)
-    pure $ SD.Block bHeader (SPayload stateTxs $ hash bBody)
+    metaStateTx <- expandBlockMetaTx (BlockMetaTx block)
+    pure $ SD.Block bHeader (SPayload (metaStateTx : stateTxs) (hash bBody))
+
+expandBlockMetaTx
+    :: ( Default (ChgAccum ctx)
+       , HasLens ctx RestrictCtx
+       , HasLens ctx (ChgAccumCtx ctx)
+       , HasCoreConfig
+       )
+    => BlockMetaTx -> ERoComp Exceptions Ids Values ctx SStateTx
+expandBlockMetaTx meta =
+    let stateTx = StateTxType $ getId (Proxy @TxIds) BlockMetaTxTypeId
+        proof = BlockMetaTxWitnessProof
+    in expandUnionRawTxs (\_ -> (stateTx, proof, seqExpandersBlockMetaTx)) [meta] >>= \case
+           [expanded] -> return expanded
+           _          -> error "expandBlockMetaTx: did not expand 1 meta into 1 sd tx"
 
 -- | Expand list of global txs.
 expandGTxs ::
@@ -88,13 +106,24 @@ getByGTx applyFees pk t =
                    GPublicationTxWitnessed ptx -> toProofPublicationTx fee ptx
     in (a, b, seqExpandersGTx addr fee t)
 
+seqExpandersGTx
+    :: HasCoreConfig
+    => Address
+    -> Fees
+    -> GTxWitnessed
+    -> SeqExpanders Exceptions Ids Proofs Values ctx GTxWitnessed
+seqExpandersGTx addr minFee (GMoneyTxWitnessed _) =
+    flip contramap (seqExpandersBalanceTx addr minFee) $ \(GMoneyTxWitnessed tx) -> tx
+seqExpandersGTx addr minFee (GPublicationTxWitnessed _) =
+    flip contramap (seqExpandersPublicationTx addr minFee) $ \(GPublicationTxWitnessed ptx) -> ptx
+
 ----------------------------------------------------------------------------
 -- Publication tx
 ----------------------------------------------------------------------------
 
 toProofPublicationTx :: Fees -> PublicationTxWitnessed -> (StateTxType, Proofs)
 toProofPublicationTx minFee (PublicationTxWitnessed tx (PublicationTxWitness {..})) =
-    (txType, Conf.PublicationTxWitness $ WithSignature
+    (txType, Conf.PublicationTxWitnessProof $ WithSignature
         { wsSignature = toDscpSig pwSig
         , wsPublicKey = toDscpPK pwPk
         , wsBody = (toPtxId tx, pwPk, ptHeader)
@@ -177,19 +206,9 @@ seqExpandersPublicationTx feesReceiverAddr (Fees minFee) =
 -- Money tx
 ----------------------------------------------------------------------------
 
-seqExpandersGTx
-    :: Address
-    -> Fees
-    -> GTxWitnessed
-    -> SeqExpanders Exceptions Ids Proofs Values ctx GTxWitnessed
-seqExpandersGTx addr minFee (GMoneyTxWitnessed _) =
-    flip contramap (seqExpandersBalanceTx addr minFee) $ \(GMoneyTxWitnessed tx) -> tx
-seqExpandersGTx addr minFee (GPublicationTxWitnessed _) =
-    flip contramap (seqExpandersPublicationTx addr minFee) $ \(GPublicationTxWitnessed ptx) -> ptx
-
 toProofBalanceTx :: Fees -> TxWitnessed -> (StateTxType, Proofs)
 toProofBalanceTx minFee (TxWitnessed tx (TxWitness {..})) =
-    (txType, AddressTxWitness $ WithSignature {..} `PersonalisedProof` minFee)
+    (txType, AddressTxWitnessProof $ WithSignature {..} `PersonalisedProof` minFee)
   where
     txType = StateTxType $ getId (Proxy @TxIds) AccountTxTypeId
     wsSignature = toDscpSig txwSig
@@ -305,6 +324,94 @@ seqExpandersBalanceTx feesReceiverAddr (Fees minimalFees) =
     inP  = Set.fromList [accountPrefix, txOfPrefix]
     -- Expander returns account changes only
     outP = Set.fromList [accountPrefix, txPrefix, txHeadPrefix, txOfPrefix]
+
+--------------------------------------------------------------------------
+-- Block meta tx
+--------------------------------------------------------------------------
+
+-- | Expands block meta.
+-- Should happend strictly after validation of transactions in block's body.
+-- Those checks which happen in block integrity validation are missing here.
+seqExpandersBlockMetaTx
+    :: HasCoreConfig
+    => SeqExpanders Exceptions Ids Proofs Values ctx BlockMetaTx
+seqExpandersBlockMetaTx =
+    SeqExpanders $ one $ Expander inP outP $ \BlockMetaTx{..} -> do
+        let block@Block{ bHeader = header, bBody = body } = bmtBlock
+        let issuerAddr = mkAddr (hIssuer header)
+        let isGenesis = header == bHeader genesisBlock
+
+        {- Validation -}
+
+        when isGenesis $
+            -- further we assume that our genesis block has the least possible difficulty
+            unless (hDifficulty header == 0) $
+                error "Genesis block difficulty must be 0"
+
+        unless isGenesis $ do
+            mSimilarHeaderHash <- queryOne (hDifficulty header)
+            case mSimilarHeaderHash of
+                Nothing -> pass
+                Just similarHeaderHash ->
+                    throwLocalError DuplicatedDifficulty
+                    { bmeProvidedHeader = header, bmeExistingHeaderHash = similarHeaderHash }
+
+            -- At this point there is no block in chain with exactly the same
+            -- header as ours
+
+            prevHash <-
+                (hDifficulty header - 1)
+                `assertExists` DifficultyIsTooLarge (hDifficulty header)
+            (sBlockReconstruct -> Block prevHeader _) <-
+                SD.BlockRef prevHash `assertExists` noPrevBlock prevHash
+
+            unless (hPrevHash header == prevHash) $
+                  throwLocalError PrevBlockIsIncorrect
+                  { bmeProvidedHash = hPrevHash header, bmeTipHash = prevHash }
+            unless (hSlotId header > hSlotId prevHeader) $
+                  throwLocalError SlotIdIsNotIncreased
+                  { bmeProvidedSlotId = hSlotId header, bmeTipSlotId = hSlotId prevHeader }
+
+            let GovCommittee com = gcGovernance $ giveL @CoreConfig
+            unless (committeeOwnsSlot com issuerAddr (hSlotId header)) $
+                throwLocalError $ IssuerDoesNotOwnSlot
+                { bmrSlotId = hSlotId header, bmrIssuer = issuerAddr }
+
+        let signedData = BlockToSign (hDifficulty header) (hSlotId header)
+                                     (hPrevHash header) (hash body)
+        unless (verify (hIssuer header) signedData (hSignature header)) $
+            throwLocalError InvalidBlockSignature
+
+        {- Change sets -}
+
+        let diffChange = Map.singleton
+                (inj $ hDifficulty header)
+                (New . BlockIdxVal $ headerHash header)
+
+        -- no keys collision is possible because at this point hPrevHash matches tip,
+        -- and block at tip is unique
+        let forwardBlockChange = Map.singleton
+                (inj . NextBlockOf $ hPrevHash header)
+                (New . NextBlockOfVal . NextBlock $ headerHash header)
+
+        -- no keys collision is possible sinse we have validated transactions
+        -- before this function call, thus every transaction is unique
+        let txBlockRefsChange = Map.fromList $
+                enumerate (bbTxs (bBody block)) <&> \(idx, gTx) ->
+                    ( inj . TxBlockRefId . toGTxId . unGTxWitnessed $ gTx
+                    , New . TxBlockVal $ TxBlockRef (headerHash block) idx
+                    )
+
+        let totalChange = mconcat [diffChange, forwardBlockChange, txBlockRefsChange]
+        pure $ mkDiffCS (totalChange :: Map.Map Ids (ValueOp Values))
+  where
+    -- Account prefixes are used during the computation to access current balance
+    inP  = Set.fromList []
+    -- Expander returns account changes only
+    outP = Set.fromList [blockIdxPrefix, txBlockPrefix, nextBlockPrefix]
+
+    noPrevBlock (h :: HeaderHash) =
+        BlockMetaInternalError $ "Can't resolve previous block " +| h |+ ""
 
 --------------------------------------------------------------------------
 -- Utils

--- a/witness/src/Dscp/Snowdrop/Validators.hs
+++ b/witness/src/Dscp/Snowdrop/Validators.hs
@@ -10,8 +10,9 @@ import qualified Snowdrop.Core as SD
 import qualified Snowdrop.Util as SD
 
 import Dscp.Core hiding (PublicationTxWitness)
-import Dscp.Crypto (PublicKey, hash, verify)
+import Dscp.Crypto (PublicKey, hash)
 import Dscp.Snowdrop.AccountValidation
+import Dscp.Snowdrop.BlockMetaValidation
 import Dscp.Snowdrop.Configuration
 import Dscp.Snowdrop.Mode
 import Dscp.Snowdrop.PublicationValidation
@@ -28,22 +29,22 @@ instance SD.HasGetter PublicKey Address where
     gett = Address . hash
 
 instance SD.HasPrism Proofs AddrTxProof where
-    proj (AddressTxWitness it) = Just it
-    proj  _                    = Nothing
+    proj (AddressTxWitnessProof it) = Just it
+    proj  _                         = Nothing
 
 instance SD.HasReview Proofs AddrTxProof where
-    inj = AddressTxWitness
+    inj = AddressTxWitnessProof
 
 instance SD.HasPrism Proofs PublicationTxProof where
-    proj (PublicationTxWitness it) = Just it
-    proj  _                        = Nothing
+    proj (PublicationTxWitnessProof it) = Just it
+    proj  _                             = Nothing
 
 instance SD.HasReview Proofs PublicationTxProof where
-    inj = PublicationTxWitness
+    inj = PublicationTxWitnessProof
 
 instance SD.HasPrism Proofs TxId where
-    proj (AddressTxWitness (SD.wsBody . ppSignedPart -> (it, _, _))) = Just it
-    proj  _                                                          = Nothing
+    proj (AddressTxWitnessProof (SD.wsBody . ppSignedPart -> (it, _, _))) = Just it
+    proj  _                                                               = Nothing
 
 -- | We have to implement one part of the Prism ("contains"), bu we
 --   can't rebuild Proofs from TxId back.
@@ -51,7 +52,8 @@ instance SD.HasReview Proofs TxId where
     inj = error "impossible to implement"
 
 instance SD.HasPrism Proofs PublicationTxId where
-    proj (PublicationTxWitness (SD.wsBody . ppSignedPart -> (it, _, _))) = Just it
+    proj (PublicationTxWitnessProof
+          (SD.wsBody . ppSignedPart -> (it, _, _))) = Just it
     proj  _                                                              = Nothing
 
 -- | Same as TxId.
@@ -59,8 +61,9 @@ instance SD.HasReview Proofs PublicationTxId where
     inj = error "impossible to implement"
 
 instance SD.HasGetter Proofs PublicKey where
-    gett (AddressTxWitness     (SD.wsBody . ppSignedPart -> (_, it, _))) = it
-    gett (PublicationTxWitness (SD.wsBody . ppSignedPart -> (_, it, _))) = it
+    gett (AddressTxWitnessProof     (SD.wsBody . ppSignedPart -> (_, it, _))) = it
+    gett (PublicationTxWitnessProof (SD.wsBody . ppSignedPart -> (_, it, _))) = it
+    gett BlockMetaTxWitnessProof = error "No public key kept for block meta"
 
 instance SD.HasGetter SPayload [SStateTx] where
     gett = sPayStateTxs
@@ -68,9 +71,11 @@ instance SD.HasGetter SPayload [SStateTx] where
 _baseValidator ::
        forall chgAccum.
        SD.Validator Exceptions Ids Proofs Values (IOCtx chgAccum)
-_baseValidator =
-    validateSimpleMoneyTransfer @(IOCtx chgAccum) <>
-    validatePublication         @(IOCtx chgAccum)
+_baseValidator = mconcat
+    [ validateSimpleMoneyTransfer @(IOCtx chgAccum)
+    , validatePublication         @(IOCtx chgAccum)
+    , validateBlockMeta           @(IOCtx chgAccum)
+    ]
 
 ----------------------------------------------------------------------------
 -- Block configuration
@@ -88,7 +93,7 @@ simpleBlkConfiguration ::
 simpleBlkConfiguration = SD.BlkConfiguration
     { bcBlockRef     = SD.CurrentBlockRef . hash
     , bcPrevBlockRef = SD.PrevBlockRef . getPrevHash . hPrevHash
-    , bcBlkVerify    = mconcat verifiers
+    , bcBlkVerify    = verifiers
     , bcIsBetterThan = isBetterThan
     , bcMaxForkDepth = 10 -- max possible fork is 10 blocks
     , bcValidateFork = \_osParams _proposedChain -> True
@@ -96,18 +101,9 @@ simpleBlkConfiguration = SD.BlkConfiguration
     }
   where
     isBetterThan (SD.OldestFirst proposedChain) (SD.OldestFirst currentChain) = length currentChain < length proposedChain
-    GovCommittee com = gcGovernance $ giveL @WitnessConfig
 
     getPrevHash h
         | h == hPrevHash genesisHeader = Nothing
         | otherwise        = Just h
 
-    verifiers :: [SD.BlockIntegrityVerifier SHeader SPayload]
-    verifiers =
-      [ SD.BIV $ \(SD.Block Header{..} (SPayload _ origBodyHash)) ->
-          verify hIssuer
-                 (BlockToSign hDifficulty hSlotId hPrevHash origBodyHash)
-                 hSignature
-      , SD.BIV $ \(SD.Block sheader _) ->
-          committeeOwnsSlot com (mkAddr $ hIssuer sheader) (hSlotId sheader)
-      ]
+    verifiers = mempty  -- we validate everything in 'BlockMetaTx' processing.

--- a/witness/src/Dscp/Witness/Listeners/Listener.hs
+++ b/witness/src/Dscp/Witness/Listeners/Listener.hs
@@ -58,7 +58,7 @@ blockIssuingListener =
         issueBlock slotId = do
             (block, proof) <-
                 writingSDLock "create & apply block" $ do
-                    block <- createBlock runSdM slotId
+                    block <- createBlock slotId
                     logInfo $ "Created a new block: \n" +| block |+ ""
                     proof <- applyBlock block
                     return (block, proof)

--- a/witness/src/Dscp/Witness/Logic/Creation.hs
+++ b/witness/src/Dscp/Witness/Logic/Creation.hs
@@ -7,7 +7,7 @@ module Dscp.Witness.Logic.Creation
 
 import Dscp.Core
 import Dscp.Crypto
-import Dscp.Resource.Keys (ourSecretKey)
+import Dscp.Resource.Keys
 import Dscp.Snowdrop
 import Dscp.Witness.Launcher.Context
 import Dscp.Witness.Logic.Getters
@@ -24,17 +24,16 @@ createPayload = BlockBody <$> takeTxsMempool @ctx
 -- | Create a public block.
 createBlock
     :: (WitnessWorkMode ctx m, WithinWriteSDLock)
-    => (forall a . SdM a -> m a)
-    -> SlotId
+    => SlotId
     -> m Block
-createBlock runner newSlot = do
-    tipHeader <- runner getTipHeader
+createBlock newSlot = do
+    tipHeader <- runSdM getTipHeader
     let tipHash = headerHash tipHeader
     let diff = hDifficulty tipHeader + 1
 
     payload <- createPayload
-    sk <- ourSecretKey @WitnessNode
-    let sgn = sign sk $ BlockToSign diff newSlot tipHash (hash payload)
-    let header = Header sgn (toPublic sk) diff newSlot tipHash
+    sk <- ourSecretKeyData @WitnessNode
+    let sgn = sign (skSecret sk) $ BlockToSign diff newSlot tipHash (hash payload)
+    let header = Header sgn (skPublic sk) diff newSlot tipHash
     let block = Block header payload
     pure block

--- a/witness/src/Dscp/Witness/Web/Error.hs
+++ b/witness/src/Dscp/Witness/Web/Error.hs
@@ -36,7 +36,7 @@ fromSnowdropException = \case
     AccountError e -> pure $ SdAccountError e
     LogicError e -> pure $ SdLogicError e
     PublicationError{} -> mzero
-    BlockApplicationError{} -> mzero
+    BlockError{} -> mzero
     SdInternalError{} -> mzero
 
 -- | All witness API exceptions.

--- a/witness/src/Dscp/Witness/Workers/Worker.hs
+++ b/witness/src/Dscp/Witness/Workers/Worker.hs
@@ -15,6 +15,7 @@ import Loot.Base.HasLens (lensOf)
 import Loot.Config (option, sub)
 import Loot.Log (logDebug, logInfo, logWarning)
 import Time (ms, sec, threadDelay)
+import UnliftIO.Exception (withException)
 
 import Dscp.Core
 import Dscp.Crypto
@@ -164,7 +165,7 @@ makeRelay (RelayState input pipe failedTxs) =
 
         writingSDLock "add to mempool" $
             addTxToMempool @ctx tx
-                `onAnException` \e -> addFailedTx (tx, e)
+                `withException` \e -> addFailedTx (tx, e)
 
         atomically $ STM.writeTBQueue pipe tx
 

--- a/witness/tests/Test/Dscp/Witness/Explorer/ExplorerSpec.hs
+++ b/witness/tests/Test/Dscp/Witness/Explorer/ExplorerSpec.hs
@@ -3,13 +3,11 @@ module Test.Dscp.Witness.Explorer.ExplorerSpec where
 import Data.Default (def)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
-import Loot.Base.HasLens (lensOf)
 import Test.QuickCheck (arbitraryBoundedEnum, shuffle)
 import Test.QuickCheck.Monadic (pre)
 
 import Dscp.Core
 import Dscp.Crypto
-import Dscp.Resource.Keys
 import Dscp.Snowdrop.Configuration
 import Dscp.Snowdrop.Mode
 import Dscp.Snowdrop.Types
@@ -72,19 +70,6 @@ createAndSubmitPubGen genSecret = do
     sk <- pick $ mkSecretKeyData <$> genSecret
     sig <- pick arbitrary
     lift $ createAndSubmitPub sk sig
-
--- | Dump all mempool transactions into a new block.
-dumpBlock
-    :: (TestWitnessWorkMode ctx m, WithinWriteSDLock)
-    => m HeaderHash
-dumpBlock = do
-    slotId <- rewindToNextSlot
-    let issuerKey = KeyResources . mkSecretKeyData $ testFindSlotOwner slotId
-
-    local (lensOf @(KeyResources WitnessNode) .~ issuerKey) $ do
-        block <- createBlock runSdM slotId
-        void $ applyBlock block
-        return (headerHash block)
 
 -- | Run 'getTransactions' with pagination page by page until all transactions
 -- are fetched.

--- a/witness/tests/Test/Dscp/Witness/Tx/PublicationTxSpec.hs
+++ b/witness/tests/Test/Dscp/Witness/Tx/PublicationTxSpec.hs
@@ -14,6 +14,8 @@ import Dscp.Snowdrop
 import Dscp.Util
 import Dscp.Util.Test
 import Dscp.Witness
+
+import Test.Dscp.Witness.Common
 import Test.Dscp.Witness.Mode
 
 genPublicationChain
@@ -143,7 +145,7 @@ spec = describe "Publication tx expansion + validation" $ do
 
         lift $ submitPub tw
         whenM (pick arbitrary) $
-            lift $ void . applyBlock =<< createBlock runSdM 0
+            void $ lift dumpBlock
         lift . throwsPrism (_PublicationError . _PublicationLocalLoop) $
             submitPub tw
 


### PR DESCRIPTION
### Description

Adding missing checks required me to add one more type of transaction - block meta, which is responsible for block-level stuff expansion and validation. It is not a true transaction though, rather just a helper, so it is not signed, it does not appear in network messages and is not visible in explorer API.

### YT issue

https://issues.serokell.io/issue/DSCP-261

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
