### PR TITLE
Revert "[DSCP-406] Remove DBT"

### DIFF
--- a/core/src/Dscp/Util/Test.hs
+++ b/core/src/Dscp/Util/Test.hs
@@ -44,7 +44,6 @@ import Test.QuickCheck.Arbitrary.Generic as T (genericArbitrary, genericShrink)
 import Test.QuickCheck.Gen (Gen (..))
 import Test.QuickCheck.Instances as T ()
 import Test.QuickCheck.Monadic as T (PropertyM, monadic, pick, stop)
-import Test.QuickCheck.Monadic (PropertyM (..))
 import Test.QuickCheck.Property as T (failed, rejected, succeeded)
 import Test.QuickCheck.Property (reason)
 import Test.QuickCheck.Random (QCGen, mkQCGen)
@@ -192,17 +191,6 @@ pickSmall = pick . Q.resize 5
 -- | Decrease required number of successful runs of the test case.
 divideMaxSuccessBy :: Int -> SpecWith a -> SpecWith a
 divideMaxSuccessBy times = modifyMaxSuccess $ max 1 . (`div` times)
-
--- | Change the monad under 'PropertyM'.
--- Note that your hoist functions can be invoked several times, so
--- it doesn't fit for e.g. converting to/from State monad.
-hoistPropertyM
-    :: (forall a. m a -> n a)
-    -> (forall a. n a -> m a)
-    -> PropertyM m r
-    -> PropertyM n r
-hoistPropertyM hst1 hst2 (MkPropertyM action) =
-    MkPropertyM $ \cont -> fmap hst1 $ action (fmap hst2 . cont)
 
 ----------------------------------------------------------------------------
 -- Helpers for data generation

--- a/educator/src/Dscp/Educator/DB/DSL/Interpret/Sqlite3.hs
+++ b/educator/src/Dscp/Educator/DB/DSL/Interpret/Sqlite3.hs
@@ -13,7 +13,9 @@ import Dscp.Educator.DB.Queries
 import Dscp.Educator.DB.Schema
 
 instance
-    ( MonadQuery m
+    ( MonadIO n
+    , MonadCatch n
+    , m ~ DBT t w n
     )
     => MonadSearchTxObj m
   where
@@ -28,8 +30,8 @@ instance
         getPrivateTxsByFilter txFilter
 
 getPrivateTxsByFilter
-    :: MonadQuery m
-    => TxsFilterExpr -> m [Core.PrivateTx]
+    :: MonadIO m
+    => TxsFilterExpr -> DBT t w m [Core.PrivateTx]
 getPrivateTxsByFilter filterExpr = do
     runSelectMap privateTxFromRow . select $ do
         privateTx <- all_ (esTransactions educatorSchema)

--- a/educator/src/Dscp/Educator/Web/Bot/Setting.hs
+++ b/educator/src/Dscp/Educator/Web/Bot/Setting.hs
@@ -254,7 +254,7 @@ botProvideCourses student courses = do
 botProvideInitSetting :: (BotWorkMode ctx m, HasBotSetting) => Student -> m ()
 botProvideInitSetting student = do
     maybePresent $ do
-        invoke @() $ void $ createStudent student
+        void . invoke $ createStudent student
         botProvideCourses student (bsBasicCourses botSetting)
         botLog . logInfo $ "Registered student " +| student |+ ""
 
@@ -277,4 +277,4 @@ botGradeSubmission ssub = do
             , _ptGrade = grade
             , _ptTime = time
             }
-    maybePresent $ transactW $ createTransaction ptx
+    maybePresent . transactW $ createTransaction ptx

--- a/educator/src/Dscp/Educator/Web/Educator/Handlers.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Handlers.hs
@@ -35,10 +35,10 @@ educatorApiHandlers =
         invoke $ educatorGetStudents mCourse
 
     , eAddStudent = \(NewStudent student) ->
-        void $ invoke $ createStudent student
+        void . invoke $ createStudent student
 
-    , eDeleteStudent = \student ->
-        invoke $ educatorRemoveStudent student
+    , eDeleteStudent =
+        invoke ... educatorRemoveStudent
 
     , eAddStudentCourse = \student (NewStudentCourse course) ->
         transactW $ enrollStudentToCourse student course
@@ -46,8 +46,8 @@ educatorApiHandlers =
     , eAddStudentAssignment = \student (NewStudentAssignment assignmentHash) ->
         transactW $ setStudentAssignment student assignmentHash
 
-    , eDeleteStudentAssignment = \student assignment ->
-        invoke $ educatorUnassignFromStudent student assignment
+    , eDeleteStudentAssignment =
+        invoke ... educatorUnassignFromStudent
 
       -- Courses
 
@@ -61,8 +61,8 @@ educatorApiHandlers =
             , cdSubjects = subjects
             }
 
-    , eGetCourse = \courseId ->
-        transactR $ educatorGetCourse courseId
+    , eGetCourse =
+        invoke ... educatorGetCourse
 
       -- Assignments
 
@@ -71,7 +71,7 @@ educatorApiHandlers =
             def{ afCourse, afStudent, afIsFinal }
 
     , eAddAssignment = \_autoAssign na -> do
-        void $ transactW $ createAssignment (requestToAssignment na)
+        void . transactW $ createAssignment (requestToAssignment na)
         -- TODO [DSCP-176]: consider autoassign
 
       -- Submissions
@@ -80,8 +80,8 @@ educatorApiHandlers =
         invoke $ educatorGetSubmissions
             def{ sfCourse, sfStudent, sfAssignmentHash }
 
-    , eGetSubmission = \submissionId ->
-        invoke $ educatorGetSubmission submissionId
+    , eGetSubmission =
+        invoke ... educatorGetSubmission
 
     , eDeleteSubmission = \submissionH ->
         transactW $ commonDeleteSubmission submissionH Nothing
@@ -92,7 +92,7 @@ educatorApiHandlers =
         invoke $ educatorGetGrades course student assignment isFinalF
 
     , eAddGrade = \(NewGrade subH grade) ->
