### PR TITLE
[DSCP-367] Merge `runSdM` and `runStateSdM`

### DIFF
--- a/educator/src/Dscp/Educator/Web/Logic.hs
+++ b/educator/src/Dscp/Educator/Web/Logic.hs
@@ -13,12 +13,10 @@ import Dscp.Educator.Launcher.Mode
 import Dscp.Educator.Web.Educator.Types
 import Dscp.Educator.Web.Types
 import Dscp.Resource.Keys
-import Dscp.Snowdrop.Mode
 import Dscp.Snowdrop.Types
 import Dscp.Util.Aeson
 import Dscp.Witness.Logic.Getters
 import Dscp.Witness.SDLock
-import Dscp.Witness.Web.Types
 
 commonGetProofs
     :: (MonadEducatorWebQuery m, WithinTx)
@@ -43,13 +41,8 @@ getEducatorStatus = do
     sk <- ourSecretKeyData @EducatorNode
     let address = skAddress sk
 
-    -- TODO [DSCP-367]: to replace with one-liner
-    accounts <- readingSDLock $ do
-        blockAccount <- runSdReadM $ getAccountMaybe address
-        poolAccount  <- runSdReadM $ getMempoolAccountMaybe address
-        return $ fromMaybe def <$>
-                 BlocksOrMempool{ bmConfirmed = blockAccount, bmTotal = poolAccount }
-
+    accounts <- readingSDLock $ runSdDual $
+        fromMaybe def <$> getAccountMaybe address
     return EducatorInfo
         { eiAddress = address
         , eiBalances = Coin . fromIntegral . aBalance <$> accounts

--- a/witness/src/Dscp/Snowdrop/Actions.hs
+++ b/witness/src/Dscp/Snowdrop/Actions.hs
@@ -3,16 +3,19 @@
 module Dscp.Snowdrop.Actions
     ( SDVars
     , SDActionsM (..)
+    , AVLPlusBlockComposition
     , initSDActions
     , sdActionsComposition
     , initAccounts
     ) where
 
 import qualified Data.Map as Map
+import Data.Reflection (Reifies (..))
 import Data.Time.Clock (UTCTime (..))
 import UnliftIO (MonadUnliftIO)
 
 import qualified Snowdrop.Block as SD
+import qualified Snowdrop.Core as SD
 import qualified Snowdrop.Execution as SD (CompositeChgAccum, DbAccessActions (..),
                                            DbModifyActions (..), SumChangeSet,
                                            constructCompositeActions)
@@ -21,7 +24,7 @@ import qualified Snowdrop.Util as SD (ExecM, RIO (..))
 import Dscp.Core
 import Dscp.Crypto
 import qualified Dscp.DB.CanProvideDB as DB
-import Dscp.Snowdrop.Configuration (BlockPlusAVLComposition, Ids (..), Values (..))
+import Dscp.Snowdrop.Configuration (Ids (..), Values (..), accountPrefix)
 import Dscp.Snowdrop.Serialise ()
 import Dscp.Snowdrop.Storage.Avlp
 import Dscp.Snowdrop.Storage.PluginBased
@@ -36,6 +39,10 @@ deriving instance MonadUnliftIO (SD.RIO ctx)
 
 type SDDataActions  m = SD.DbModifyActions (AVLChgAccum AvlHash Ids Values) Ids Values m AvlProof
 type SDBlockActions m = SD.DbModifyActions (SD.SumChangeSet Ids Values) Ids Values m ()
+
+data AVLPlusBlockComposition
+instance Reifies AVLPlusBlockComposition (Set SD.Prefix) where
+    reflect _ = one accountPrefix
 
 -- Parameter m will be instantiated with RIO Context when the context is defined.
 data SDActionsM m = SDActionsM
@@ -80,14 +87,14 @@ sdActionsComposition
   => SDActionsM m
   -> SD.DbAccessActions
       (SD.CompositeChgAccum
-          (SD.SumChangeSet Ids Values)
           (AVLChgAccum AvlHash Ids Values)
-          BlockPlusAVLComposition)
+          (SD.SumChangeSet Ids Values)
+          AVLPlusBlockComposition)
       Ids
       Values
       m
 sdActionsComposition SDActionsM{..} =
     SD.constructCompositeActions
