### PR TITLE
[LTB-52] Bump lootbox with simpler `HasLens`

### DIFF
--- a/core/src/Dscp/Config/Util.hs
+++ b/core/src/Dscp/Config/Util.hs
@@ -46,7 +46,7 @@ import Data.Yaml (FromJSON (..), ParseException (AesonException), decodeFileEith
                   (.:?))
 import Fmt (blockListF)
 import GHC.TypeLits (KnownSymbol, Symbol, symbolVal)
-import Loot.Base.HasLens (HasLens', lensOf)
+import Loot.Base.HasLens (HasLens, lensOf)
 import Loot.Config (ConfigKind (Final, Partial), ConfigRec, HasLensC, finalise, lensOfC, option,
                     sub)
 import qualified Options.Applicative as Opt
@@ -167,10 +167,10 @@ configParamsParser = do
 ----------------------------------------------------------------------------
 
 type HasGiven is v =
-    (Given (ConfigRec 'Final is), HasLens' (ConfigRec 'Final is) v)
+    (Given (ConfigRec 'Final is), HasLens (ConfigRec 'Final is) v)
 
 giveL :: forall is v . HasGiven is v => v
-giveL = given @(ConfigRec 'Final is) ^. (lensOf @v)
+giveL = given @(ConfigRec 'Final is) ^. lensOf
 
 type HasGivenC path is v =
     (Given (ConfigRec 'Final is), HasLensC path is v)

--- a/core/src/Dscp/Resource/Class.hs
+++ b/core/src/Dscp/Resource/Class.hs
@@ -32,7 +32,7 @@ data InitContext = InitContext
 
 makeLenses ''InitContext
 
-instance HasLens LoggingIO InitContext LoggingIO where
+instance HasLens InitContext LoggingIO where
     lensOf = icLogging
 
 -- | Resources safe allocation.

--- a/core/src/Dscp/Rio.hs
+++ b/core/src/Dscp/Rio.hs
@@ -29,11 +29,11 @@ newtype RIO ctx a = RIO { unRIO :: ReaderT ctx IO a }
 runRIO :: MonadIO m => ctx -> RIO ctx a -> m a
 runRIO ctx (RIO act) = liftIO $ runReaderT act ctx
 
-instance HasLens LoggingIO ctx LoggingIO =>
+instance HasLens ctx LoggingIO =>
          MonadLogging (RIO ctx) where
     log = Rio.defaultLog
     logName = Rio.defaultLogName
 
-instance HasLens LoggingIO ctx LoggingIO =>
+instance HasLens ctx LoggingIO =>
          ModifyLogName (RIO ctx) where
     modifyLogNameSel = Rio.defaultModifyLogNameSel

--- a/core/src/Dscp/Util/HasLens.hs
+++ b/core/src/Dscp/Util/HasLens.hs
@@ -59,15 +59,15 @@ deriveHasLensExt deriveWay preLensQ ctxName tyName = do
     mkInstance fieldTy mkLensName = do
       preLens <- preLensQ
       let addPreLens = TH.UInfixE (preLens) (TH.VarE $ TH.mkName ".")
-      fieldLens <- [e| lensOf @($(pure fieldTy)) |]
+      fieldLens <- [e| lensOf @_ @($(pure fieldTy)) |]
       case deriveWay of
         DeriveViaLensOf ->
-            [d| instance HasLens $(pure fieldTy) $(TH.conT ctxName) $(pure fieldTy) where
+            [d| instance HasLens $(TH.conT ctxName) $(pure fieldTy) where
                       lensOf = $(pure $ addPreLens fieldLens)
                 |]
         DeriveViaFieldLens rules -> do
             lensName <- mkLensName rules
-            [d| instance HasLens $(pure fieldTy) $(TH.conT ctxName) $(pure fieldTy) where
+            [d| instance HasLens $(TH.conT ctxName) $(pure fieldTy) where
                       lensOf = $(pure $ addPreLens (TH.VarE lensName))
                 |]
 

--- a/core/src/Dscp/Util/Time.hs
+++ b/core/src/Dscp/Util/Time.hs
@@ -20,7 +20,7 @@ import qualified Control.Concurrent.STM as STM
 import Control.Exception (BlockedIndefinitelyOnSTM (..))
 import Control.Exception.Safe (handle)
 import Data.Time.Clock.POSIX (getPOSIXTime)
-import Loot.Base.HasLens (HasCtx, HasLens', lensOf)
+import Loot.Base.HasLens (HasCtx, HasLens, lensOf)
 import Time (KnownRat, Second, Time, Timestamp (..), fromUnixTime, threadDelay, timeAdd, toUnit)
 
 -- | Basic timing actions.
@@ -41,13 +41,13 @@ type HasTime ctx m =
 
 type HasTestTime ctx m =
     ( HasTime ctx m
-    , HasLens' ctx TestTimeActions
+    , HasLens ctx TestTimeActions
     )
 
 -- | Get current time.
 getCurTime :: HasTime ctx m => m Timestamp
 getCurTime = do
-    TimeActions{..} <- view $ lensOf @TimeActions
+    TimeActions{..} <- view lensOf
     liftIO taGetCurrent
 
 -- | Get current time, in microseconds.
@@ -57,13 +57,13 @@ getCurTimeMcs = getCurTime <&> \(Timestamp t) -> floor (t * 1000000)
 -- | Analogy to 'threadDelay'.
 sleep :: (KnownRat unit, HasTime ctx m) => Time unit -> m ()
 sleep duration = do
-    TimeActions{..} <- view $ lensOf @TimeActions
+    TimeActions{..} <- view lensOf
     liftIO $ taSleep (toUnit duration)
 
 -- | Instantly increase current time by given amount.
 rewindTime :: (KnownRat unit, HasTestTime ctx m) => Time unit -> m ()
 rewindTime by = do
-    TestTimeActions{..} <- view $ lensOf @TestTimeActions
+    TestTimeActions{..} <- view lensOf
     liftIO $ taRewind (toUnit by)
 
 ----------------------------------------------------------------------------

--- a/educator/src/Dscp/DB/SQLite/Functions.hs
+++ b/educator/src/Dscp/DB/SQLite/Functions.hs
@@ -75,7 +75,7 @@ notingPending
     :: (MonadUnliftIO m, HasCtx ctx m '[SQLiteDB])
     => m a -> m a
 notingPending action = do
-    db <- view (lensOf @SQLiteDB)
+    db <- view lensOf
     let pendingNum = sdPendingNum db
         maxPending = sdMaxPending db
     UIO.bracket_ (increaseCounterOrThrow pendingNum maxPending)
@@ -98,7 +98,7 @@ borrowConnection
 borrowConnection action = do
     -- TODO: timeout?
     -- TODO: drop warnings on long execution?
-    db <- view (lensOf @SQLiteDB)
+    db <- view lensOf
     let connPool = sdConnPool db
     UIO.bracket (notingPending $ liftIO $ readChan connPool)
                 (liftIO . writeChan connPool)

--- a/educator/src/Dscp/Educator/DB/Queries.hs
+++ b/educator/src/Dscp/Educator/DB/Queries.hs
@@ -76,7 +76,7 @@ import Data.Default (Default (..))
 import qualified Data.Map as Map (empty, fromList, insertWith, toList)
 import Data.Time.Clock (UTCTime)
 import GHC.Exts (fromList)
-import Loot.Base.HasLens (HasLens')
+import Loot.Base.HasLens (HasLens)
 import Snowdrop.Util (OldestFirst (..))
 
 import Dscp.Core
@@ -306,7 +306,7 @@ genesisBlockIdx :: BlockIdx
 genesisBlockIdx = 0
 
 getLastBlockIdAndIdx
-    :: (MonadQuery m, HasLens' ctx (KeyResources EducatorNode))
+    :: (MonadQuery m, HasLens ctx (KeyResources EducatorNode))
     => ctx -> m (Hash PrivateBlockHeader, BlockIdx)
 getLastBlockIdAndIdx ctx = do
     author <- runRIO ctx $ ourAddress @EducatorNode
@@ -326,7 +326,7 @@ getPrivateBlock = selectByPk pbHeaderFromRow (esBlocks es)
 
 -- TODO [DSCP-384]: requires index on Blocks.hash
 getPrivateBlockIdxByHash
-    :: (MonadQuery m, HasLens' ctx (KeyResources EducatorNode))
+    :: (MonadQuery m, HasLens ctx (KeyResources EducatorNode))
     => ctx -> PrivateHeaderHash -> m (Maybe BlockIdx)
 getPrivateBlockIdxByHash ctx phHash = do
     author <- runRIO ctx $ ourAddress @EducatorNode
@@ -350,14 +350,14 @@ getPrivateBlocksAfter idx =
         all_ (esBlocks es)
 
 getPrivateBlocksAfterHash
-    :: (MonadQuery m, HasLens' ctx (KeyResources EducatorNode))
+    :: (MonadQuery m, HasLens ctx (KeyResources EducatorNode))
     => ctx -> PrivateHeaderHash -> m (Maybe $ OldestFirst [] PrivateBlockHeader)
 getPrivateBlocksAfterHash ctx phHash = do
     midx <- getPrivateBlockIdxByHash ctx phHash
     forM @Maybe midx getPrivateBlocksAfter
 
 createPrivateBlock
-    :: (MonadQuery m, HasLens' ctx (KeyResources EducatorNode), WithinWriteTx)
+    :: (MonadQuery m, HasLens ctx (KeyResources EducatorNode), WithinWriteTx)
     => ctx -> Maybe ATGDelta -> m (Maybe PrivateBlockHeader)
 createPrivateBlock ctx delta = runMaybeT $ do
     (prev, idx) <- lift (getLastBlockIdAndIdx ctx)

--- a/educator/src/Dscp/Educator/Launcher/Mode.hs
+++ b/educator/src/Dscp/Educator/Launcher/Mode.hs
@@ -17,7 +17,7 @@ module Dscp.Educator.Launcher.Mode
     ) where
 
 import Control.Lens (makeLenses)
-import Loot.Base.HasLens (HasLens')
+import Loot.Base.HasLens (HasLens)
 
 import Dscp.DB.CanProvideDB as DB
 import Dscp.DB.SQLite (SQLiteDB)
@@ -43,9 +43,9 @@ type EducatorOnlyWorkMode ctx m =
 
     , MonadReader ctx m
 
-    , HasLens' ctx DB.Plugin
-    , HasLens' ctx SQLiteDB
-    , HasLens' ctx (KeyResources EducatorNode)
+    , HasLens ctx DB.Plugin
+    , HasLens ctx SQLiteDB
+    , HasLens ctx (KeyResources EducatorNode)
     , MonadThrow m
     )
 

--- a/educator/src/Dscp/Educator/Web/Server.hs
+++ b/educator/src/Dscp/Educator/Web/Server.hs
@@ -10,7 +10,7 @@ module Dscp.Educator.Web.Server
 import Data.Proxy (Proxy (..))
 import Data.Reflection (Reifies, reify)
 import Fmt ((+|), (|+))
-import Loot.Base.HasLens (lensOf)
+import Loot.Base.HasLens (glensOf)
 import Loot.Config (option, sub)
 import Loot.Log (logInfo)
 import Network.HTTP.Types.Header (hAuthorization, hContentType)
@@ -34,7 +34,7 @@ import Dscp.Educator.Web.Educator (EducatorPublicKey (..), ProtectedEducatorAPI,
                                    protectedEducatorAPI)
 import Dscp.Educator.Web.Student (ProtectedStudentAPI, StudentCheckAction (..),
                                   convertStudentApiHandler, studentAPI, studentApiHandlers)
-import Dscp.Resource.Keys (KeyResources, krPublicKey)
+import Dscp.Resource.Keys (krPublicKey)
 import Dscp.Util.Servant (LoggingApi, ServantLogConfig (..), methodsCoveringAPI)
 import Dscp.Web (ServerParams (..), buildServantLogConfig, serveWeb)
 import Dscp.Web.Metrics (responseTimeMetric)
@@ -110,7 +110,7 @@ serveEducatorAPIsReal withWitnessApi = do
         educatorAPINoAuth = webCfg ^. option #educatorAPINoAuth
         studentAPINoAuth  = webCfg ^. option #studentAPINoAuth
 
-    educatorKeyResources <- view (lensOf @(KeyResources EducatorNode))
+    educatorKeyResources <- view (glensOf @EducatorNode)
     studentCheckAction <- createStudentCheckAction botParams
     let educatorPublicKey = EducatorPublicKey $ educatorKeyResources ^. krPublicKey
     let srvCtx = educatorPublicKey :. educatorAPINoAuth :.

--- a/faucet/exec/Main.hs
+++ b/faucet/exec/Main.hs
@@ -3,7 +3,7 @@
 module Main where
 
 import Fmt ((+|), (|+))
-import Loot.Base.HasLens (lensOf)
+import Loot.Base.HasLens (glensOf)
 import Loot.Log (logInfo)
 import Options.Applicative (execParser, fullDesc, helper, info, progDesc)
 
@@ -22,7 +22,7 @@ main = do
         serveFaucetAPIReal
   where
     printSourceInfo = do
-        pk <- view $ lensOf @(KeyResources FaucetApp) . krPublicKey
+        pk <- view $ glensOf @FaucetApp . krPublicKey
         let addr = mkAddr pk
         logInfo $ "Faucet source address: " +| addr |+ ""
 

--- a/faucet/src/Dscp/Faucet/Launcher/Mode.hs
+++ b/faucet/src/Dscp/Faucet/Launcher/Mode.hs
@@ -62,7 +62,7 @@ type FaucetRealMode = RIO FaucetContext
 ---------------------------------------------------------------------
 
 #define GenHasLens(SUBRES, IMPL) \
-    instance HasLens (SUBRES) FaucetContext (SUBRES) where \
+    instance HasLens FaucetContext (SUBRES) where \
         lensOf = IMPL
 
 GenHasLens(Logging IO            , fcResources . frLogging)

--- a/faucet/src/Dscp/Faucet/Launcher/Resource.hs
+++ b/faucet/src/Dscp/Faucet/Launcher/Resource.hs
@@ -43,7 +43,7 @@ instance AllocResource FaucetResources where
     type Deps FaucetResources = FaucetConfigRec
     allocResource faucetCfg = do
         let cfg = faucetCfg ^. sub #faucet
-        _frLogging <- view (lensOf @(Logging IO))
+        _frLogging <- view lensOf
         _frAppDir <- allocResource $ cfg ^. option #appDir
         _frKeys <- allocResource (faucetCfg, _frAppDir)
         _frWitnessClient <- allocResource $ cfg ^. option #witnessBackend

--- a/faucet/src/Dscp/Faucet/Web/Logic.hs
+++ b/faucet/src/Dscp/Faucet/Web/Logic.hs
@@ -29,7 +29,7 @@ ensureFirstGift
     :: (MonadIO m, MonadThrow m, HasCtx ctx m '[GiftedAddresses])
     => Address -> m ()
 ensureFirstGift addr = do
-    giftedAddresses <- view (lensOf @GiftedAddresses)
+    giftedAddresses <- view (lensOf @_ @GiftedAddresses)
     prevVal <- atomically . modifyTVarS giftedAddresses $
         at addr <<.= Just ()
     when (isJust prevVal) $
@@ -42,8 +42,8 @@ faucetTransferMoneyTo dest = do
     sk <- ourSecretKeyData @FaucetApp
     let source = skAddress sk
 
-    wc <- views (lensOf @WitnessClient) (hoistWitnessClient liftIO)
-    lock <- view (lensOf @TxSendLock)
+    wc <- views lensOf (hoistWitnessClient liftIO)
+    lock <- view lensOf
     let DryRun dryRun = giveL @FaucetConfig @DryRun
         TransferredAmount transfer = giveL @FaucetConfig @TransferredAmount
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -35,7 +35,7 @@ extra-deps:
   commit: 333a2b2cf113e115ea2ec450dc706d3f47ee54e4
 
 - git: https://github.com/serokell/blockchain-util.git
-  commit: 9a28a192c55cb61735ffc0c899fbd80815e1dd2c # volhovm/dscp193
+  commit: 4c8d1fa17e3dc3578c0e93958b3a3715610214e5 # (will be at volhovm/dscp193)
   subdirs:
     - snowdrop-core
     - snowdrop-util
@@ -62,7 +62,7 @@ extra-deps:
 - primitive-0.6.4.0
 
 - git: https://github.com/serokell/lootbox.git
-  commit: b66d53bf42e88d44184046f3450ab2f01bd9c8b6
+  commit: 8b35882bbc918007f21ef75054c993268a6b467a
   subdirs:
     - code/base
     - code/config

--- a/witness/src/Dscp/DB/CanProvideDB/Proxied.hs
+++ b/witness/src/Dscp/DB/CanProvideDB/Proxied.hs
@@ -1,9 +1,9 @@
 
 module Dscp.DB.CanProvideDB.Proxied () where
 
-import Loot.Base.HasLens (HasLens', lensOf)
+import Loot.Base.HasLens (HasLens, lensOf)
 
 import Dscp.DB.CanProvideDB.Class
 
-instance (MonadReader ctx m, HasLens' ctx Plugin) => ProvidesPlugin m where
-    providePlugin = view (lensOf @Plugin)
+instance (MonadReader ctx m, HasLens ctx Plugin) => ProvidesPlugin m where
+    providePlugin = view lensOf

--- a/witness/src/Dscp/DB/Rocks/Real/Functions.hs
+++ b/witness/src/Dscp/DB/Rocks/Real/Functions.hs
@@ -28,13 +28,13 @@ module Dscp.DB.Rocks.Real.Functions
        , iterate
        ) where
 
-import Prelude hiding (get, put, iterate)
+import Prelude hiding (get, iterate, put)
 
 import Codec.Serialise
 import Control.Monad.Reader (MonadReader)
 import Control.Monad.Trans.Resource (runResourceT)
 import qualified Database.RocksDB as Rocks
-import Loot.Base.HasLens (HasLens')
+import Loot.Base.HasLens (HasLens)
 import System.Directory (doesDirectoryExist, removeDirectoryRecursive)
 import UnliftIO (MonadUnliftIO)
 
@@ -51,7 +51,7 @@ data DeserialisationError = DeserialisationError DeserialiseFailure
 
 instance Exception DeserialisationError
 
-type HasRocksDB ctx m = (MonadReader ctx m, HasLens' ctx RocksDB, MonadIO m, MonadThrow m)
+type HasRocksDB ctx m = (MonadReader ctx m, HasLens ctx RocksDB, MonadIO m, MonadThrow m)
 
 openRocksDB :: MonadIO m => FilePath -> m DB
 openRocksDB path = do

--- a/witness/src/Dscp/DB/Rocks/Real/Types.hs
+++ b/witness/src/Dscp/DB/Rocks/Real/Types.hs
@@ -13,14 +13,14 @@ import Control.Lens (makeLenses, makeLensesWith)
 import Data.Aeson.Options (defaultOptions)
 import Data.Aeson.TH (deriveFromJSON)
 import qualified Database.RocksDB as Rocks
-import Loot.Base.HasLens (HasLens')
+import Loot.Base.HasLens (HasLens)
 
 import Dscp.Util (postfixLFields)
 
 -- | Set of constraints necessary to operate on real DB.
 type MonadRealDB ctx m =
     ( MonadReader ctx m
-    , HasLens' ctx RocksDB
+    , HasLens ctx RocksDB
     , MonadIO m
     , Monad m
     )

--- a/witness/src/Dscp/Network/Instances.hs
+++ b/witness/src/Dscp/Network/Instances.hs
@@ -2,7 +2,7 @@
 
 module Dscp.Network.Instances () where
 
-import Loot.Base.HasLens (HasLens')
+import Loot.Base.HasLens (HasLens)
 import Loot.Network.Class (NetworkingCli (..), NetworkingServ (..))
 import Loot.Network.ZMQ (ZTGlobalEnv, ZTNetCliEnv, ZTNetServEnv, ZmqTcp)
 import qualified Loot.Network.ZMQ.Instance as Z
@@ -10,7 +10,7 @@ import qualified Loot.Network.ZMQ.Instance as Z
 import Dscp.Rio (RIO)
 
 
-instance (HasLens' ctx ZTGlobalEnv, HasLens' ctx ZTNetCliEnv) =>
+instance (HasLens ctx ZTGlobalEnv, HasLens ctx ZTNetCliEnv) =>
          NetworkingCli ZmqTcp (RIO ctx) where
     type NodeId ZmqTcp = Z.ZTNodeId
     runClient = Z.runClientDefault
@@ -18,7 +18,7 @@ instance (HasLens' ctx ZTGlobalEnv, HasLens' ctx ZTNetCliEnv) =>
     updatePeers = Z.updatePeersDefault
     registerClient = Z.registerClientDefault
 
-instance (HasLens' ctx ZTGlobalEnv, HasLens' ctx ZTNetServEnv) =>
+instance (HasLens ctx ZTGlobalEnv, HasLens ctx ZTNetServEnv) =>
          NetworkingServ ZmqTcp (RIO ctx) where
     type CliId ZmqTcp = Z.ZTCliId
     runServer = Z.runServerDefault

--- a/witness/src/Dscp/Resource/Keys/Types.hs
+++ b/witness/src/Dscp/Resource/Keys/Types.hs
@@ -22,7 +22,7 @@ import Control.Lens (Getter, makeLenses, makeLensesWith, to)
 import Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.:), (.=))
 import Data.Aeson.Options (defaultOptions)
 import Data.Aeson.TH (deriveJSON)
-import Loot.Base.HasLens (HasLens', lensOf)
+import Loot.Base.HasLens (HasLens, glensOf)
 
 import Dscp.Core.Aeson ()
 import Dscp.Core.Foundation.Address
@@ -125,24 +125,24 @@ deriveJSON defaultOptions ''BaseKeyParams
 -- different key resources.
 ourSecretKey
     :: forall node ctx m.
-       (HasLens' ctx (KeyResources node), MonadReader ctx m)
+       (HasLens ctx (KeyResources node), MonadReader ctx m)
     => m SecretKey
-ourSecretKey = view $ lensOf @(KeyResources node) . krSecretKeyData . to skSecret
+ourSecretKey = view $ glensOf @node . krSecretKeyData . to skSecret
 
 ourPublicKey
     :: forall node ctx m.
-       (HasLens' ctx (KeyResources node), MonadReader ctx m)
+       (HasLens ctx (KeyResources node), MonadReader ctx m)
     => m PublicKey
-ourPublicKey = view $ lensOf @(KeyResources node) . krSecretKeyData . to skPublic
+ourPublicKey = view $ glensOf @node . krSecretKeyData . to skPublic
 
 ourAddress
     :: forall node ctx m.
-       (HasLens' ctx (KeyResources node), MonadReader ctx m)
+       (HasLens ctx (KeyResources node), MonadReader ctx m)
     => m Address
-ourAddress = view $ lensOf @(KeyResources node) . krSecretKeyData . to skAddress
+ourAddress = view $ glensOf @node . krSecretKeyData . to skAddress
 
 ourSecretKeyData
     :: forall node ctx m.
-       (MonadReader ctx m, HasLens' ctx (KeyResources node))
+       (MonadReader ctx m, HasLens ctx (KeyResources node))
     => m SecretKeyData
-ourSecretKeyData = view $ lensOf @(KeyResources node) . krSecretKeyData
+ourSecretKeyData = view $ glensOf @node . krSecretKeyData

--- a/witness/src/Dscp/Resource/Network.hs
+++ b/witness/src/Dscp/Resource/Network.hs
@@ -79,8 +79,8 @@ data NetCliResources = NetCliResources
 
 makeLenses ''NetCliResources
 
-instance HasLens ZTGlobalEnv NetCliResources ZTGlobalEnv where lensOf = ncGlobalEnv
-instance HasLens ZTNetCliEnv NetCliResources ZTNetCliEnv where lensOf = ncClientEnv
+instance HasLens NetCliResources ZTGlobalEnv where lensOf = ncGlobalEnv
+instance HasLens NetCliResources ZTNetCliEnv where lensOf = ncClientEnv
 
 instance WithNetLogging => AllocResource NetCliResources where
     type Deps NetCliResources = NetCliParams
@@ -116,9 +116,9 @@ data NetServResources = NetServResources
 
 makeLenses ''NetServResources
 
-instance HasLens ZTGlobalEnv NetServResources ZTGlobalEnv where lensOf = nsGlobalEnv
-instance HasLens ZTNetCliEnv NetServResources ZTNetCliEnv where lensOf = nsClientEnv
-instance HasLens ZTNetServEnv NetServResources ZTNetServEnv where lensOf = nsServerEnv
+instance HasLens NetServResources ZTGlobalEnv where lensOf = nsGlobalEnv
+instance HasLens NetServResources ZTNetCliEnv where lensOf = nsClientEnv
+instance HasLens NetServResources ZTNetServEnv where lensOf = nsServerEnv
 
 instance WithNetLogging => AllocResource NetServResources where
     type Deps NetServResources = NetServParams

--- a/witness/src/Dscp/Snowdrop/Mode.hs
+++ b/witness/src/Dscp/Snowdrop/Mode.hs
@@ -67,7 +67,7 @@ type MonadSD ctx m =
 -- This is terrible
 runSdRIO :: MonadSD ctx m => RIO LoggingIO a -> m a
 runSdRIO action = do
-    logger <- view (lensOf @LoggingIO)
+    logger <- view lensOf
     liftIO $ runRIO logger action
 
 -- | Snowdrop's @run..IO@ throw exceptions being wrapped into 'BaseMException',
@@ -78,7 +78,7 @@ unwrapSDBaseRethrow = wrapRethrow $ \(BaseMException e) -> e :: Exceptions
 -- | SdM runner, should be protected by some lock.
 runSdM :: (MonadSD ctx m, Lock.WithinReadSDLock) => SdM a -> m a
 runSdM action = do
-    blockDBA <- view (lensOf @SDVars) <&> SD.dmaAccessActions . nsBlockDBActions
+    blockDBA <- view lensOf <&> SD.dmaAccessActions . nsBlockDBActions
     plugin   <- providePlugin
     unwrapSDBaseRethrow $ do
         initAVLStorage @AvlHash plugin initAccounts
@@ -94,7 +94,7 @@ runStateSdM
     :: (MonadSD ctx m, Lock.WithinReadSDLock)
     => StateSdM a -> m a
 runStateSdM action = do
-    stateDBA <- view (lensOf @SDVars) <&> SD.dmaAccessActions . nsStateDBActions
+    stateDBA <- view lensOf <&> SD.dmaAccessActions . nsStateDBActions
     plugin   <- providePlugin
     unwrapSDBaseRethrow $ do
         initAVLStorage @AvlHash plugin initAccounts

--- a/witness/src/Dscp/Web/Server.hs
+++ b/witness/src/Dscp/Web/Server.hs
@@ -9,7 +9,7 @@ module Dscp.Web.Server
        ) where
 
 import Control.Lens (views)
-import Loot.Base.HasLens (HasLens', lensOf)
+import Loot.Base.HasLens (HasLens, lensOf)
 import Loot.Log (Logging, Message (..), MonadLogging, Name, NameSelector (..))
 import qualified Loot.Log.Internal as Log
 import Network.HTTP.Client.TLS (newTlsManager)
@@ -36,11 +36,11 @@ serveWeb addr = liftIO . Warp.runSettings (warpSettings addr)
 
 -- | Grab logging context and build config for servant requests logging.
 buildServantLogConfig
-    :: (MonadReader ctx m, HasLens' ctx (Logging IO), MonadLogging m)
+    :: (MonadReader ctx m, HasLens ctx (Logging IO), MonadLogging m)
     => (Name -> Name) -> m ServantLogConfig
 buildServantLogConfig modifyName = do
     origNameSel <- Log.logName
-    logger <- views (lensOf @(Logging IO)) Log._log
+    logger <- views lensOf Log._log
     let origName = case origNameSel of
                        GivenName x -> x
                        _           -> mempty

--- a/witness/src/Dscp/Witness/Launcher/Context.hs
+++ b/witness/src/Dscp/Witness/Launcher/Context.hs
@@ -21,7 +21,7 @@ module Dscp.Witness.Launcher.Context
 
 import Control.Lens (makeLenses)
 
-import Loot.Base.HasLens (HasCtx, HasLens')
+import Loot.Base.HasLens (HasCtx, HasLens)
 import Loot.Log.Rio (LoggingIO)
 import Loot.Network.Class (NetworkingCli, NetworkingServ)
 import Loot.Network.ZMQ as Z
@@ -70,9 +70,9 @@ type NetworkMode ctx m =
     ( NetworkingCli ZmqTcp m
     , NetworkingServ ZmqTcp m
 
-    , HasLens' ctx Z.ZTGlobalEnv
-    , HasLens' ctx Z.ZTNetCliEnv
-    , HasLens' ctx Z.ZTNetServEnv
+    , HasLens ctx Z.ZTGlobalEnv
+    , HasLens ctx Z.ZTNetCliEnv
+    , HasLens ctx Z.ZTNetServEnv
     )
 
 -- | Full set of typeclasses which define capabilities of Witness node.

--- a/witness/src/Dscp/Witness/Launcher/Resource.hs
+++ b/witness/src/Dscp/Witness/Launcher/Resource.hs
@@ -70,7 +70,7 @@ instance AllocResource WitnessResources where
     type Deps WitnessResources = WitnessConfigRec
     allocResource witnessCfg = do
         let cfg = witnessCfg ^. sub #witness
-        _wrLogging <- view (lensOf @LoggingIO)
+        _wrLogging <- view lensOf
         _wrDB <- fmap RealRocks.plugin . allocResource $ cfg ^. option #db
         _wrNetwork <- do
             let modGivenName (GivenName x) = GivenName $ x <> "network"

--- a/witness/src/Dscp/Witness/Listeners/Listener.hs
+++ b/witness/src/Dscp/Witness/Listeners/Listener.hs
@@ -28,7 +28,7 @@ import Dscp.Witness.SDLock
 
 witnessListeners :: WitnessWorkMode ctx m => m [Listener m]
 witnessListeners = do
-    relayState <- view (lensOf @RelayState)
+    relayState <- view lensOf
     return
         [ blockIssuingListener
         , getBlocksListener

--- a/witness/src/Dscp/Witness/Logic/Apply.hs
+++ b/witness/src/Dscp/Witness/Logic/Apply.hs
@@ -33,7 +33,7 @@ applyBlockRaw
     -> m AvlProof
 applyBlockRaw applyFees block = do
     plugin <- providePlugin
-    sdActions <- view (lensOf @SDVars)
+    sdActions <- view lensOf
 
     let sdOSParamsBuilder = nsSDParamsBuilder sdActions
     let blockDBM = nsBlockDBActions sdActions

--- a/witness/src/Dscp/Witness/Relay.hs
+++ b/witness/src/Dscp/Witness/Relay.hs
@@ -15,7 +15,7 @@ import qualified Data.Text.Buildable
 import qualified Text.Show
 import qualified UnliftIO.Exception as UIO
 
-import Loot.Base.HasLens (HasLens (..), HasLens')
+import Loot.Base.HasLens (HasLens (..))
 
 import Dscp.Core
 import Dscp.Crypto
@@ -54,11 +54,11 @@ newRelayState = atomically $
         <*> STM.newTVar mempty
 
 relayTx
-    :: (MonadReader ctx m, HasLens' ctx RelayState, MonadIO m)
+    :: (MonadReader ctx m, HasLens ctx RelayState, MonadIO m)
     => GTxWitnessed
     -> m (Waiter "tx in mempool")
 relayTx tx = do
-    input <- view (lensOf @RelayState . rsInput)
+    input <- view (lensOf . rsInput)
     (notifier, waiter) <- newWaitPair
     isFull <- atomically $ do
         full <- STM.isFullTBQueue input

--- a/witness/src/Dscp/Witness/SDLock.hs
+++ b/witness/src/Dscp/Witness/SDLock.hs
@@ -10,7 +10,7 @@ module Dscp.Witness.SDLock
 
 import qualified Control.Concurrent.ReadWriteLock as RawLock
 import Data.Reflection (Given, give)
-import Loot.Base.HasLens (HasLens (..), HasLens')
+import Loot.Base.HasLens (HasLens (..))
 import Loot.Log (MonadLogging)
 import Time (sec)
 import qualified UnliftIO
@@ -46,25 +46,25 @@ readingSDLock
     ::  ( UnliftIO.MonadUnliftIO m
         , MonadReader ctx m
         , MonadLogging m
-        , HasLens' ctx SDLock
+        , HasLens ctx SDLock
         )
     => (WithinReadSDLock => m a)
     -> m a
 readingSDLock action = do
-    lock <- view (lensOf @SDLock)
+    lock <- view lensOf
     readingSDLockOf lock action
 
 writingSDLock
     ::  ( UnliftIO.MonadUnliftIO m
         , MonadReader ctx m
         , MonadLogging m
-        , HasLens' ctx SDLock
+        , HasLens ctx SDLock
         )
     => Text
     -> (WithinWriteSDLock => m a)
     -> m a
 writingSDLock desc action = do
-    lock <- view (lensOf @SDLock)
+    lock <- view lensOf
     logWarningWaitInf (sec 1) desc $
         writingSDLockOf lock action
 

--- a/witness/src/Dscp/Witness/TestConfig.hs
+++ b/witness/src/Dscp/Witness/TestConfig.hs
@@ -21,7 +21,7 @@ import Control.Lens (makeLenses, (.=), (?=))
 import Data.Default (def)
 import qualified Data.List as L
 import qualified Data.Map as M
-import Loot.Base.HasLens (HasLens')
+import Loot.Base.HasLens (HasLens)
 import Loot.Config.Record (finaliseDeferredUnsafe, option, sub)
 
 import Dscp.Core
@@ -40,7 +40,7 @@ import Dscp.Witness.SDLock
 
 type TestWitnessWorkMode ctx m =
     ( WitnessWorkMode ctx m
-    , HasLens' ctx TestTimeActions
+    , HasLens ctx TestTimeActions
     )
 
 testGenesisSecrets :: [SecretKey]

--- a/witness/src/Dscp/Witness/Workers/Worker.hs
+++ b/witness/src/Dscp/Witness/Workers/Worker.hs
@@ -37,7 +37,7 @@ witnessWorkers
     :: FullWitnessWorkMode ctx m
     => m [Worker m]
 witnessWorkers = do
-    relayState <- view (lensOf @RelayState)
+    relayState <- view lensOf
     let (inputReader, subReader) = makeRelay relayState
     return [blockUpdateWorker, inputReader, subReader]
 

--- a/witness/tests/Test/Dscp/Witness/Common.hs
+++ b/witness/tests/Test/Dscp/Witness/Common.hs
@@ -5,7 +5,7 @@ module Test.Dscp.Witness.Common
     , dumpBlock
     ) where
 
-import Loot.Base.HasLens (lensOf)
+import Loot.Base.HasLens (glensOf)
 
 import Dscp.Core
 import Dscp.Crypto
@@ -37,7 +37,7 @@ dumpBlock = do
     slotId <- rewindToNextSlot
     let issuerKey = KeyResources . mkSecretKeyData $ testFindSlotOwner slotId
 
-    local (lensOf @(KeyResources WitnessNode) .~ issuerKey) $ do
+    local (glensOf @WitnessNode .~ issuerKey) $ do
         block <- createBlock slotId
         void $ applyBlock block
         return (headerHash block)


### PR DESCRIPTION
### Description

Where there is no need to specify a tag anymore.
Although now instead of `lensOf @a` you have to write `lensOf @_ @a`, which is the case
in a few places.

This all is arguable, the more people express their concerns the better the overall result
will be.

**Before merge:**
- [ ] Depend on lootbox commit in master.
- [ ] Depend on blockchain-util commit in a reasonable branch.

### YT issue

https://issues.serokell.io/issue/LTB-52

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
