### PR TITLE
[SRK-8] Remove warning in package.yaml of multieducator

### DIFF
--- a/multi-educator/package.yaml
+++ b/multi-educator/package.yaml
@@ -51,38 +51,6 @@ library:
     - wai
     - wai-cors
 
-  tests:
-    disciplina-test:
-      <<: *test-common
-
-      build-tools:
-        - tasty-discover
-
-      dependencies:
-        - containers
-        - cryptonite
-        - data-default
-        - disciplina-core
-        - disciplina-witness
-        - disciplina-educator
-        - directory
-        - fmt
-        - generic-arbitrary
-        - hspec
-        - interpolatedstring-perl6
-        - lens
-        - loot-base
-        - loot-log
-        - safe-exceptions >= 0.1.4
-        - sqlite-simple
-        - stm
-        - tasty
-        - tasty-hspec
-        - text-format
-        - time
-        - QuickCheck
-        - unliftio
-
 executables:
   dscp-multi-educator:
     <<: *exec-common


### PR DESCRIPTION
### Description

Otherwise on each build I get 
```
Warning: /home/martoon/serokell/disciplina/multi-educator/package.yaml:
         Ignoring unrecognized field
         $.library.tests
```
which is annoying.

Generally, the problem is, `tests` section is part of `library` section while it should be a standalone property, but since multi-educator actually has no tests, I just remove test section entirely.

### YT issue

https://issues.serokell.io/issue/DSCP-

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] If any public documentation was written, I have spellchecked it.
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).

Stylistic (obligatory):
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