-        @BlockPlusAVLComposition
-        (SD.dmaAccessActions nsBlockDBActions)
+        @AVLPlusBlockComposition
         (SD.dmaAccessActions nsStateDBActions)
+        (SD.dmaAccessActions nsBlockDBActions)

--- a/witness/src/Dscp/Snowdrop/Configuration.hs
+++ b/witness/src/Dscp/Snowdrop/Configuration.hs
@@ -40,13 +40,10 @@ module Dscp.Snowdrop.Configuration
     , _LogicError
 
     , TxIds (..)
-
-    , BlockPlusAVLComposition
     ) where
 
 
 import Control.Lens (makePrisms)
-import Data.Reflection (Reifies (..))
 import qualified Data.Set as S
 import qualified Data.Text.Buildable as B
 import Fmt (build, (+|))
@@ -366,14 +363,6 @@ instance Enum TxIds where
 instance IdStorage TxIds AccountTxTypeId
 instance IdStorage TxIds PublicationTxTypeId
 instance IdStorage TxIds BlockMetaTxTypeId
-
-----------------------------------------------------------------------------
--- Misc
-----------------------------------------------------------------------------
-
-data BlockPlusAVLComposition
-instance Reifies BlockPlusAVLComposition (Set Prefix) where
-    reflect _ = blockPrefixes
 
 ----------------------------------------------------------------------------
 -- HasReview and lenses

--- a/witness/src/Dscp/Snowdrop/Mode.hs
+++ b/witness/src/Dscp/Snowdrop/Mode.hs
@@ -2,26 +2,15 @@
 
 module Dscp.Snowdrop.Mode
     ( IOCtx
-    , SdM_
+    , ChgAccum
     , SdM
-    , StateSdM
     , MonadSD
     , runSdRIO
     , runSdM
     , runSdMLocked
-    , runStateSdM
-    , runStateSdMLocked
     , unwrapSDBaseRethrow
-
-    -- * Generalized SD runners
-    , SdReadMode (..)
-    , SdReadM (..)
-    , KnownSdReadMode (..)
-    , runSdReadMLocked
-    , lift2xSdM
     ) where
 
-import Data.Coerce (coerce)
 import Data.Default (def)
 import Loot.Base.HasLens (HasCtx, lensOf)
 import Loot.Log (Logging, ModifyLogName, MonadLogging)
@@ -40,19 +29,19 @@ import Dscp.Snowdrop.Storage.Avlp
 import Dscp.Util
 import Dscp.Witness.AVL (AvlHash)
 import Dscp.Witness.Config
-import Dscp.Witness.Launcher.Context
 import qualified Dscp.Witness.SDLock as Lock
 
 -- | Alias for ERoComp with concrete config types.
 type SdM_ chgacc = SD.ERoComp Exceptions Ids Values (IOCtx chgacc)
 
-type SumChangeSet = SD.SumChangeSet Ids Values
+type ChgAccum =
+    SD.CompositeChgAccum
+        (SD.SumChangeSet Ids Values)
+        (AVLChgAccum AvlHash Ids Values)
+        BlockPlusAVLComposition
 
 -- | Monad representing actions in snowdrop BaseM, related to rocksdb storage.
