### PR TITLE
[DSCP-414] Add a "all valid" field in `FairCVCheckResult`

### DIFF
--- a/core/src/Dscp/Core/Aeson.hs
+++ b/core/src/Dscp/Core/Aeson.hs
@@ -160,9 +160,6 @@ deriving instance FromJSON GenesisDistribution
 deriving instance Serialise (MerkleProof PrivateTx) => ToJSON FairCV
 deriving instance Serialise (MerkleProof PrivateTx) => FromJSON FairCV
 
-deriving instance ToJSON FairCVCheckResult
-deriving instance FromJSON FairCVCheckResult
-
 ---------------------------------------------------------------------------
 -- TH derivations for data
 ---------------------------------------------------------------------------
@@ -205,3 +202,14 @@ instance Typeable tx => FromJSON (FeePolicy tx) where
         ]
       where
         unallowedPolicy = "This fees policy is not applicable"
+
+instance ToJSON FairCVCheckResult where
+    toJSON FairCVCheckResult{..} = object
+        [ "isValid" .= fairCVFullyValid
+        , "checkResponse" .= fairCVCheckResults
+        ]
+instance FromJSON FairCVCheckResult where
+    parseJSON = withObject "FairCVCheckResult" $ \o -> do
+        fairCVFullyValid <- o .: "isValid"
+        fairCVCheckResults <- o .: "checkResponse"
+        return FairCVCheckResult{..}

--- a/core/src/Dscp/Core/FairCV.hs
+++ b/core/src/Dscp/Core/FairCV.hs
@@ -12,7 +12,6 @@ module Dscp.Core.FairCV
 
          -- * Fair CV check result
        , FairCVCheckResult (..)
-       , fullyValid
        ) where
 
 import qualified Data.Map.Merge.Strict as M
@@ -86,13 +85,13 @@ addProof educatorAddr blkHash proof =
 -- Fair CV check result
 ---------------------------------------------------------------------------
 
-newtype FairCVCheckResult = FairCVCheckResult
-    { unFairCVCheckResult :: GenericFairCV Bool
+data FairCVCheckResult = FairCVCheckResult
+    { fairCVCheckResults :: GenericFairCV Bool
+    , fairCVFullyValid   :: Bool
     } deriving (Show, Eq, Generic)
 
 instance Buildable FairCVCheckResult where
-    build (FairCVCheckResult res) =
-        "Fair CV check result { "+|mapF (mapF <$> res)|+" }"
-
-fullyValid :: FairCVCheckResult -> Bool
-fullyValid = all and . unFairCVCheckResult
+    build (FairCVCheckResult res total) =
+        "Fair CV check result: "+|totalS+|" "+|mapF (mapF <$> res)
+      where
+        totalS = if total then "✔" else "✘"

--- a/specs/disciplina/witness/api/witness.yaml
+++ b/specs/disciplina/witness/api/witness.yaml
@@ -671,10 +671,19 @@ components:
                 $ref: '#/components/schemas/PrivateTx'
     FairCVCheckResult:
       type: object
-      additionalProperties:
-        type: object
-        additionalProperties:
+      required:
+        - isValid
+        - checkResponse
+      properties:
+        isValid:
           type: boolean
+          description: Is the entire FairCV valid?
+        checkResponse:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              type: boolean
 
     ErrResponse:
       type: object

--- a/witness/tests/Test/Dscp/Witness/Explorer/Explorer.hs
+++ b/witness/tests/Test/Dscp/Witness/Explorer/Explorer.hs
@@ -330,9 +330,9 @@ spec_Explorer = describe "Explorer" $ do
             checkResBad <- lift $ checkFairCV fairCvInvalid
             let goodCheck =
                     counterexample "Valid FairCV is not checked correctly" $
-                    fullyValid checkResGood
+                    fairCVFullyValid checkResGood
                 badCheck =
                     counterexample "Invalid FairCV is not rejected" $
-                    not $ fullyValid checkResBad
+                    not $ fairCVFullyValid checkResBad
 
             return $ goodCheck .&&. badCheck


### PR DESCRIPTION
### Description

As it was previously discussed, we add a field to quickly ensure whether everything is valid or not.

### YT issue

https://issues.serokell.io/issue/DSCP-414

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
