### PR TITLE
[DSCP-419] Enforce correspondence between methods used in API and in …

### DIFF
--- a/educator/src/Dscp/Educator/Web/Server.hs
+++ b/educator/src/Dscp/Educator/Web/Server.hs
@@ -16,7 +16,7 @@ import Loot.Log (logInfo)
 import Network.HTTP.Types.Header (hAuthorization, hContentType)
 import Network.Wai (Middleware)
 import Network.Wai.Middleware.Cors (CorsResourcePolicy (..), cors, simpleCorsResourcePolicy)
-import Servant ((:<|>) (..), Context (..), Handler, ServantErr (..), Server, err405,
+import Servant ((:<|>) (..), Context (..), Handler, ServantErr (..), Server, StdMethod (..), err405,
                 hoistServerWithContext, serveWithContext)
 import Servant.Auth.Server.Internal.ThrowAll (throwAll)
 import Servant.Generic (toServant)
@@ -35,7 +35,7 @@ import Dscp.Educator.Web.Educator (EducatorPublicKey (..), ProtectedEducatorAPI,
 import Dscp.Educator.Web.Student (ProtectedStudentAPI, StudentCheckAction (..),
                                   convertStudentApiHandler, studentAPI, studentApiHandlers)
 import Dscp.Resource.Keys (KeyResources, krPublicKey)
-import Dscp.Util.Servant (LoggingApi, ServantLogConfig (..))
+import Dscp.Util.Servant (LoggingApi, ServantLogConfig (..), methodsCoveringAPI)
 import Dscp.Web (ServerParams (..), buildServantLogConfig, serveWeb)
 import Dscp.Web.Metrics (responseTimeMetric)
 import Dscp.Witness.Web
@@ -99,7 +99,7 @@ educatorCors = cors $ const $ Just $
       -- authentication prevents CSRF attacks, and API is public anyway.
       corsOrigins = Nothing
     , corsRequestHeaders = [hContentType, hAuthorization]
-    , corsMethods = ["GET", "POST", "DELETE"]
+    , corsMethods = methodsCoveringAPI @['GET, 'POST, 'PUT, 'DELETE] @EducatorWebAPI
     }
 
 serveEducatorAPIsReal :: EducatorWorkMode ctx m => Bool -> m ()

--- a/faucet/src/Dscp/Faucet/Web/Server.hs
+++ b/faucet/src/Dscp/Faucet/Web/Server.hs
@@ -13,7 +13,7 @@ import Loot.Log (logInfo)
 import Network.HTTP.Types.Header (hContentType)
 import Network.Wai (Middleware)
 import Network.Wai.Middleware.Cors (CorsResourcePolicy (..), cors, simpleCorsResourcePolicy)
-import Servant ((:>), Handler, Server, hoistServer, serve)
+import Servant ((:>), Handler, Server, StdMethod (..), hoistServer, serve)
 import Servant.Generic (toServant)
 
 import Dscp.Config
@@ -21,7 +21,7 @@ import Dscp.Faucet.Config
 import Dscp.Faucet.Launcher (FaucetRealMode, FaucetWorkMode)
 import Dscp.Faucet.Web.API (FaucetAPI, faucetAPI)
 import Dscp.Faucet.Web.Handlers (convertFaucetApiHandler, faucetApiHandlers)
-import Dscp.Util.Servant (LoggingApi)
+import Dscp.Util.Servant (LoggingApi, methodsCoveringAPI)
 import Dscp.Web (ServerParams (..), serveWeb)
 import Dscp.Web.Server (buildServantLogConfig)
 
@@ -40,6 +40,7 @@ faucetCors = cors $ const $ Just $
     simpleCorsResourcePolicy
     { -- We use @Access-Control-Allow-Origin: *@ as soon as API is public.
       corsOrigins = Nothing
+    , corsMethods = methodsCoveringAPI @['GET, 'POST] @FaucetWebAPI
     , corsRequestHeaders = [hContentType]
     }
 

--- a/multi-educator/src/Dscp/MultiEducator/Web/Server.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Web/Server.hs
@@ -14,8 +14,8 @@ import Loot.Log (logInfo)
 import Network.HTTP.Types.Header (hAuthorization, hContentType)
 import Network.Wai (Middleware)
 import Network.Wai.Middleware.Cors (CorsResourcePolicy (..), cors, simpleCorsResourcePolicy)
-import Servant ((:<|>) (..), Context (..), Handler, ServantErr (..), Server, ServerT, err401,
-                err405, hoistServerWithContext, serveWithContext)
+import Servant ((:<|>) (..), Context (..), Handler, ServantErr (..), Server, ServerT,
+                StdMethod (..), err401, err405, hoistServerWithContext, serveWithContext)
 import Servant.Auth.Server (AuthResult (..), CookieSettings, JWTSettings, defaultCookieSettings,
                             defaultJWTSettings, generateKey)
 import Servant.Auth.Server.Internal.ThrowAll (throwAll)
@@ -35,6 +35,7 @@ import Dscp.MultiEducator.Launcher.Resource (EducatorCtxWithCfg (..))
 import Dscp.MultiEducator.Web.Educator (MultiEducatorAPI, MultiStudentAPI, multiEducatorAPI,
                                         multiEducatorApiHandlers, multiStudentAPI)
 import Dscp.MultiEducator.Web.Educator.Auth
+import Dscp.Util.Servant (methodsCoveringAPI)
 import Dscp.Web (ServerParams (..), serveWeb)
 import Dscp.Web.Metrics (responseTimeMetric)
 import Dscp.Witness.Web
@@ -136,7 +137,7 @@ educatorCors = cors $ const $ Just $
       -- authentication prevents CSRF attacks, and API is public anyway.
       corsOrigins = Nothing
     , corsRequestHeaders = [hContentType, hAuthorization]
-    , corsMethods = ["GET", "POST", "DELETE"]
+    , corsMethods = methodsCoveringAPI @['GET, 'POST, 'PUT, 'DELETE] @EducatorWebAPI
     }
 
 serveEducatorAPIsReal :: MultiCombinedWorkMode ctx m => Bool -> m ()

