### PR TITLE
[DSCP-396] Remove inner nodes from Merkle proofs

### DIFF
--- a/core/src/Dscp/Core/Arbitrary.hs
+++ b/core/src/Dscp/Core/Arbitrary.hs
@@ -192,15 +192,9 @@ instance Arbitrary Block where
     arbitrary = genericArbitrary
     shrink    = genericShrink
 
--- | Not newtype deriving, because @'TaggedProof'@ constructor is hidden.
-instance (HasHash a, Arbitrary a) =>
-         Arbitrary (TaggedProof Unchecked a) where
-    arbitrary = mkTaggedProof <$> arbitrary
-    shrink = map mkTaggedProof . shrink . unTaggedProof
-
 -- | TODO: resolve the weird problem with _very_ long generation
 -- and produce larger FairCVs.
-instance Arbitrary (FairCV Unchecked) where
+instance Arbitrary FairCV where
     arbitrary = resize 5 $ FairCV <$> arbitrary
 
 instance ArbitraryMixture (AbstractSK ss) where

--- a/core/src/Dscp/Core/Fees.hs
+++ b/core/src/Dscp/Core/Fees.hs
@@ -68,7 +68,7 @@ calcFee policy tx = case policy of
 calcFeePub :: FeePolicy PublicationTx -> PrivateBlockHeader -> Fees
 calcFeePub policy header = case policy of
     LinearFeePolicy coeffs ->
-        calcLinearFees coeffs $ mrSize $ header ^. pbhBodyProof
+        calcLinearFees coeffs $ msSize $ header ^. pbhBodyProof
 
 -- | Calculates fees of 'GTxWitnessed'.
 calcFeeG :: FeeConfig -> GTxWitnessed -> Fees

--- a/core/src/Dscp/Crypto/Arbitrary.hs
+++ b/core/src/Dscp/Crypto/Arbitrary.hs
@@ -3,6 +3,7 @@
 module Dscp.Crypto.Arbitrary () where
 
 import qualified Data.Set as Set
+import GHC.Exts (fromList)
 import Test.QuickCheck.Arbitrary.Generic (genericShrink)
 
 import Dscp.Util.Test
@@ -54,7 +55,7 @@ longerThan :: Container f => Int -> f -> Bool
 longerThan n x = length x > n
 
 instance Arbitrary (MerkleSignature a) where
-    arbitrary = MerkleSignature <$> arbitrary <*> choose (0, 100)
+    arbitrary = MerkleSignature <$> choose (0, 100) <*> arbitrary
     shrink = genericShrink
 
 instance (HasHash a, Arbitrary a) => Arbitrary (MerkleTree a) where

--- a/core/src/Dscp/Crypto/Impl.hs
+++ b/core/src/Dscp/Crypto/Impl.hs
@@ -28,6 +28,9 @@ module Dscp.Crypto.Impl
        , verify
        , unsafeVerify
        , Signed (..)
+
+         -- * Other
+       , Raw
        ) where
 
 import Crypto.Error (CryptoFailable (..))
@@ -94,7 +97,7 @@ withSeed seed action = fst $ withDRG (drgNewSeed seed'') action
         0 -> error "withSeed: provided seed is an empty bytestring"
         _ | len > 40 -> BS.take 40 seed
         _ | len < 40 -> let (d,m) = 40 `divMod` len
-                        in BS.concat (replicate d seed) `BS.append` (BS.take m seed)
+                        in BS.concat (replicate d seed) `BS.append` BS.take m seed
         _ -> seed
     seed'' = case seedFromBinary seed' of
         CryptoPassed x -> x
@@ -133,3 +136,9 @@ data Signed msg = Signed
 instance Buildable msg => Buildable (Signed msg) where
     build Signed{..} = "Signed { sig: " +| build sgSignature |+
                        "; pk: " +| build sgPublicKey |+ " }"
+
+-- | Type alias for denoting raw bytes. Indended to be used with hashes
+-- and signatures, like in type `Hash Raw`, and not type-safe hashing and
+-- signing.
+-- TODO: probably it makes sense to make it a newtype, like in Cardano?
+type Raw = LByteString

--- a/core/src/Dscp/Crypto/Serialise.hs
+++ b/core/src/Dscp/Crypto/Serialise.hs
@@ -1,8 +1,6 @@
-{-# LANGUAGE TypeApplications #-}
-
 -- | Instances for binary serialisation for 'Dscp.Crypto' datatypes
 --
--- We provide them for every possible framework, but expect serialisee
+-- We provide them for every possible framework, but expect serialise
 -- instances to come from 'FromByteArray'.
 
 module Dscp.Crypto.Serialise
@@ -10,16 +8,15 @@ module Dscp.Crypto.Serialise
        ) where
 
 import Codec.Serialise (Serialise (..), serialise)