-        transactW $ educatorPostGrade subH grade
+        invoke $ educatorPostGrade subH grade
 
       -- Proofs
 

--- a/educator/src/Dscp/Educator/Web/Logic.hs
+++ b/educator/src/Dscp/Educator/Web/Logic.hs
@@ -19,9 +19,9 @@ import Dscp.Witness.Logic.Getters
 import Dscp.Witness.SDLock
 
 commonGetProofs
-    :: (MonadEducatorWebQuery m, WithinTx)
+    :: MonadEducatorWebQuery m
     => GetProvenStudentTransactionsFilters
-    -> m [BlkProofInfo]
+    -> DBT 'WithinTx w m [BlkProofInfo]
 commonGetProofs filters = do
     rawProofs <- getProvenStudentTransactions filters
     return

--- a/educator/src/Dscp/Educator/Web/Queries.hs
+++ b/educator/src/Dscp/Educator/Web/Queries.hs
@@ -53,7 +53,7 @@ commonExistsSubmission
     :: MonadEducatorWebQuery m
     => Hash Submission
     -> Maybe Student
-    -> m Bool
+    -> DBT t w m Bool
 commonExistsSubmission submissionH studentF =
     checkExists $ do
         submission <- all_ (esSubmissions es)
@@ -63,7 +63,7 @@ commonExistsSubmission submissionH studentF =
 -- | Whether a submission has taken any grade.
 isGradedSubmission
     :: MonadEducatorWebQuery m
-    => Hash Submission -> m Bool
+    => Hash Submission -> DBT t w m Bool
 isGradedSubmission submissionH =
     checkExists $ do
         privateTx <- all_ (esTransactions es)
@@ -77,10 +77,10 @@ isGradedSubmission submissionH =
 -- If student is supplied, then submissions owned by other students won't be
 -- visible/affected.
 commonDeleteSubmission
-    :: (MonadEducatorWebQuery m, WithinWriteTx)
+    :: MonadEducatorWebQuery m
     => Hash Submission
     -> Maybe Student
-    -> m ()
+    -> DBT 'WithinTx 'Writing m ()
 commonDeleteSubmission submissionH studentF = do
     commonExistsSubmission submissionH studentF
         `assert` AbsentError (SubmissionDomain submissionH)

--- a/educator/src/Dscp/Educator/Web/Server.hs
+++ b/educator/src/Dscp/Educator/Web/Server.hs
@@ -20,10 +20,10 @@ import Servant ((:<|>) (..), Context (..), Handler, ServantErr (..), Server, Std
                 hoistServerWithContext, serveWithContext)
 import Servant.Auth.Server.Internal.ThrowAll (throwAll)
 import Servant.Generic (toServant)
-import UnliftIO (UnliftIO (..), askUnliftIO)
+import UnliftIO (askUnliftIO)
 
 import Dscp.Core (mkAddr)
-import Dscp.DB.SQLite (invoke)
+import Dscp.DB.SQLite (SQLiteDB, invoke)
 import Dscp.Educator.Config
 import Dscp.Educator.DB (existsStudent)
 import Dscp.Educator.Launcher.Mode (EducatorNode, EducatorWorkMode)
@@ -86,10 +86,10 @@ createStudentCheckAction
 createStudentCheckAction EducatorBotParams {..}
     | ebpEnabled = return . StudentCheckAction . const $ pure True
     | otherwise = do
-          UnliftIO unliftIO <- askUnliftIO
+          db <- view (lensOf @SQLiteDB)
           return . StudentCheckAction $ \pk ->
               let addr = mkAddr pk
-              in unliftIO (invoke $ existsStudent addr)
+              in runReaderT (invoke $ existsStudent addr) db
 
 -- | CORS is enabled to ease development for frontend team.
 educatorCors :: Middleware

--- a/educator/src/Dscp/Educator/Web/Student/Queries.hs
+++ b/educator/src/Dscp/Educator/Web/Student/Queries.hs
@@ -57,7 +57,7 @@ es = educatorSchema
 
 studentIsCourseFinished
     :: MonadEducatorWebQuery m
-    => Id Student -> Course -> m Bool
+    => Id Student -> Course -> DBT t w m Bool
 studentIsCourseFinished studentId' courseId' =
     checkExists $ do
         privateTx <- all_ (esTransactions es)
@@ -69,8 +69,8 @@ studentIsCourseFinished studentId' courseId' =
         guard_ (isPositiveGradeQ (trGrade privateTx))
 
 studentGetCourse
-    :: (MonadEducatorWebQuery m, WithinTx)
-    => Id Student -> Course -> m CourseStudentInfo
+    :: MonadEducatorWebQuery m
+    => Id Student -> Course -> DBT 'WithinTx w m CourseStudentInfo
 studentGetCourse studentId courseId = do
     ciDesc <- selectByPk crDesc (esCourses es) courseId
         `assertJust` AbsentError (CourseDomain courseId)
@@ -80,8 +80,8 @@ studentGetCourse studentId courseId = do
     return CourseStudentInfo{ ciId = courseId, .. }
 
 studentGetCourses
-    :: (MonadEducatorWebQuery m, WithinTx)
-    => Id Student -> Maybe IsEnrolled -> m [CourseStudentInfo]
+    :: MonadEducatorWebQuery m
+    => Id Student -> Maybe IsEnrolled -> DBT 'WithinTx w m [CourseStudentInfo]
 studentGetCourses studentId (coerce -> isEnrolledF) = do
     courses <- runSelect . select $ do
         course <- all_ (esCourses es)
@@ -100,9 +100,9 @@ studentGetCourses studentId (coerce -> isEnrolledF) = do
 
 studentGetGrade
     :: MonadEducatorWebQuery m
-    => Hash Submission -> m (Maybe GradeInfo)
+    => Hash Submission -> DBT 'WithinTx w m (Maybe GradeInfo)
 studentGetGrade submissionH = do