--- a/witness/src/Dscp/Util/Servant.hs
+++ b/witness/src/Dscp/Util/Servant.hs
@@ -22,6 +22,8 @@ module Dscp.Util.Servant
     , ApiCanLogArg (..)
 
     , SimpleJSON
+
+    , methodsCoveringAPI
     ) where
 
 import Prelude hiding (log)
@@ -36,10 +38,11 @@ import qualified Data.Text as T
 import qualified Data.Text.Buildable as B
 import qualified Data.Text.Lazy.Builder as B
 import Data.Time.Clock.POSIX (getPOSIXTime)
-import Fmt (blockListF, (+|), (|+), Builder)
+import Fmt (Builder, blockListF, (+|), (|+))
 import GHC.IO.Unsafe (unsafePerformIO)
-import GHC.TypeLits (KnownSymbol, symbolVal)
+import GHC.TypeLits (ErrorMessage (..), KnownSymbol, Symbol, TypeError, symbolVal)
 import Loot.Log (Severity (Info))
+import Network.HTTP.Types.Method (Method, StdMethod)
 import Serokell.Util ()
 import Serokell.Util.ANSI (Color (..), colorizeDull)
 import Servant.API ((:<|>) (..), (:>), Capture, Description, JSON, NoContent, QueryFlag, QueryParam,
@@ -453,3 +456,46 @@ instance (FromJSON a, Reifies err String) => MimeUnrender (SimpleJSON err) a whe
     mimeUnrender _ =
         let errMsg = reflect (Proxy @err)
         in first (\_ -> errMsg) . eitherDecode
+
+-------------------------------------------------------------------------
+-- CORS methods coherence
+-------------------------------------------------------------------------
+
+-- | Whether a given type item is element of a given list.
+type family IsElemBool (x :: StdMethod) (l :: [StdMethod]) :: Bool where
+    IsElemBool x (x : _) = 'True
+    IsElemBool x (y : xs) = IsElemBool x xs
+    IsElemBool x '[] = 'False
+
+type family FailOnDissallowedMethod (method :: StdMethod) (allowed :: Bool) :: Constraint where
+    FailOnDissallowedMethod _ 'True = ()
+    FailOnDissallowedMethod m 'False = TypeError
+        ( 'Text "Method " ':$$: 'ShowType m ':$$: 'Text " is not allowed, but appears in API"
+        )
+
+-- | Ensure that the given api uses only methods from the list provided.
+type family ContainsOnlyMethods (methods :: [StdMethod]) api :: Constraint where
+    ContainsOnlyMethods ms ((path :: Symbol) :> sub) = ContainsOnlyMethods ms sub
+    ContainsOnlyMethods ms (part :> sub) = ContainsOnlyMethods ms sub
+    ContainsOnlyMethods ms (api1 :<|> api2) = (ContainsOnlyMethods ms api1,
+                                               ContainsOnlyMethods ms api2)
+    ContainsOnlyMethods ms (Verb m _ _ _) = FailOnDissallowedMethod m (IsElemBool m ms)
+
+-- | 'ReflectMethod' lifted to method lists.
+class ReflectMethods (methods :: [StdMethod]) where
+    reflectMethods :: Proxy methods -> [Method]
+instance ReflectMethods '[] where
+    reflectMethods _ = []
+instance (ReflectMethod m, ReflectMethods ms) => ReflectMethods (m ': ms) where
+    reflectMethods _ = reflectMethod @m Proxy : reflectMethods @ms Proxy
+
+-- | For the given list of methods, ensure only they are used in API, and get corresponding
+-- 'Method' terms.
+--
+-- A primary use case for this function is specifying CORS methods where we need to think
+-- about each single method we allow, thus expecting methods list to be specified manually.
+methodsCoveringAPI
+    :: forall methods api.
+       (ContainsOnlyMethods methods api, ReflectMethods methods)
+    => [Method]
+methodsCoveringAPI = reflectMethods @methods Proxy

--- a/witness/src/Dscp/Witness/Web/Server.hs
+++ b/witness/src/Dscp/Witness/Web/Server.hs
@@ -12,10 +12,10 @@ import Loot.Log (logInfo)
 import Network.HTTP.Types.Header (hContentType)
 import Network.Wai (Middleware)
 import Network.Wai.Middleware.Cors (CorsResourcePolicy (..), cors, simpleCorsResourcePolicy)
-import Servant (Handler, Server, hoistServer, serve, throwError)
+import Servant (Handler, Server, StdMethod (..), hoistServer, serve, throwError)
 import UnliftIO (UnliftIO (..), askUnliftIO)
 
-import Dscp.Util.Servant (LoggingApi, ServantLogConfig (..))
+import Dscp.Util.Servant (LoggingApi, ServantLogConfig (..), methodsCoveringAPI)
 import Dscp.Web (ServerParams (..), buildServantLogConfig, serveWeb)
 import Dscp.Web.Class
 import Dscp.Witness.Launcher.Context
@@ -47,7 +47,7 @@ witnessCors = cors $ const $ Just $
     simpleCorsResourcePolicy
     { -- We use @Access-Control-Allow-Origin: *@ as soon as API is public.
       corsOrigins = Nothing
-    , corsMethods = ["GET", "POST", "PUT", "DELETE"]
+    , corsMethods = methodsCoveringAPI @['GET, 'POST, 'PUT] @WitnessAPI
     , corsRequestHeaders = [hContentType]
     }
 


### PR DESCRIPTION
### Description

Now we check at compile-time that methods listed in CORS cover all methods used
in corresponding API.

### YT issue

https://issues.serokell.io/issue/DSCP-419

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