-type SdM = SdM_ SumChangeSet
-
--- | Monad representing actions in snowdrop BaseM, related to AVL+ storage.
-type StateSdM a = SdM_ (AVLChgAccum AvlHash Ids Values) a
+type SdM = SdM_ ChgAccum
 
 type MonadSD ctx m =
     ( MonadUnliftIO m
@@ -78,71 +67,12 @@ unwrapSDBaseRethrow = wrapRethrow $ \(BaseMException e) -> e :: Exceptions
 -- | SdM runner, should be protected by some lock.
 runSdM :: (MonadSD ctx m, Lock.WithinReadSDLock) => SdM a -> m a
 runSdM action = do
-    blockDBA <- view (lensOf @SDVars) <&> SD.dmaAccessActions . nsBlockDBActions
-    plugin   <- providePlugin
+    dba <- sdActionsComposition <$> view (lensOf @SDVars)
+    plugin <- providePlugin
     unwrapSDBaseRethrow $ do
         initAVLStorage @AvlHash plugin initAccounts
-
-        SD.runERoCompIO @Exceptions blockDBA def action
+        SD.runERoCompIO @Exceptions dba def action
 
 -- | Often used SdM runner that takes read lock.
 runSdMLocked :: MonadSD ctx m => SdM a -> m a
 runSdMLocked action = Lock.readingSDLock $ runSdM action
-
--- | SdM runner, should be protected by some lock.
-runStateSdM
-    :: (MonadSD ctx m, Lock.WithinReadSDLock)
-    => StateSdM a -> m a
-runStateSdM action = do
-    stateDBA <- view (lensOf @SDVars) <&> SD.dmaAccessActions . nsStateDBActions
-    plugin   <- providePlugin
-    unwrapSDBaseRethrow $ do
-        initAVLStorage @AvlHash plugin initAccounts
-
-        SD.runERoCompIO @Exceptions stateDBA def action
-
--- | Often used SdM runner that takes read lock.
-runStateSdMLocked :: MonadSD ctx m => StateSdM a -> m a
-runStateSdMLocked action = Lock.readingSDLock $ runStateSdM action
-
-----------------------------------------------------------------------------
--- Generalized SD runners
-----------------------------------------------------------------------------
-
--- | Which version of snowdrop data should be read.
-data SdReadMode = ChainOnly | ChainAndMempool
-
--- | Wrapper over an action to indicate read mode it should be executed in.
--- Sometimes we want an action to work both in chain-only and chain+mempool modes
--- and have an access to the context at the same time, this monad is intended for such situations.
-newtype SdReadM (mode :: SdReadMode) m a = SdReadM { runSdReadM :: m a }
-    deriving (Functor, Applicative, Monad, MonadIO, MonadReader __, MonadLogging,
-              MonadThrow, MonadCatch)
-
-instance MonadTrans (SdReadM mode) where
-    lift = SdReadM
-
-instance MonadUnliftIO m => MonadUnliftIO (SdReadM mode m) where
-    askUnliftIO = lift $ coerce <$> askUnliftIO @m
-
-runSdReadMLocked
-    :: forall mode m ctx a. MonadSD ctx m
-    => (Lock.WithinReadSDLock => SdReadM mode m a) -> m a
-runSdReadMLocked action = Lock.readingSDLock $ runSdReadM action
-
--- | Lifting snowdrop 'SdM'-like actions to 'SdReadM'.
-class KnownSdReadMode (mode :: SdReadMode) where
-    type SdReadModeChgAcc mode :: *
-    liftSdM
-        :: (WitnessWorkMode ctx m, Lock.WithinReadSDLock)
-        => SdM_ (SdReadModeChgAcc mode) a -> SdReadM mode m a
-
--- | Commonly used double lift.
-lift2xSdM
-    :: (WitnessWorkMode ctx m, Lock.WithinReadSDLock, KnownSdReadMode mode, MonadTrans t)
-    => SdM_ (SdReadModeChgAcc mode) a -> t (SdReadM mode m) a
-lift2xSdM = lift . liftSdM
-
-instance KnownSdReadMode 'ChainOnly where
-    type SdReadModeChgAcc 'ChainOnly = SumChangeSet
-    liftSdM = lift . runSdM

--- a/witness/src/Dscp/Snowdrop/Mode.hs
+++ b/witness/src/Dscp/Snowdrop/Mode.hs
@@ -36,9 +36,9 @@ type SdM_ chgacc = SD.ERoComp Exceptions Ids Values (IOCtx chgacc)
 
 type ChgAccum =
     SD.CompositeChgAccum
-        (SD.SumChangeSet Ids Values)
         (AVLChgAccum AvlHash Ids Values)
-        BlockPlusAVLComposition
+        (SD.SumChangeSet Ids Values)
+        AVLPlusBlockComposition
 
 -- | Monad representing actions in snowdrop BaseM, related to rocksdb storage.
 type SdM = SdM_ ChgAccum

--- a/witness/src/Dscp/Snowdrop/ReadMode.hs
+++ b/witness/src/Dscp/Snowdrop/ReadMode.hs
@@ -1,0 +1,53 @@
+-- | SD extended reading mode.
+
+module Dscp.Snowdrop.ReadMode
+    ( SdReadMode (..)
+    , SdReadM (..)
+    , KnownSdReadMode (..)
+    , runSdReadMLocked
+    , lift2xSdM
+    ) where
+
+import Data.Coerce (coerce)
+import Loot.Log (MonadLogging)
+import UnliftIO (MonadUnliftIO (..))
+
+import Dscp.Snowdrop.Mode
+import Dscp.Witness.Launcher.Context
+import qualified Dscp.Witness.SDLock as Lock
+
+-- | Which version of snowdrop data should be read.
+data SdReadMode = ChainOnly | ChainAndMempool
+
+-- | Wrapper over an action to indicate read mode it should be executed in.
+-- Sometimes we want an action to work both in chain-only and chain+mempool modes
+-- and have an access to the context at the same time, this monad is intended for such situations.
+newtype SdReadM (mode :: SdReadMode) m a = SdReadM { runSdReadM :: m a }
+    deriving (Functor, Applicative, Monad, MonadIO, MonadReader __, MonadLogging,
+              MonadThrow, MonadCatch)
+
+instance MonadTrans (SdReadM mode) where
+    lift = SdReadM
+
+instance MonadUnliftIO m => MonadUnliftIO (SdReadM mode m) where
+    askUnliftIO = lift $ coerce <$> askUnliftIO @m
+
+runSdReadMLocked
+    :: forall mode m ctx a. MonadSD ctx m
+    => (Lock.WithinReadSDLock => SdReadM mode m a) -> m a
+runSdReadMLocked action = Lock.readingSDLock $ runSdReadM action
+
+-- | Lifting snowdrop 'SdM'-like actions to 'SdReadM'.
+class KnownSdReadMode (mode :: SdReadMode) where
+    liftSdM
+        :: (WitnessWorkMode ctx m, Lock.WithinReadSDLock)
+        => SdM a -> SdReadM mode m a
+
+-- | Commonly used double lift.
+lift2xSdM
+    :: (WitnessWorkMode ctx m, KnownSdReadMode mode, Lock.WithinReadSDLock, MonadTrans t)
+    => SdM a -> t (SdReadM mode m) a
+lift2xSdM = lift . liftSdM
+
+instance KnownSdReadMode 'ChainOnly where
+    liftSdM = lift . runSdM

--- a/witness/src/Dscp/Witness/Logic/Apply.hs
+++ b/witness/src/Dscp/Witness/Logic/Apply.hs
@@ -40,9 +40,7 @@ applyBlockRaw applyFees block = do
     let stateDBM = nsStateDBActions sdActions
 
     (blockCS, stateCS) <-
-        let actions = SD.constructCompositeActions @BlockPlusAVLComposition
-                                                   (SD.dmaAccessActions blockDBM)
-                                                   (SD.dmaAccessActions stateDBM)
+        let actions = sdActionsComposition sdActions
             rwComp = do
               sblock <- SD.liftERoComp $ expandBlock applyFees block
               -- getCurrentTime requires MonadIO

--- a/witness/src/Dscp/Witness/Logic/Apply.hs
+++ b/witness/src/Dscp/Witness/Logic/Apply.hs
@@ -39,7 +39,7 @@ applyBlockRaw applyFees block = do
     let blockDBM = nsBlockDBActions sdActions
     let stateDBM = nsStateDBActions sdActions
 
-    (blockCS, stateCS) <-
+    (stateCS, blockCS) <-
         let actions = sdActionsComposition sdActions
             rwComp = do
               sblock <- SD.liftERoComp $ expandBlock applyFees block
@@ -50,8 +50,8 @@ applyBlockRaw applyFees block = do
               Avlp.initAVLStorage @AvlHash plugin initAccounts
 
               res <- unwrapSDBaseRethrow $
-                  SD.runERwCompIO actions def rwComp <&>
-                  \((), (SD.CompositeChgAccum blockCS_ stateCS_)) -> (blockCS_, stateCS_)
+                     SD.runERwCompIO actions def rwComp <&>
+                  \((), (SD.CompositeChgAccum stateCS_ blockCS_)) -> (stateCS_, blockCS_)
 
               return res
 

--- a/witness/src/Dscp/Witness/Mempool/Logic.hs
+++ b/witness/src/Dscp/Witness/Mempool/Logic.hs
@@ -32,6 +32,7 @@ import qualified Dscp.Snowdrop as SD
 import Dscp.Snowdrop.Actions (sdActionsComposition)
 import Dscp.Snowdrop.Configuration (Exceptions, Ids, Values)
 import Dscp.Snowdrop.Mode
+import Dscp.Snowdrop.ReadMode
 import Dscp.Witness.Mempool.Type
 import Dscp.Witness.SDLock
 
@@ -95,7 +96,7 @@ normalizeMempool = do
 ----------------------------------------------------------------------------
 
 -- | Read-only action with mempool.
-type SdMemReadM = SdM_ ChgAccum
+type SdMemReadM = SdM
 
 -- | Read-write action with mempool.
 type SdMemWriteM =
@@ -118,7 +119,7 @@ _sdMGeneralizationCheck =
         _ = action :: SdM ()
     in ()
   where
-    action :: SdM_ chgacc ()
+    action :: SdM ()
     action = pass
 
 ----------------------------------------------------------------------------
@@ -173,7 +174,6 @@ runSdMempoolLocked
 runSdMempoolLocked action = readingSDLock $ runSdMempool action
 
 instance KnownSdReadMode 'ChainAndMempool where
-    type SdReadModeChgAcc 'ChainAndMempool = ChgAccum
     liftSdM = lift . runSdMempool
 
 ----------------------------------------------------------------------------

--- a/witness/src/Dscp/Witness/Mempool/Type.hs
+++ b/witness/src/Dscp/Witness/Mempool/Type.hs
@@ -14,14 +14,7 @@ import qualified Snowdrop.Execution as Pool
 import Dscp.Core.Foundation (GTxWitnessed)
 import Dscp.Snowdrop.Configuration
 import qualified Dscp.Snowdrop.IOCtx as SD
-import Dscp.Snowdrop.Storage.Avlp as Avlp
-import Dscp.Witness.AVL (AvlHash)
-
-type ChgAccum =
-    Pool.CompositeChgAccum
-        (Pool.SumChangeSet Ids Values)
-        (Avlp.AVLChgAccum AvlHash Ids Values)
-        BlockPlusAVLComposition
+import Dscp.Snowdrop.Mode
 
 type MempoolVar = Mempool (SD.IOCtx ChgAccum)
 

--- a/witness/src/Dscp/Witness/Web/Types.hs
+++ b/witness/src/Dscp/Witness/Web/Types.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE StrictData    #-}
+{-# LANGUAGE DeriveFunctor     #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE StrictData        #-}
 
 module Dscp.Witness.Web.Types
     ( BlocksOrMempool (..)
@@ -34,7 +35,7 @@ data BlocksOrMempool a = BlocksOrMempool
       -- ^ Only looking at blocks
     , bmTotal     :: a
       -- ^ From blocks + mempool
-    } deriving (Eq, Ord, Show, Functor, Generic)
+    } deriving (Eq, Ord, Show, Functor, Foldable, Traversable, Generic)
 
 -- | Paginated list of something.
 -- Parameter @d@ is required to tell name of entities for JSON encoding,

--- a/witness/tests/Test/Dscp/Witness/Explorer/Explorer.hs
+++ b/witness/tests/Test/Dscp/Witness/Explorer/Explorer.hs
@@ -10,7 +10,7 @@ import Test.QuickCheck.Monadic (pre)
 import Dscp.Core
 import Dscp.Crypto
 import Dscp.Snowdrop.Configuration
-import Dscp.Snowdrop.Mode
+import Dscp.Snowdrop.ReadMode
 import Dscp.Snowdrop.Types
 import Dscp.Util
 import Dscp.Util.Test
@@ -25,8 +25,8 @@ createAndSubmitTx
     :: (WitnessWorkMode ctx m, WithinWriteSDLock)
     => SecretKeyData -> [TxOut] -> m Tx
 createAndSubmitTx sk outs = do
-    account <- runSdReadM $
-        fromMaybe def <$> getMempoolAccountMaybe (skAddress sk)
+    account <- runSdReadM @'ChainAndMempool $
+        fromMaybe def <$> getAccountMaybe (skAddress sk)
     let txw = createTxw (fcMoney feeConfig) sk (aNonce account) outs
     addTxToMempool (GMoneyTxWitnessed txw)
     return $ twTx txw

--- a/witness/tests/Test/Dscp/Witness/Explorer/ExplorerSpec.hs
+++ b/witness/tests/Test/Dscp/Witness/Explorer/ExplorerSpec.hs
@@ -1,0 +1,221 @@
+module Test.Dscp.Witness.Explorer.ExplorerSpec where
+
+import Data.Default (def)
+
+import Dscp.Core
+import Dscp.Crypto
+import Dscp.Snowdrop.Configuration
+import Dscp.Snowdrop.ReadMode
+import Dscp.Snowdrop.Types
+import Dscp.Util
+import Dscp.Util.Test
+import Dscp.Witness
+
+import Test.Dscp.Witness.Common
+import Test.Dscp.Witness.Mode
+
+-- | Generate valid transaction and put it into mempool.
+createAndSubmitTx
+    :: (WitnessWorkMode ctx m, WithinWriteSDLock)
+    => Gen SecretKey -> PropertyM m Tx
+createAndSubmitTx genSecret = do
+    sk <- pick $ mkSecretKeyData <$> genSecret
+    outs <- pick $ genSafeTxOuts 100 (choose (1, 5))
+    account <- lift . runSdReadM @'ChainAndMempool $
+               fromMaybe def <$> getAccountMaybe (skAddress sk)
+
+    let txw = createTxw (fcMoney feeConfig) sk (aNonce account) outs
+    lift $ addTxToMempool (GMoneyTxWitnessed txw)
+    return $ twTx txw
+
+-- | Generate valid publication and put it into mempool.
+createAndSubmitPub
+    :: (WitnessWorkMode ctx m, WithinWriteSDLock)
+    => Gen SecretKey -> PropertyM m PublicationTx
+createAndSubmitPub genSecret = do
+    sk <- pick $ mkSecretKeyData <$> genSecret
+    sig <- pick arbitrary
+    lastHeaderHash <- lift . runSdMempool $ getPrivateTipHash (skAddress sk)
+    let ptHeader = PrivateBlockHeader
+            { _pbhPrevBlock = lastHeaderHash
+            , _pbhBodyProof = sig
+            , _pbhAtgDelta = mempty
+            }
+        tx = PublicationTx
+            { ptAuthor = skAddress sk
+            , ptFeesAmount = unFees $ calcFeePub (fcPublication feeConfig) ptHeader
+            , ptHeader
+            }
+    let txw = signPubTx sk tx
+    lift $ addTxToMempool (GPublicationTxWitnessed txw)
+    return tx
+
+-- | Run 'getTransactions' with pagination page by page until all transactions
+-- are fetched.
+getTransactionsPaged
+    :: WitnessWorkMode ctx m
+    => Int
+    -> Maybe Address
+    -> m [[WithBlockInfo Tx]]
+getTransactionsPaged chunkSize mAddress = getFrom Nothing
+  where
+    getFrom mFrom = do
+        txList <- getTransactions (Just chunkSize) mFrom mAddress
+        next <- maybe (pure []) (getFrom . Just) (plNextId txList)
+        return (plItems txList : next)
+
+spec :: Spec
+spec = describe "Explorer" $ do
+  describe "getTransaction" $ do
+    it "Returns existing tx fine" . once $ witnessProperty $ do
+        tx <- createAndSubmitTx selectGenesisSecret
+        _ <- lift $ dumpBlock
+        res <- lift $ getTransactionInfo (toGTxId $ GMoneyTx tx)
+        return $ wbiItem res === GMoneyTx tx
+
+    it "Mempool txs are taken into account" . once $ witnessProperty $ do
+        tx <- createAndSubmitTx selectGenesisSecret
+        res <- lift $ getTransactionInfo (toGTxId $ GMoneyTx tx)
+        return $ res === WithBlockInfo Nothing (GMoneyTx tx)
+
+    it "Errors on absent tx correctly" . once $ witnessProperty $ do
+        gTxId <- pick arbitrary
+        _ <- lift $ dumpBlock
+        lift $ throwsPrism (_LogicError . _LETxAbsent) $
+            getTransactionInfo gTxId
+
+  describe "getTransactions" $ do
+    it "Returns all transactions at once just fine" . once $ witnessProperty $ do
+        n <- pick $ choose (1, 3)
+        txs <- replicateM n $ createAndSubmitTx selectGenesisSecret
+        _ <- lift $ dumpBlock
+
+        res <- lift $ getTransactions Nothing Nothing Nothing
+        -- return from recent-first order, discarding genesis transactions
+        let resTop = reverse . take n $ plItems res
+        -- comparing transactions on their id for prettier errors
+        return $ map (toTxId . wbiItem) resTop
+                 ===
+                 map toTxId txs
+
+    it "Pagination works fine" $ witnessProperty $ do
+        txsNum <- pick $ choose (1, 5)
+        chunkSize <- pick $ choose (1, 3)
+        txs <- replicateM txsNum $ createAndSubmitTx selectGenesisSecret
+        _ <- lift $ dumpBlock
+
+        res <- lift $ getTransactionsPaged chunkSize Nothing
+        return $ conjoin
+            [ property $
+                  all ((== chunkSize) . length) $
+                  maybe [] init (nonEmpty res)
+
+            , map (toTxId . wbiItem) (reverse . take txsNum $ concat res)
+              ===
+              map toTxId txs
+            ]
+
+    it "Skipping transactions works fine with mempool" $ witnessProperty $ do
+        chainTxsNum <- pick $ choose (1, 3)
+        chainTxs <- replicateM chainTxsNum $ createAndSubmitTx selectGenesisSecret
+        _ <- lift $ dumpBlock
+        memTxsNum <- pick $ choose (0, 3)
+        memTxs <- replicateM memTxsNum $ createAndSubmitTx selectGenesisSecret
+
+        let txs = chainTxs <> memTxs
+        mSince <- pick $ elements (Nothing : map (Just . toTxId) txs)
+
+        res <- lift $ getTransactions Nothing mSince Nothing
+        let expected = maybe id (\since -> dropWhile ((/= since) . toTxId)) mSince (reverse txs)
+        let resTop = zipWith const (plItems res) expected
+
+        return $ map (toTxId . wbiItem) resTop
+                 ===
+                 map toTxId expected
+
+    it "Errors nicely when 'since' transaction is absent" $ witnessProperty $ do
+        chainTxsNum <- pick $ choose (1, 5)
+        replicateM_ chainTxsNum $ createAndSubmitTx selectGenesisSecret
+        _ <- lift $ dumpBlock
+        memTxsNum <- pick $ choose (0, 3)
+        replicateM_ memTxsNum $ createAndSubmitTx selectGenesisSecret
+
+        since <- pick arbitrary
+
+        lift $ throwsPrism (_LogicError . _LETxAbsent) $
+            getTransactions Nothing (Just since) Nothing
+
+    it "Blocks info is present" . once $ witnessProperty $ do
+        _ <- createAndSubmitTx selectGenesisSecret
+        blockHash <- lift $ dumpBlock
+        _ <- createAndSubmitTx selectGenesisSecret
+
+        res <- lift $ getTransactions Nothing Nothing Nothing
+        let tx2 : tx1 : _ = plItems res
+        return $ conjoin
+            [ fmap biHeaderHash (wbiBlockInfo tx1) === Just blockHash
+            , property $ isNothing (wbiBlockInfo tx2)
+            ]
+
+    it "Filtering on address works fine (when the address is tx input)" $ witnessProperty $ do
+        let selectSecret = oneof [selectGenesisSecret, pure testSomeGenesisSecret]
+            interestingAddress = mkAddr $ toPublic testSomeGenesisSecret
+        n <- pick $ choose (1, 5)
+        txs <- replicateM n $ createAndSubmitTx selectSecret
+        _ <- lift $ dumpBlock
+
+        let expected = filter (\tx -> interestingAddress `elem` txRelatedAddrs tx) txs
+        res <- lift $ getTransactions Nothing Nothing (Just interestingAddress)
+        let resTop = reverse . take (length expected) $ plItems res
+        return $ map (toTxId . wbiItem) resTop
+                 ===
+                 map toTxId expected
+
+  describe "getPublications" $ do
+    it "Returns all transactions at once just fine" $ once $ witnessProperty $ do
+        n <- pick $ choose (1, 3)
+        txs <- replicateM n $ createAndSubmitPub (pure testSomeGenesisSecret)
+        _ <- lift $ dumpBlock
+
+        res <- lift $ getPublications Nothing Nothing Nothing
+        let resTop = reverse $ plItems res
+        return $ map (toPtxId . wbiItem) resTop
+                 ===
+                 map toPtxId txs
+
+    it "Filtering on author works fine" $ witnessProperty $ do
+        let selectSecret = oneof [selectGenesisSecret, pure testSomeGenesisSecret]
+            interestingAddress = mkAddr $ toPublic testSomeGenesisSecret
+        n <- pick $ choose (1, 5)
+        txs <- replicateM n $ createAndSubmitPub selectSecret
+        _ <- lift $ dumpBlock
+
+        let expected = filter (\tx -> interestingAddress == ptAuthor tx) txs
+        res <- lift $ getPublications Nothing Nothing (Just interestingAddress)
+        let resTop = reverse $ plItems res
+        return $ map (toPtxId . wbiItem) resTop
+                 ===
+                 map toPtxId expected
+
+    it "Blocks info is present" . once $ witnessProperty $ do
+        _ <- createAndSubmitPub selectGenesisSecret
+        blockHash <- lift $ dumpBlock
+        _ <- createAndSubmitPub selectGenesisSecret
+
+        res <- lift $ getPublications Nothing Nothing Nothing
+        let tx2 : tx1 : _ = plItems res
+        return $ conjoin
+            [ fmap biHeaderHash (wbiBlockInfo tx1) === Just blockHash
+            , property $ isNothing (wbiBlockInfo tx2)
+            ]
+
+  describe "getHashType" $ do
+    it "Handles (mempool) money transactions correctly" . once $ witnessProperty $ do
+        tx <- createAndSubmitTx selectGenesisSecret
+        res <- lift $ getHashType (toHex $ toTxId tx)
+        return $ res === HashIsMoneyTx
+
+    it "Handles (mempool) pub transactions correctly" . once $ witnessProperty $ do
+        tx <- createAndSubmitPub selectGenesisSecret
+        res <- lift $ getHashType (toHex $ toPtxId tx)
+        return $ res === HashIsPublicationTx


### PR DESCRIPTION
### Description

Previously we had separate processing for data stored in AVL and all other data.
They both were considered simultaneously only when necessary, i.e. in block application
and mempool modification.

Problem: this does not provide a reasonable level of abstraction, allowing for subtle bugs.

Solution: quick observation of blockchain-util's code has shown that composition of
actions on storages deliver an about-zero overhead (O(log (prefixes number))),
thus it makes sense to provide an interface which hides exact storage being accessed.

### YT issue

https://issues.serokell.io/issue/DSCP-367

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
