### PR TITLE
[DSCP-386] Add a test on persistency of Educator's data

### DIFF
--- a/educator/package.yaml
+++ b/educator/package.yaml
@@ -82,6 +82,7 @@ tests:
       - stm
       - tasty
       - tasty-hspec
+      - temporary
       - text-format
       - time
       - QuickCheck

--- a/educator/tests/Test/Dscp/DB/SQLite/Real/Mode.hs
+++ b/educator/tests/Test/Dscp/DB/SQLite/Real/Mode.hs
@@ -1,0 +1,34 @@
+module Test.Dscp.DB.SQLite.Real.Mode
+    ( runSQLiteMode
+    , launchSQLiteMode
+    ) where
+
+import System.IO.Temp (withSystemTempFile)
+
+import Dscp.DB.SQLite
+import Dscp.Rio
+
+-- | Test parameters for db which is stored in filesystem.
+testRealSQLiteParams :: FilePath -> SQLiteParams
+testRealSQLiteParams dbPath = SQLiteParams
+    { sdpMode = SQLiteReal SQLiteRealParams
+        { srpPath = dbPath
+        , srpConnNum = Just 5
+        , srpMaxPending = 1000
+        }
+    }
+
+-- | Run an action with context supplied with database stored in the provided file.
+runSQLiteMode :: FilePath -> RIO SQLiteDB a -> IO a
+runSQLiteMode dbPath action = do
+    bracket (openSQLiteDB dbParams)
+            (\db -> closeSQLiteDB db) $
+            \db -> runRIO db action
+  where
+    dbParams = testRealSQLiteParams dbPath
+
+-- | Run an action with a database at temporary location.
+launchSQLiteMode :: RIO SQLiteDB a -> IO a
+launchSQLiteMode action =
+    withSystemTempFile "test-db-XXX.sql" $ \tmpFile _hdl -> do
+        runSQLiteMode tmpFile action

--- a/educator/tests/Test/Dscp/DB/SQLite/Real/Persistency.hs
+++ b/educator/tests/Test/Dscp/DB/SQLite/Real/Persistency.hs
@@ -1,0 +1,23 @@
+module Test.Dscp.DB.SQLite.Real.Persistency where
+
+import Loot.Base.HasLens (lensOf)
+import System.IO.Temp (withSystemTempFile)
+
+import Dscp.DB.SQLite
+import Dscp.Educator.DB.Queries
+import Dscp.Educator.DB.Resource
+import Dscp.Util.Test
+
+import Test.Dscp.DB.SQLite.Real.Mode
+
+spec_SQLiteWrapper :: Spec
+spec_SQLiteWrapper =
+    it "SQL database persistency" . once . ioProperty $ do
+        withSystemTempFile "persistency-test-db-XXX.sql" $ \dbFile _hdl -> do
+            cid <- runSQLiteMode dbFile $ do
+                prepareEducatorSchema =<< view (lensOf @SQLiteDB)
+                transactW $ createCourse nullCourse{ cdDesc = "Proper belts placing" }
+
+            runSQLiteMode dbFile $ do
+                prepareEducatorSchema =<< view (lensOf @SQLiteDB)
+                invoke $ existsCourse cid


### PR DESCRIPTION
### Description

:man_shrugging: 

### YT issue

https://issues.serokell.io/issue/DSCP-386

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