-import Codec.Serialise.Decoding (Decoder, decodeBytes)
-import Codec.Serialise.Encoding (Encoding, encodeBytes)
+import Codec.Serialise.Decoding (Decoder, decodeBytes, decodeWordOf)
+import Codec.Serialise.Encoding (Encoding, encodeBytes, encodeWord)
 import Data.ByteArray (ByteArrayAccess, convert)
-import qualified Data.ByteString.Lazy as LBS
 
-import Dscp.Crypto.ByteArray (FromByteArray (..))
-import Dscp.Crypto.Hash (AbstractHash (..), HasAbstractHash (..), HashFunc (..))
-import Dscp.Crypto.Impl (Signed (..))
-import Dscp.Crypto.Signing (AbstractPK (..), AbstractSK (..), AbstractSig (..),
-                            HasAbstractSignature (..), SignatureScheme (..))
+import Dscp.Crypto.ByteArray
+import Dscp.Crypto.Hash
+import Dscp.Crypto.Impl
+import Dscp.Crypto.MerkleTree
+import Dscp.Crypto.Signing
 
 ---------------------------------------------------------------
 -- Hashes
@@ -66,6 +63,39 @@ instance {-# OVERLAPPABLE #-}
     unsafeAbstractVerify pk = unsafeAbstractVerify pk . serialise
 
 ----------------------------------------------------------------------------
+-- Merkle trees
+----------------------------------------------------------------------------
+
+{-
+Custom CBOR tag values are picked from on of `Unassigned` ranges
+not yet claimed in the large `First Come First Served` range:
+https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml#tags
+-}
+
+elStubTag :: Word
+elStubTag = 1042
+
+mSigTag :: Word
+mSigTag = 1043
+
+instance Serialise ElementStub where
+    encode _ = encodeWord elStubTag
+    decode = ElementStub <$ decodeWordOf elStubTag
+
+instance Serialise (MerkleSignature a) where
+    encode MerkleSignature {..} =
+        encodeWord mSigTag <> encode msSize <> encode msHash
+    decode =
+        MerkleSignature <$ decodeWordOf mSigTag <*> decode <*> decode
+
+instance Serialise a => Serialise (MerkleNode a)
+instance Serialise a => Serialise (MerkleTree a)
+instance Serialise a => Serialise (MerkleProof a)
+
+deriving instance Serialise (EmptyMerkleTree a)
+deriving instance Serialise (EmptyMerkleProof a)
+
+----------------------------------------------------------------------------
 -- Other
 ----------------------------------------------------------------------------
 
@@ -74,10 +104,3 @@ encodeBA = encodeBytes . convert
 
 decodeBA :: FromByteArray x => Decoder s x
 decodeBA = either fail pure . fromByteArray =<< decodeBytes
-
--- | Type alias for denoting raw bytes. Indended to be used with hashes
--- and signatures, like in type `Hash Raw`, and not type-safe hashing and
--- signing.
--- TODO: probably it makes sense to make it a newtype, like in Cardano?
--- Also, is it the most appropriate place for it?
-type Raw = LBS.ByteString

--- a/core/tests/Test/Dscp/Core/Serialise.hs
+++ b/core/tests/Test/Dscp/Core/Serialise.hs
@@ -36,7 +36,7 @@ spec_coreAeson = describe "Core datatypes JSON serialisation" $ do
     aesonRoundtripProp @Tx
     aesonRoundtripProp @PublicationTx
     aesonRoundtripProp @GTx
-    aesonRoundtripProp @(FairCV Unchecked)
+    aesonRoundtripProp @FairCV
 
 spec_coreHttpApi :: Spec
 spec_coreHttpApi = describe "Core datatypes HttpApiData serialisation" $ do

--- a/core/tests/Test/Dscp/Crypto/MerkleTree.hs
+++ b/core/tests/Test/Dscp/Crypto/MerkleTree.hs
@@ -1,5 +1,7 @@
 module Test.Dscp.Crypto.MerkleTree where
 
+import GHC.Exts (fromList)
+
 import qualified Data.List as List
 import qualified Data.Set as Set
 
@@ -9,67 +11,81 @@ import Dscp.Util.Test
 spec_merkleTree :: Spec
 spec_merkleTree = describe "Merkle Tree Tests" $ do
     it "should preserve leaf order when constructed from Foldable" $ property $
-      \(xs :: [Int]) -> toList (fromFoldable xs) == xs
+        \(xs :: [Int]) -> toList (fromFoldable xs) == xs
 
     it "should preserve leaf order when constructed from Container" $ property $
-      \(xs :: String) -> toList (fromContainer xs) == xs
+        \(xs :: String) -> toList (fromContainer xs) == xs
 
     it "should have correct length" $ property $
-       \(xs :: [ByteString]) ->
-         length (fromFoldable xs) `shouldBe` length xs
+        \(xs :: [ByteString]) ->
+            length (fromFoldable xs) `shouldBe` length xs
 
     it "should have correct size" $ property $
-       \(xs :: [ByteString]) ->
-         mrSize (getMerkleRoot (fromFoldable xs))
-          `shouldBe` fromIntegral (length xs)
-
-    it "should have correct length and size even for empty tree" $ do
-         mrSize (getMerkleRoot MerkleEmpty) `shouldBe` 0
-         length MerkleEmpty `shouldBe` 0
-
-    it "should have equal length and size" $ property $
-       \(xs :: String) ->
-         mrSize (getMerkleRoot (fromFoldable xs))
+        \(xs :: [ByteString]) ->
+            msSize (getMerkleRoot (fromFoldable xs))
             `shouldBe` fromIntegral (length xs)
 
+    it "should have correct length and size even for empty tree" $ do
+        msSize (getMerkleRoot MerkleEmpty) `shouldBe` 0
+        length MerkleEmpty `shouldBe` 0
+
+    it "should have equal length and size" $ property $
+        \(xs :: String) ->
+            msSize (getMerkleRoot (fromFoldable xs))
+            `shouldBe` fromIntegral (length xs)
+
+    it "estimates the proof size correctly (equal to original tree's size)" $ property $
+        \(xs :: [Int], idxs :: Set Word32) ->
+            let tree = fromList xs
+                mProof = mkMerkleProof tree idxs
+            in case mProof of
+                   Nothing    -> property True
+                   Just proof -> length tree === fromIntegral (mpSize proof)
+
     it "can construct and verify single proofs " $ property $
-       \(xs :: [Int], leafIdx) ->
-        let tree = fromFoldable xs
-        in (validateMerkleProof <$> mkMerkleProofSingle tree leafIdx <*> Just (getMerkleRoot tree))
-            `shouldBe` if leafIdx < fromIntegral (length xs) && leafIdx >= 0
-                       then Just True
-                       else Nothing
+        \(xs :: [Int], leafIdx) ->
+            let tree = fromFoldable xs
+                validationRes = validateMerkleProof <$>
+                                (readyProof <$> mkMerkleProofSingle tree leafIdx) <*>
+                                Just (getMerkleRoot tree)
+            in validationRes `shouldBe` if leafIdx < fromIntegral (length xs) && leafIdx >= 0
+                                        then Just True
+                                        else Nothing
 
     it "can construct and verify Set proofs " $ property $
-       \(treeLeafs :: [Int], proofIndicies' :: [Word32]) ->
-        let tree = fromFoldable treeLeafs
-            proofIndicies = Set.fromList proofIndicies'
-            haveLeafIndex = any (\x -> x < fromIntegral (length treeLeafs) && x >= 0) proofIndicies'
-        in (validateMerkleProof <$> mkMerkleProof tree proofIndicies <*> Just (getMerkleRoot tree))
-            `shouldBe` if haveLeafIndex then Just True else Nothing
+        \(treeLeafs :: [Int], proofIndicies' :: [Word32]) ->
+            let tree = fromFoldable treeLeafs
+                proofIndicies = Set.fromList proofIndicies'
+                haveLeafIndex = any (\x -> x < fromIntegral (length treeLeafs) && x >= 0) proofIndicies'
+                validationRes = validateMerkleProof <$>
+                                (readyProof <$> mkMerkleProof tree proofIndicies) <*>
+                                Just (getMerkleRoot tree)
+            in validationRes `shouldBe` if haveLeafIndex then Just True else Nothing
 
     it "performs lookup correctly" $ property $
-      \(Fixed (xs' :: [ByteString], indices :: [Word32])) ->
-        let xs          = List.nub xs'
-            withIndices = zip [0..] xs
-            tree        = fromList xs
-            count       = fromIntegral $ length tree
-            uniqIndices = Set.fromList $ map (`mod` count) $ List.nub indices
-            proof'      = mkMerkleProof tree uniqIndices
+        \(Fixed (xs' :: [ByteString], indices :: [Word32])) ->
+            let xs          = List.nub xs'
+                withIndices = zip [0..] xs
+                tree        = fromList xs
+                count       = fromIntegral $ length tree
+                uniqIndices = Set.fromList $ map (`mod` count) $ List.nub indices
+                proof'      = mkMerkleProof tree uniqIndices
 
-            (pairsToLook, pairsToFail) =
-                List.partition
+                (pairsToLook, pairsToFail) = List.partition
                     ((`elem` uniqIndices) . fst)
                     withIndices
 
-            shouldBeFoundIn    proof (index, value) = Just value == lookup index proof
-            shouldBeNotFoundIn proof (index, _    ) = isNothing $ lookup index proof
+                shouldBeFoundIn    proof (index, value) = Just value == lookup index proof
+                shouldBeNotFoundIn proof (index, _    ) = isNothing $ lookup index proof
 
-        in  case proof' of
-                Nothing    -> True
+            in case proof' of
+                Nothing    -> property True
                 Just proof ->
-                       all (shouldBeFoundIn    proof) pairsToLook
-                    && all (shouldBeNotFoundIn proof) pairsToFail
+                    counterexample "Not found indices which should be found"
+                    (all (shouldBeFoundIn    proof) pairsToLook)
+                    .&&.
+                    counterexample "Found some indices which should not be found"
+                    (all (shouldBeNotFoundIn proof) pairsToFail)
 
     it "splits and merges proofs and its data correctly" $ property $
         \(proof :: MerkleProof Int) ->

--- a/educator/src/Dscp/DB/SQLite/Queries.hs
+++ b/educator/src/Dscp/DB/SQLite/Queries.hs
@@ -75,13 +75,13 @@ import Control.Lens (makePrisms, to)
 import Data.Default (Default (..))
 import qualified Data.Map as Map (empty, fromList, insertWith, toList)
 import Data.Time.Clock (UTCTime)
+import GHC.Exts (fromList)
 import Loot.Base.HasLens (HasCtx)
 import Snowdrop.Util (OldestFirst (..))
 
 import Dscp.Core
 import Dscp.Crypto (EmptyMerkleTree, Hash, MerkleProof, fillEmptyMerkleTree, getEmptyMerkleTree,
                     getMerkleRoot, hash)
-import qualified Dscp.Crypto.MerkleTree as MerkleTree (fromList)
 import Dscp.DB.SQLite.BlockData
 import Dscp.DB.SQLite.Error (asAlreadyExistsError, asReferenceInvalidError)
 import Dscp.DB.SQLite.Functions
@@ -362,7 +362,7 @@ createPrivateBlock delta = runMaybeT $ do
     (prev, idx) <- lift getLastBlockIdAndIdx
     txs         <- lift getAllNonChainedTransactions
 
-    let tree = MerkleTree.fromList txs
+    let tree = fromList txs
         root = getMerkleRoot tree
 
         txs' = zip [0..] (getId <$> txs)

--- a/educator/src/Dscp/Educator/Web/Types.hs
+++ b/educator/src/Dscp/Educator/Web/Types.hs
@@ -131,7 +131,7 @@ instance Buildable (GradeInfo) where
 instance Buildable (BlkProofInfo) where
     build (BlkProofInfo{..}) =
       "{ tree root hash = " +||
-          fmap getMerkleProofRoot bpiMtreeSerialized ||+
+          fmap reconstructRoot bpiMtreeSerialized ||+
       ", transactons num = " +| length bpiTxs |+
       "} "
 
@@ -147,7 +147,7 @@ instance Buildable (ForResponseLog GradeInfo) where
 instance Buildable (ForResponseLog BlkProofInfo) where
     build (ForResponseLog BlkProofInfo{..}) =
       "{ tree root hash = " +||
-          fmap getMerkleProofRoot bpiMtreeSerialized ||+
+          fmap reconstructRoot bpiMtreeSerialized ||+
       "} "
 
 instance Buildable (ForResponseLog Course) where

--- a/specs/disciplina/witness/api/witness.yaml
+++ b/specs/disciplina/witness/api/witness.yaml
@@ -668,16 +668,7 @@ components:
             txs:
               type: array
               items:
-                type: object
-                required:
-                  - idx
-                  - val
-                properties:
-                  idx:
-                    type: integer
-                    format: int32
-                  tx:
-                    $ref: '#/components/schemas/PrivateTx'
+                $ref: '#/components/schemas/PrivateTx'
     FairCVCheckResult:
       type: object
       additionalProperties:

--- a/witness/src/Dscp/Witness/Web/API.hs
+++ b/witness/src/Dscp/Witness/Web/API.hs
@@ -75,7 +75,7 @@ data WitnessEndpoints route = WitnessEndpoints
 
     , wCheckFairCV :: route
         :- "checkcv"
-        :> ReqBody '[JSON] (FairCV Unchecked)
+        :> ReqBody '[JSON] FairCV
         :> Verb 'PUT 200 '[DSON] FairCVCheckResult
     } deriving (Generic)
 


### PR DESCRIPTION
### Description

1) Merkle proofs do not have inned Merkle signatures anymore
2) Some functions working with Merkle proofs are optimized
3) Refactored the code accordingly to the style guide
4) Moved `Serialise` instances for Merkle datatypes to `Dscp.Crypto.Serialise`
5) and other changes which followed

### YT issue

https://issues.serokell.io/issue/DSCP-396

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