-    mgrade <- fmap maybeOneOrError . runSelect . select $ do
+    mgrade <- listToMaybeWarnM . runSelect . select $ do
         ptx <- all_ (esTransactions es)
         let SubmissionRowId subH = trSubmission ptx
         guard_ (subH ==. val_ submissionH)
@@ -113,12 +113,12 @@ studentGetGrade submissionH = do
         return GradeInfo{..}
 
 studentGetLastAssignmentSubmission
-    :: (MonadEducatorWebQuery m, WithinTx)
+    :: MonadEducatorWebQuery m
     => Student
     -> Hash Assignment
-    -> m (Maybe SubmissionStudentInfo)
+    -> DBT 'WithinTx w m (Maybe SubmissionStudentInfo)
 studentGetLastAssignmentSubmission student assignH = do
-    msubmission <- fmap maybeOneOrError . runSelect . select $ do
+    msubmission <- listToMaybeWarnM . runSelect . select $ do
         submission <- limit_ 1 . orderBy_ (desc_ . srCreationTime) $
                       all_ (esSubmissions es)
         guard_ (srAssignment submission ==. valPk_ assignH)
@@ -132,11 +132,11 @@ studentGetLastAssignmentSubmission student assignH = do
 
 -- | Helper to post-process fetched assignment and full it with missing info.
 studentComplementAssignmentInfo
-    :: (MonadEducatorWebQuery m, WithinTx)
+    :: MonadEducatorWebQuery m
     => Student
     -> Hash Assignment
     -> Assignment
-    -> m AssignmentStudentInfo
+    -> DBT 'WithinTx w m AssignmentStudentInfo
 studentComplementAssignmentInfo student assignH assignment = do
     aiLastSubmission <- studentGetLastAssignmentSubmission student assignH
     return AssignmentStudentInfo
@@ -150,26 +150,26 @@ studentComplementAssignmentInfo student assignH assignment = do
 
 -- | Get exactly one assignment.
 studentGetAssignment
-    :: (MonadEducatorWebQuery m, WithinTx)
+    :: MonadEducatorWebQuery m
     => Student
     -> Hash Assignment
-    -> m AssignmentStudentInfo
+    -> DBT 'WithinTx w m AssignmentStudentInfo
 studentGetAssignment student assignH = do
     assignments <- runSelectMap assignmentFromRow . select $ do
         assignment <- related_ (esAssignments es) (valPk_ assignH)
         link_ (esStudentAssignments es) (valPk_ student :-: pk_ assignment)
         return assignment
     assignment <-
-        nothingToThrow (AbsentError $ AssignmentDomain assignH) $
-            maybeOneOrError assignments
+        listToMaybeWarn assignments
+        >>= nothingToThrow (AbsentError $ AssignmentDomain assignH)
     studentComplementAssignmentInfo student assignH assignment
 
 -- | Get student assignments.
 studentGetAssignments
-    :: (MonadEducatorWebQuery m, WithinTx)
+    :: MonadEducatorWebQuery m
     => Student
     -> StudentGetAssignmentsFilters
-    -> m [AssignmentStudentInfo]
+    -> DBT 'WithinTx w m [AssignmentStudentInfo]
 studentGetAssignments student filters = do
     assignments <- runSelectMap (arHash &&& assignmentFromRow) . select $ do
         assignment <- all_ (esAssignments es)
@@ -192,7 +192,7 @@ studentGetSubmission
     :: MonadEducatorWebQuery m
     => Student
     -> Hash Submission
-    -> m SubmissionStudentInfo
+    -> DBT t w m SubmissionStudentInfo
 studentGetSubmission student subH = do
     submissions <- runSelectMap studentSubmissionInfoFromRow . select $ do
         submission <- related_ (esSubmissions es) (valPk_ subH)
@@ -203,15 +203,15 @@ studentGetSubmission student subH = do
                                 ((`references_` submission) . trSubmission)
 
         return (submission, mPrivateTx)
-    maybeOneOrError submissions
-        & nothingToThrow (AbsentError $ SubmissionDomain subH)
+    listToMaybeWarn submissions
+        >>= nothingToThrow (AbsentError $ SubmissionDomain subH)
 
 -- | Get student submissions.
 studentGetSubmissions
     :: MonadEducatorWebQuery m
     => Student
     -> StudentGetSubmissionsFilters
-    -> m [SubmissionStudentInfo]
+    -> DBT t w m [SubmissionStudentInfo]
 studentGetSubmissions student filters = do
     runSelectMap studentSubmissionInfoFromRow . select $ do
         submission <- all_ (esSubmissions es)

--- a/educator/src/Dscp/Educator/Web/Types.hs
+++ b/educator/src/Dscp/Educator/Web/Types.hs
@@ -33,6 +33,7 @@ import Data.Aeson.TH (deriveJSON)
 import Data.Time.Clock (UTCTime)
 import Fmt (build, (+|), (+||), (|+), (||+))
 import Loot.Base.HasLens (HasCtx)
+import Loot.Log (ModifyLogName, MonadLogging)
 import Servant (FromHttpApiData (..), ToHttpApiData)
 
 import Dscp.Core
@@ -46,8 +47,10 @@ import Dscp.Util.Servant
 import Dscp.Witness.Launcher.Context
 
 type MonadEducatorWebQuery m =
-    ( MonadQuery m
+    ( MonadIO m
     , MonadCatch m
+    , MonadLogging m
+    , ModifyLogName m
     )
 
 type MonadEducatorWeb ctx m =

--- a/educator/tests/Test/Dscp/DB/SQLite/Queries.hs
+++ b/educator/tests/Test/Dscp/DB/SQLite/Queries.hs
@@ -19,30 +19,30 @@ spec_Instances = do
     describe "Basic database operations" $ do
         describe "Courses" $ do
             it "Course does not exist before it is created" $
-                sqliteProperty $ \_ctx courseId -> do
+                sqliteProperty $ \courseId -> do
                     isThere <- DB.existsCourse courseId
                     return (not isThere)
 
             it "Course does exist after it is created" $
-                sqliteProperty $ \_ctx courseId -> do
+                sqliteProperty $ \courseId -> do
                     _       <- DB.createCourse (simpleCourse courseId)
                     isThere <- DB.existsCourse courseId
 
                     return isThere
 
             it "Can create unique courses relying on autoincrement" $
-                sqliteProperty $ \_ctx n -> do
+                sqliteProperty $ \n -> do
                     ids <- replicateM n $ DB.createCourse nullCourse
                     return $ allUniqueOrd ids
 
         describe "Students" $ do
             it "Student does not exist before she is created" $
-                sqliteProperty $ \_ctx student -> do
+                sqliteProperty $ \student -> do
                     isThere <- DB.existsStudent student
                     return (not isThere)
 
             it "Student does exist after she is created" $
-                sqliteProperty $ \_ctx student -> do
+                sqliteProperty $ \student -> do
                     _       <- DB.createStudent student
                     isThere <- DB.existsStudent student
 
@@ -50,7 +50,7 @@ spec_Instances = do
 
         describe "Assignments" $ do
             it "Assignment is created and retrieved by hash" $
-                sqliteProperty $ \_ctx assignment -> do
+                sqliteProperty $ \assignment -> do
 
                     _              <- DB.createCourse    (simpleCourse $ assignment^.aCourseId)
                     assignmentHash <- DB.createAssignment assignment
@@ -59,20 +59,20 @@ spec_Instances = do
                     return (assignment' == Just assignment)
 
             it "Assignment is not created if course does not exist" $
-                sqliteProperty $ \_ctx (assignment) -> do
+                sqliteProperty $ \(assignment) -> do
                     throws @DomainError $ do
                         _ <- DB.createAssignment assignment
                         return ()
 
         describe "Submissions" $ do
             it "Submission is not created unless Assignment exist" $
-                sqliteProperty $ \_ctx submission -> do
+                sqliteProperty $ \submission -> do
                     throws @DomainError $ do
                         _ <- DB.createSignedSubmission submission
                         return ()
 
             it "Submission is not created unless Student exist" $
-                sqliteProperty $ \_ctx
+                sqliteProperty $ \
                     ( delayedGen (genCoreTestEnv simpleCoreTestParams) -> env
                     ) -> do
                     let assignment    = tiOne $ cteAssignments env
@@ -88,7 +88,7 @@ spec_Instances = do
                         return ()
 
             it "Submission is not created unless StudentAssignment exist" $
-                sqliteProperty $ \_ctx
+                sqliteProperty $ \
                     ( delayedGen (genCoreTestEnv simpleCoreTestParams) -> env
                     ) -> do
                     let assignment    = tiOne $ cteAssignments env
@@ -108,7 +108,7 @@ spec_Instances = do
 
         describe "Transactions" $ do
             it "Transaction is created if all deps exist" $
-                sqliteProperty $ \_ctx
+                sqliteProperty $ \
                     ( delayedGen (genCoreTestEnv simpleCoreTestParams) -> env
                     ) -> do
                     let assignment    = tiOne $ cteAssignments env
@@ -133,7 +133,7 @@ spec_Instances = do
 
     describe "Concrete operations from domain" $ do
         it "getStudentCourses/enrollStudentToCourse" $ do
-            sqliteProperty $ \_ctx
+            sqliteProperty $ \
                 (student,
                  delayedGen (vectorUnique 3)
                     -> [course1, course2, course3]
@@ -155,7 +155,7 @@ spec_Instances = do
                 return (sort (map getId courses) == sort courseIds')
 
         it "getStudentAssignments" $ do
-            sqliteProperty $ \_ctx
+            sqliteProperty $ \
                 ( student
                 , (delayedGen (vectorUnique 2)
                     -> [course1, course2])
@@ -204,7 +204,7 @@ spec_Instances = do
                             (assignments1 <> assignments2) `equal` toHer
 
         it "submitAssignment" $
-            sqliteProperty $ \_ctx
+            sqliteProperty $ \
                 ( delayedGen (genCoreTestEnv simpleCoreTestParams) -> env
                 ) -> do
                 let assignment    = tiOne $ cteAssignments env
@@ -226,7 +226,7 @@ spec_Instances = do
                 return (sub' == Just sigSubmission)
 
         it "getGradesForCourseAssignments" $
-            sqliteProperty $ \_ctx
+            sqliteProperty $ \
                 ( delayedGen (genCoreTestEnv simpleCoreTestParams) -> env
                 , course2
                 ) -> do
@@ -274,7 +274,7 @@ spec_Instances = do
 
     -- describe "Retrieval of proven transactions" $ do
     --     it "getProvenStudentTransactions" $
-    --         sqliteProperty $ \ctx
+    --         sqliteProperty $ \
     --             ( delayedGen (genCoreTestEnv simpleCoreTestParams
     --                           `suchThat` ((>= 3) . tiNum . ctePrivateTxs)
     --                          ) -> env
@@ -302,7 +302,7 @@ spec_Instances = do
     --                     ptId <- DB.createTransaction trans
     --                     return ptId
 
-    --                 mblock <- DB.createPrivateBlock ctx Nothing
+    --                 mblock <- DB.createPrivateBlock Nothing
     --                 let !_ = mblock ?: error "No private block created"
 
     --                 transPacksSince <- DB.getProvenStudentTransactions

--- a/educator/tests/Test/Dscp/DB/SQLite/Real/Transactions.hs
+++ b/educator/tests/Test/Dscp/DB/SQLite/Real/Transactions.hs
@@ -24,7 +24,7 @@ type MonadMoney m = (MonadIO m, MonadCatch m, MonadUnliftIO m)
 
 type Money = Int
 
-prepareSchema :: MonadQuery m => m ()
+prepareSchema :: (MonadIO m) => DBT t 'Writing m ()
 prepareSchema =
     forM_ [createTableQuery, addAccountQuery] $
         \que -> withConnection $ \conn -> execute conn que ()
@@ -38,7 +38,7 @@ prepareSchema =
         insert into Accounts values (0);
         |]
 
-getMoney :: MonadQuery m => m Money
+getMoney :: MonadIO m => DBT t w m Money
 getMoney = withConnection $ \conn ->
            fromOnly . L.head <$> query conn queryText ()
   where
@@ -46,7 +46,7 @@ getMoney = withConnection $ \conn ->
         select amount from Accounts
     |]
 
-setMoney :: MonadQuery m => Money -> m ()
+setMoney :: MonadIO m => Money -> DBT t 'Writing m ()
 setMoney val = withConnection $ \conn -> execute conn queryText (Only val)
   where
     queryText = [q|
@@ -55,7 +55,7 @@ setMoney val = withConnection $ \conn -> execute conn queryText (Only val)
 
 addMoney :: (MonadUnliftIO m, HasCtx ctx m '[SQLiteDB]) => m ()
 addMoney =
-    transactW $ do
+    transactW @'WithinTx $ do
         money <- getMoney
         setMoney (money + 1)
 

--- a/educator/tests/Test/Dscp/Educator/Web/Educator/Queries.hs
+++ b/educator/tests/Test/Dscp/Educator/Web/Educator/Queries.hs
@@ -25,14 +25,14 @@ spec_EducatorApiQueries :: Spec
 spec_EducatorApiQueries = describe "Basic database operations" $ do
   describe "Students" $ do
     describe "getStudents" $ do
-        it "Returns previously added students" $ sqlitePropertyM $ \_ctx -> do
+        it "Returns previously added students" $ sqlitePropertyM $ do
             students <- pickSmall listUnique
             lift $ forM_ students createStudent
 
             students' <- lift $ educatorGetStudents Nothing
             return $ sort students' === sort (map StudentInfo students)
 
-        it "Filtering works" $ sqlitePropertyM $ \_ctx -> do
+        it "Filtering works" $ sqlitePropertyM $ do
             students@[student1, student2] <- pick $ vectorUnique 2
             courses@[course1, course2] <- pick $ vectorUnique 2
             lift $ do
@@ -49,7 +49,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
 
   describe "Courses" $ do
     describe "getCourses" $ do
-        it "Returns previously added courses" $ sqlitePropertyM $ \_ctx -> do
+        it "Returns previously added courses" $ sqlitePropertyM $ do
             coursesDetails <- nubBy ((==) `on` cdCourseId) <$>
                               pickSmall (listOf genCourseNoSubjects)
             lift $ forM_ coursesDetails createCourse
@@ -66,7 +66,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
                 sort coursesBone === sort coursesBone'
 
     describe "getCourses" $ do
-        it "Filtering works" $ sqlitePropertyM $ \_ctx -> do
+        it "Filtering works" $ sqlitePropertyM $ do
             students@[student1, student2] <- pick $ vectorUnique 2
             courses@[course1, course2] <- pick $ vectorUnique 2
             lift $ do
@@ -82,14 +82,14 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
                 .&&. map ciId res2 === one (course1)
 
     describe "getCourse" $ do
-        it "Fails on request of non-existent course" $ sqlitePropertyM $ \_ctx -> do
+        it "Fails on request of non-existent course" $ sqlitePropertyM $ do
             env <- pickSmall $ genCoreTestEnv simpleCoreTestParams
             let course = tiOne $ cteCourses env
 
             lift . throwsPrism (_AbsentError . _CourseDomain) $
                 educatorGetCourse (getId course)
 
-        it "Returns existing course properly" $ sqlitePropertyM $ \_ctx -> do
+        it "Returns existing course properly" $ sqlitePropertyM $ do
             env <- pickSmall $ genCoreTestEnv simpleCoreTestParams
             course <- lift $ createCourse . simpleCourse . tiOne . cteCourses $ env
 
@@ -104,7 +104,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
         -- Similar endpoint is fully covered by tests for Student API,
         -- so just checking it at least works.
 
-        it "Returns existing assignment properly" $ sqlitePropertyM $ \_ctx -> do
+        it "Returns existing assignment properly" $ sqlitePropertyM $ do
             env <- pickSmall $ genCoreTestEnv simpleCoreTestParams
             let assignment = tiOne $ cteAssignments env
             let student = tiOne $ cteStudents env
@@ -126,7 +126,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
 
   describe "Submissions" $ do
     describe "getSubmission" $ do
-        it "Fails on request of non-existent submission" $ sqlitePropertyM $ \_ctx -> do
+        it "Fails on request of non-existent submission" $ sqlitePropertyM $ do
             env <- pickSmall $ genCoreTestEnv simpleCoreTestParams
             let submission = tiOne $ cteSubmissions env
             let student = _sStudentId submission
@@ -136,7 +136,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
             lift . throwsPrism (_AbsentError . _SubmissionDomain) $
                 educatorGetSubmission (getId submission)
 
-        it "Returns existing submission properly" $ sqlitePropertyM $ \_ctx -> do
+        it "Returns existing submission properly" $ sqlitePropertyM $ do
             env <- pickSmall $ genCoreTestEnv simpleCoreTestParams
             let assignment = tiOne $ cteAssignments env
                 submission = tiOne $ cteSubmissions env
@@ -154,7 +154,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
                 }
 
     describe "getSubmissions" $ do
-        it "Student has no last submissions initially" $ sqlitePropertyM $ \_ctx -> do
+        it "Student has no last submissions initially" $ sqlitePropertyM $ do
             env <- pickSmall $ genCoreTestEnv simpleCoreTestParams
             lift $ prepareForAssignments env
             -- even after this ^ there should be no submissions
@@ -163,7 +163,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
             return $ submissions === []
 
         it "Returns existing submission properly" $
-          sqlitePropertyM $ \_ctx -> do
+          sqlitePropertyM $ do
             env <- pickSmall $ genCoreTestEnv wildCoreTestParams
             let submission = tiOne $ cteSubmissions env
                 signedSubmission = tiOne $ cteSignedSubmissions env
@@ -179,7 +179,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
                 , siWitness = _ssWitness signedSubmission
                 }
 
-        it "Returns grade when present" $ sqlitePropertyM $ \_ctx -> do
+        it "Returns grade when present" $ sqlitePropertyM $ do
             env <- pickSmall $ genCoreTestEnv simpleCoreTestParams
             let txs     = tiList $ ctePrivateTxs env
                 sigSubs = tiList $ cteSignedSubmissions env
@@ -202,7 +202,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
                 ===
                 sortOn fst submissionsAndGrades'
 
-        it "Filtering works" $ sqlitePropertyM $ \_ctx -> do
+        it "Filtering works" $ sqlitePropertyM $ do
             env <- pickSmall $ genCoreTestEnv simpleCoreTestParams
                                          { ctpAssignment = variousItems }
             courseIdF <- pick arbitrary
@@ -238,7 +238,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
 
   describe "Proofs" $ do
     describe "getProofs" $ do
-        it "No proofs initially" $ sqlitePropertyM $ \_ctx -> do
+        it "No proofs initially" $ sqlitePropertyM $ do
             env <- pickSmall $ genCoreTestEnv simpleCoreTestParams
             let student = tiOne $ cteStudents env
             lift $ prepareAndCreateSubmissions env
@@ -247,7 +247,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
 
             return $ proofs === []
 
-        it "Returns existing proof properly" $ sqlitePropertyM $ \ctx -> do
+        it "Returns existing proof properly" $ sqlitePropertyM $ do
             env <- pickSmall $ genCoreTestEnv simpleCoreTestParams
             let student = tiOne $ cteStudents env
                 ptx = tiOne $ ctePrivateTxs env
@@ -255,7 +255,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
             lift $ do
                 prepareAndCreateSubmissions env
                 void $ createTransaction ptx
-                mblock <- createPrivateBlock ctx Nothing
+                mblock <- createPrivateBlock Nothing
                 let !_ = mblock ?: error "No private block created"
                 return ()
 
@@ -264,7 +264,7 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
 
             return $ bpiTxs proof === [ptx]
 
-        it "Proofs are grouped properly" $ sqlitePropertyM $ \ctx -> do
+        it "Proofs are grouped properly" $ sqlitePropertyM $ do
             env <- pickSmall $ genCoreTestEnv simpleCoreTestParams
             let student = tiOne $ cteStudents env
                 ptxs = tiList $ ctePrivateTxs env
@@ -276,9 +276,9 @@ spec_EducatorApiQueries = describe "Basic database operations" $ do
                 prepareAndCreateSubmissions env
                 void $ createTransaction ptx1
                 void $ createTransaction ptx2
-                mblock1 <- createPrivateBlock ctx Nothing
+                mblock1 <- createPrivateBlock Nothing
                 void $ createTransaction ptx3
-                mblock2 <- createPrivateBlock ctx Nothing
+                mblock2 <- createPrivateBlock Nothing
                 let !_ = (mblock1 >> mblock2) ?: error "No private blocks created"
                 return ()
 

--- a/educator/tests/Test/Dscp/Educator/Web/Scenarios.hs
+++ b/educator/tests/Test/Dscp/Educator/Web/Scenarios.hs
@@ -19,8 +19,8 @@ import Dscp.Educator.DB
 -- | Puts in db all needed to put 'SignedSubmission's
 -- later, tolerates repeated entities.
 prepareForAssignments
-    :: (MonadQuery m, WithinWriteTx)
-    => CoreTestEnv -> m ()
+    :: (MonadIO m, MonadCatch m)
+    => CoreTestEnv -> DBT 'WithinTx 'Writing m ()
 prepareForAssignments CoreTestEnv{..} = do
     let assignments = F.toList cteAssignments
         courses = map _aCourseId assignments
@@ -34,8 +34,8 @@ prepareForAssignments CoreTestEnv{..} = do
 -- | Puts in db all needed to put 'SignedSubmission's
 -- later, tolerates repeated entities.
 prepareForSubmissions
-    :: (MonadQuery m, WithinWriteTx)
-    => CoreTestEnv -> m ()
+    :: (MonadIO m, MonadCatch m)
+    => CoreTestEnv -> DBT 'WithinTx 'Writing m ()
 prepareForSubmissions env@CoreTestEnv{..} = do
     let assignments = F.toList cteAssignments
         owners = F.toList cteStudents
@@ -47,8 +47,8 @@ prepareForSubmissions env@CoreTestEnv{..} = do
 
 -- | Prepare all needed to put 'SignedSubmission's, and puts the first one.
 prepareAndCreateSubmission
-    :: (MonadQuery m, WithinWriteTx)
-    => CoreTestEnv -> m ()
+    :: (MonadIO m, MonadCatch m)
+    => CoreTestEnv -> DBT 'WithinTx 'Writing m ()
 prepareAndCreateSubmission env = do
     prepareForSubmissions env
     let sigSub = tiOne $ cteSignedSubmissions env
@@ -56,8 +56,8 @@ prepareAndCreateSubmission env = do
 
 -- | Add all submissions from given test env to the database.
 prepareAndCreateSubmissions
-    :: (MonadQuery m, WithinWriteTx)
-    => CoreTestEnv -> m ()
+    :: (MonadIO m, MonadCatch m)
+    => CoreTestEnv -> DBT 'WithinTx 'Writing m ()
 prepareAndCreateSubmissions env@CoreTestEnv{..} = do
     prepareForSubmissions env
     let sigSubs = nub $ tiList cteSignedSubmissions
@@ -66,8 +66,8 @@ prepareAndCreateSubmissions env@CoreTestEnv{..} = do
 -- | Add all transactions from given test env to the database.
 -- Transactions will have no block assiged to them.
 prepareAndCreateTransactions
-    :: (MonadQuery m, WithinWriteTx)
-    => CoreTestEnv -> m ()
+    :: (MonadIO m, MonadCatch m)
+    => CoreTestEnv -> DBT 'WithinTx 'Writing m ()
 prepareAndCreateTransactions env@CoreTestEnv{..} = do
     prepareAndCreateSubmissions env
     let txs = nub $ tiList ctePrivateTxs

--- a/educator/tests/Test/Dscp/Educator/Web/Student/Queries.hs
+++ b/educator/tests/Test/Dscp/Educator/Web/Student/Queries.hs
@@ -56,7 +56,7 @@ submission1 : _ = detGen 23423 $ do
         <&> \(_sStudentId, _sContentsHash, (hash -> _sAssignmentHash))
             -> Submission{..}
 
-createCourseSimple :: (MonadQuery m, WithinWriteTx) => Int -> m Course
+createCourseSimple :: DBM m => Int -> DBT 'WithinTx 'Writing m Course
 createCourseSimple i =
     createCourse
         CourseDetails
@@ -91,7 +91,7 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
   describe "Courses" $ do
     describe "getCourse" $ do
         it "Student is not enrolled initially" $
-            sqliteProperty $ \_ctx () -> do
+            sqliteProperty $ \() -> do
                 _ <- createStudent student1
                 _ <- createCourseSimple 1
 
@@ -99,7 +99,7 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
                 return (not $ ciIsEnrolled course)
 
         it "Student gets enrolled when she asks to" $
-            sqliteProperty $ \_ctx () -> do
+            sqliteProperty $ \() -> do
                 _ <- createStudent student1
                 _ <- createCourseSimple 1
                 enrollStudentToCourse student1 courseId1
@@ -108,7 +108,7 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
                 return (ciIsEnrolled course)
 
         it "'Course' datatype is filled correctly" $
-            sqlitePropertyM $ \_ctx -> do
+            sqlitePropertyM $ do
                 courseDetails <- pick arbitrary
                 pre $ isJust (cdCourseId courseDetails)
                 let courseId = cdCourseId courseDetails
@@ -126,7 +126,7 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
                         }
 
         it "Student has vision proper for him" $
-            sqliteProperty $ \_ctx () -> do
+            sqliteProperty $ \() -> do
                 _ <- createStudent student1
                 _ <- createStudent student2
                 _ <- createCourseSimple 1
@@ -137,8 +137,8 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
                 return (not $ ciIsEnrolled course)
 
         it "Course 'isFinished' flag is correct" $
-            sqliteProperty $ \_ctx
-               ( delayedGen
+            sqliteProperty $
+              \( delayedGen
                  (genCoreTestEnv simpleCoreTestParams
                   { ctpAssignment = assignmentItemsForSameCourse }) -> env
                , delayedGen (infiniteList @(Maybe Grade)) -> mgrades
@@ -167,7 +167,7 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
 
     describe "getCourses" $ do
         it "Student is not enrolled initially" $
-            sqliteProperty $ \_ctx () -> do
+            sqliteProperty $ \() -> do
                 _ <- createStudent student1
                 _ <- createCourseSimple 1
 
@@ -175,7 +175,7 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
                 return . not $ any ciIsEnrolled courses
 
         it "Student gets enrolled when he asks to" $
-            sqliteProperty $ \_ctx () -> do
+            sqliteProperty $ \() -> do
                 _ <- createStudent student1
                 _ <- createCourseSimple 1
                 enrollStudentToCourse student1 courseId1
@@ -185,7 +185,7 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
                 return (ciIsEnrolled course1)
 
         it "'Course' datatype is filled correctly" $
-            sqliteProperty $ \_ctx
+            sqliteProperty $ \
               ( courseId
               , desc
               , delayedGen listUnique -> subjects
@@ -201,7 +201,7 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
                     }
 
         it "Student has vision proper for him" $
-            sqliteProperty $ \_ctx () -> do
+            sqliteProperty $ \() -> do
                 _ <- createStudent student1
                 _ <- createStudent student2
                 _ <- createCourseSimple 1
@@ -216,7 +216,7 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
                 return (map ciIsEnrolled courses === [True, False])
 
         it "Filtering on IsEnrolled works" $
-            sqliteProperty $ \_ctx () -> do
+            sqliteProperty $ \() -> do
                 _ <- createStudent student1
                 _ <- createCourseSimple 1
                 _ <- createCourseSimple 2
@@ -232,8 +232,8 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
                     map ciDesc notEnrolled === ["course 1"]
 
         it "Course 'isFinished' flag is correct" $
-            sqliteProperty $ \_ctx
-               (delayedGen
+            sqliteProperty $
+              \( delayedGen
                  (genCoreTestEnv simpleCoreTestParams
                   { ctpAssignment = assignmentItemsForSameCourse }) -> env
                , delayedGen (infiniteList @(Maybe Grade)) -> mgrades
@@ -266,7 +266,7 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
   describe "Assignments" $ do
     describe "getAssignment" $ do
         it "Fails on request of non-existent assignment" $
-            sqliteProperty $ \_ctx () ->
+            sqliteProperty $ \() ->
                 throwsPrism (_AbsentError . _AssignmentDomain) $ do
                     _ <- createStudent student1
                     studentGetAssignment student1 (hash assignment1)
@@ -274,7 +274,7 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
         it "Fails when student is not assigned to submission" $
             -- Student is required to just take his recent submission,
             -- but we have to fail on all unautharized actions.
-            sqliteProperty $ \_ctx assignment -> do
+            sqliteProperty $ \assignment -> do
                 let course = _aCourseId assignment
                 _ <- createStudent student1
                 _ <- createCourse $ simpleCourse course
@@ -283,7 +283,7 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
                     studentGetAssignment student1 (hash assignment1)
 
         it "Returns existing assignment properly" $
-            sqliteProperty $ \_ctx assignment -> do
+            sqliteProperty $ \assignment -> do
                 let assignmentH = hash assignment
                 let course = _aCourseId assignment
                 _ <- createStudent student1
@@ -303,7 +303,7 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
                     }
 
         it "Student sees only his assignment" $
-            sqliteProperty $ \_ctx
+            sqliteProperty $ \
               ( delayedGen (vectorUnique 2) -> [assignment, needlessAssignment]
               ) -> do
                 let course = _aCourseId assignment
@@ -317,7 +317,7 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
 
     describe "getAssignments" $ do
         it "Student has no last submission initially" $
-            sqliteProperty $ \_ctx () -> do
+            sqliteProperty $ \() -> do
                 let course = _aCourseId assignment1
                 _ <- createStudent student1
                 _ <- createCourse $ simpleCourse course
@@ -328,8 +328,8 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
                 return $ all (isNothing . aiLastSubmission) assignments
 
         it "Returns existing assignment properly and only related to student" $
-            sqliteProperty $ \_ctx
-               (delayedGen (vectorUnique 2)
+            sqliteProperty $
+              \(delayedGen (vectorUnique 2)
                  -> assignments@[assignment, needlessAssignment]) -> do
                 let assignmentH = hash assignment
                 _ <- createStudent student1
@@ -352,7 +352,7 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
                     }
 
         it "Filtering works" $
-            sqliteProperty $ \_ctx
+            sqliteProperty $ \
               ( delayedGen listUnique -> preAssignments
               , courseF
               , docTypeF
@@ -381,8 +381,8 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
                 return $ sortOn aiHash assignments === sortOn aiHash assignments'
 
         it "Last submission is actually the last" $
-            sqliteProperty $ \_ctx
-               ( delayedGen
+            sqliteProperty $
+              \( delayedGen
                  (genCoreTestEnv simpleCoreTestParams) -> env
                ) -> do
                 let student = tiOne $ cteStudents env
@@ -406,7 +406,7 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
                     -- Just (studentLiftSubmission lastSubmission Nothing)
 
         it "Cannot see the last submission of other students" $
-            sqlitePropertyM $ \_ctx -> do
+            sqlitePropertyM $ do
                 env <- pickSmall $ genCoreTestEnv wildCoreTestParams
                 let student = tiOne $ cteStudents env
                     submissions = tiList $ cteSubmissions env
@@ -432,7 +432,7 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
         -- there are still some student-specific things we'd like to check
 
         it "Fails when student is not submission owner" $
-            sqlitePropertyM $ \_ctx -> do
+            sqlitePropertyM $ do
                 env <- pickSmall $ genCoreTestEnv simpleCoreTestParams
                 user <- pick arbitrary
 
@@ -458,7 +458,7 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
 
     describe "getSubmissions" $ do
         it "Returns existing submission properly and only related to student" $
-            sqlitePropertyM $ \_ctx -> do
+            sqlitePropertyM $ do
                 env <- pickSmall $ genCoreTestEnv wildCoreTestParams
                 let sigSubs = tiList $ cteSignedSubmissions env
                 pre (length sigSubs >= 2)
@@ -479,14 +479,14 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
 
     describe "deleteSubmission" $ do
         it "Deletion of non-existing submission throws" $
-            sqliteProperty $ \_ctx submission -> do
+            sqliteProperty $ \submission -> do
                 _ <- createStudent student1
                 throwsPrism (_AbsentError . _SubmissionDomain) $
                     commonDeleteSubmission (hash submission) (Just student1)
 
         it "Delete works" $
-            sqliteProperty $ \_ctx
-               ( delayedGen (genCoreTestEnv simpleCoreTestParams) -> env
+            sqliteProperty $
+              \( delayedGen (genCoreTestEnv simpleCoreTestParams) -> env
                ) -> do
                   let student = tiOne $ cteStudents env
                       subToDel = tiOne $ cteSignedSubmissions env
@@ -504,8 +504,8 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
                   return $ sortOn siHash subAfter === sortOn siHash expected
 
         it "Can not delete graded submission" $
-            sqliteProperty $ \_ctx
-               ( delayedGen (genCoreTestEnv simpleCoreTestParams) -> env
+            sqliteProperty $
+              \( delayedGen (genCoreTestEnv simpleCoreTestParams) -> env
                ) -> do
                 let student = tiOne $ cteStudents env
                     sigSub = tiOne $ cteSignedSubmissions env
@@ -518,8 +518,8 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
                      commonDeleteSubmission (hash sub) (Just student)
 
         it "Can not delete other student's submission" $
-            sqliteProperty $ \_ctx
-               ( delayedGen (genCoreTestEnv simpleCoreTestParams) -> env
+            sqliteProperty $
+              \( delayedGen (genCoreTestEnv simpleCoreTestParams) -> env
                , otherStudent
                ) -> do
                 let student = tiOne $ cteStudents env
@@ -536,8 +536,8 @@ spec_StudentApiQueries = describe "Educator endpoint" $ do
 
     describe "makeSubmission" $ do
         it "Making same submission twice throws" $
-            sqliteProperty $ \_ctx
-               ( delayedGen (genCoreTestEnv simpleCoreTestParams) -> env
+            sqliteProperty $
+              \( delayedGen (genCoreTestEnv simpleCoreTestParams) -> env
                ) -> do
                 let sigSub = tiOne $ cteSignedSubmissions env
 


### PR DESCRIPTION
This is an ~exact revert of DisciplinaOU/disciplina#335.

Motivation:
* I need `instance MonadCatch` in database endpoints, and that's problematic to achieve in `Pg` monad which is `MonadBeam` implementation in Postgres case.
* `Pg`'s `>>=` does not execute SQL requests, rather collects them for execution in `Pg` runner. That's an inconvenient property for database endpoint monad, it complicates debugging.
* Previously mentioned reasons, like the fact that we carry context explicitly now (and we always carry it explicitly in tests).