### PR TITLE
[DSCP-393] replace config type with vinyl records

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -37,29 +37,32 @@ demo: &demo
       clean: false
     logging:
       default-name: "witness"
-      backends:
-      - type: stderr
-      - type: syslog
-        app-name: "witness"
-      min-level: Debug
+      config:
+        backends:
+        - type: stderr
+        - type: syslog
+          app-name: "witness"
+        min-level: Debug
 
   educator:
     logging:
       default-name: "educator"
-      backends:
-      - type: stderr
-      - type: syslog
-        app-name: "educator"
-      min-level: Debug
+      config:
+        backends:
+        - type: stderr
+        - type: syslog
+          app-name: "educator"
+        min-level: Debug
 
   faucet:
     logging:
       default-name: "faucet"
-      backends:
-      - type: stderr
-      - type: syslog
-        app-name: "faucet"
-      min-level: Debug
+      config:
+        backends:
+        - type: stderr
+        - type: syslog
+          app-name: "faucet"
+        min-level: Debug
 
 singleton:
   <<: *demo

--- a/core/src/Dscp/Core/Aeson.hs
+++ b/core/src/Dscp/Core/Aeson.hs
@@ -197,11 +197,9 @@ deriveJSON defaultOptions ''PublicationTxWitness
 deriveJSON defaultOptions ''PublicationTxWitnessed
 deriveJSON defaultOptions ''PublicationTx
 deriveJSON defaultOptions ''FeeCoefficients
-deriveFromJSON defaultOptions ''FeeConfig
 
 deriveFromJSON defaultOptions ''Committee
 deriveJSON defaultOptions ''GenesisDistributionElem
-deriveFromJSON defaultOptions ''GenesisConfig
 
 instance FromJSON GenesisInfo where
     parseJSON = error "FromJSON GenesisInfo should never be called"

--- a/core/src/Dscp/Core/Genesis.hs
+++ b/core/src/Dscp/Core/Genesis.hs
@@ -1,10 +1,15 @@
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TypeOperators    #-}
+
 -- | Genesis info and related.
 
 module Dscp.Core.Genesis
     ( GenesisInfo (..)
     , GenesisDistributionElem (..)
     , GenesisDistribution (..)
-    , GenesisConfig (..)
+    , GenesisConfig
+    , GenesisConfigRec
+    , GenesisConfigRecP
     , GenAddressMap (..)
     , totalCoinsAddrMap
     , distrToMap
@@ -15,6 +20,7 @@ module Dscp.Core.Genesis
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as M
 import qualified Data.Map.Strict as Map
+import Loot.Config ((:::), PartialConfig, Config, option)
 
 import Dscp.Core.Foundation
 import Dscp.Core.Governance
@@ -57,14 +63,17 @@ newtype GenesisDistribution = GenesisDistribution
     } deriving (Eq, Show, Generic)
 
 -- | Genesis configuration.
-data GenesisConfig = GenesisConfig
-    { gcGenesisSeed  :: Text
-      -- ^ Seed that will be used in the creation of genesis block.
-    , gcGovernance   :: Governance
-      -- ^ Type of governance used.
-    , gcDistribution :: GenesisDistribution
-      -- ^ Initial coins distribution.
-    } deriving (Eq, Show, Generic)
+type GenesisConfig =
+    '[ "genesisSeed"  ::: Text
+       -- ^ Seed that will be used in the creation of genesis block.
+     , "governance"   ::: Governance
+       -- ^ Type of governance used.
+     , "distribution" ::: GenesisDistribution
+       -- ^ Initial coins distribution.
+     ]
+
+type GenesisConfigRec = Config GenesisConfig
+type GenesisConfigRecP = PartialConfig GenesisConfig
 
 distrElemToMap :: Maybe (NonEmpty Address) -> GenesisDistributionElem -> GenAddressMap
 distrElemToMap _ (GDSpecific addrMap) = addrMap
@@ -90,17 +99,18 @@ genesisSk :: SecretKey
 genesisSk = withIntSeed 12345 genSecretKey
 
 -- | Generate genesis info (addr map, block).
-formGenesisInfo :: GenesisConfig -> GenesisInfo
-formGenesisInfo GenesisConfig{..} =
+formGenesisInfo :: GenesisConfigRec -> GenesisInfo
+formGenesisInfo genesisConfig =
     GenesisInfo { giAddressMap = genesisAddrMap
                 , giGenesisBlock = genesisBlock
                 }
   where
-    govAddresses = case gcGovernance of
+    govAddresses = case genesisConfig ^. option #governance of
         GovCommittee com -> committeeAddrs com
         GovOpen          -> error "formGenesisInfo: open governance is not implemented"
 
-    genesisAddrMap = distrToMap (Just $ NE.fromList govAddresses) gcDistribution
+    genesisAddrMap = distrToMap (Just $ NE.fromList govAddresses) $
+        genesisConfig ^. option #distribution
 
     genesisBlock :: Block
     genesisBlock = Block header payload
@@ -121,7 +131,7 @@ formGenesisInfo GenesisConfig{..} =
 
         payload = BlockBody [initTx]
 
-        prevHash = unsafeHash (gcGenesisSeed :: Text)
+        prevHash = unsafeHash $ genesisConfig ^. option #genesisSeed
         toSign = BlockToSign 0 0 prevHash (hash payload)
         header = Header { hSignature = sign sk toSign
                         , hIssuer = pk

--- a/core/src/Dscp/Core/Genesis.hs
+++ b/core/src/Dscp/Core/Genesis.hs
@@ -65,11 +65,11 @@ newtype GenesisDistribution = GenesisDistribution
 -- | Genesis configuration.
 type GenesisConfig =
     '[ "genesisSeed"  ::: Text
-       -- ^ Seed that will be used in the creation of genesis block.
+       -- Seed that will be used in the creation of genesis block.
      , "governance"   ::: Governance
-       -- ^ Type of governance used.
+       -- Type of governance used.
      , "distribution" ::: GenesisDistribution
-       -- ^ Initial coins distribution.
+       -- Initial coins distribution.
      ]
 
 type GenesisConfigRec = Config GenesisConfig

--- a/core/src/Dscp/Resource/AppDir.hs
+++ b/core/src/Dscp/Resource/AppDir.hs
@@ -30,9 +30,9 @@ import Dscp.System (appName)
 type AppDirParam =
    '[ "param" ::+
        '[ "os" ::- '[]
-          -- ^ Dedicated folder inside OS directory for applications
+          -- Dedicated folder inside OS directory for applications
         , "specific" ::- '[ "path" ::: FilePath ]
-          -- ^ Given path
+          -- Given path
         ]
     ]
 

--- a/core/src/Dscp/Resource/Class.hs
+++ b/core/src/Dscp/Resource/Class.hs
@@ -17,12 +17,12 @@ import Control.Monad.Component (ComponentM, buildComponent)
 import Loot.Base.HasLens (HasLens (..))
 import Loot.Log.Rio (LoggingIO)
 
-import Dscp.Resource.Logging (LoggingParams)
+import Dscp.Resource.Logging (LoggingParamsRec)
 import Dscp.Rio (RIO, runRIO)
 
 -- | Contains parameters required for most of resources allocation.
 data InitParams = InitParams
-    { ipLoggingParams :: LoggingParams
+    { ipLoggingParams :: LoggingParamsRec
     }
 
 -- | Context used in most of resource allocations.

--- a/core/src/Dscp/Resource/Logging.hs
+++ b/core/src/Dscp/Resource/Logging.hs
@@ -31,9 +31,9 @@ import Dscp.Rio (runRIO)
 -- | Contains all parameters required for hierarchical logger initialization.
 type LoggingParams =
     '[ "config"      ::: LogConfig
-       -- ^ Logger configuration that will be used
+       -- Logger configuration that will be used
      , "defaultName" ::: Name
-       -- ^ Logger name which will be used by default
+       -- Logger name which will be used by default
      ]
 
 type LoggingParamsRec = Config LoggingParams

--- a/core/src/Dscp/Resource/Logging.hs
+++ b/core/src/Dscp/Resource/Logging.hs
@@ -1,9 +1,12 @@
-{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TypeOperators    #-}
 
 -- | Logging resource.
 
 module Dscp.Resource.Logging
-    ( LoggingParams(..)
+    ( LoggingParams
+    , LoggingParamsRec
+    , LoggingParamsRecP
     , basicLoggingParams
     , allocLogging
     , noLogging
@@ -11,9 +14,9 @@ module Dscp.Resource.Logging
 
 import Colog.Syslog (Collector (..), Facility (User), SyslogConfig (..))
 import Control.Monad.Component (ComponentM)
-import Data.Aeson (FromJSON (..), ToJSON (..), Value (Object), (.:), (.=),
-                   encode, object, withObject)
+import Data.Aeson (encode)
 import Fmt ((+|), (|+))
+import Loot.Config ((:::), (?~), Config, PartialConfig, option)
 import Loot.Log (BackendConfig (..), LogConfig (..), Logging (..), Name,
                  NameSelector (..), Severity (Debug, Info), allocateLogging,
                  fromLogAction, logDebug, modifyLogName)
@@ -26,51 +29,40 @@ import Dscp.Rio (runRIO)
 ----------------------------------------------------------------------------
 
 -- | Contains all parameters required for hierarchical logger initialization.
-data LoggingParams = LoggingParams
-    { lpConfig      :: !LogConfig
-    -- ^ Logger configuration that will be used
-    , lpDefaultName :: !Name
-    -- ^ Logger name which will be used by default
-    } deriving (Show, Eq)
+type LoggingParams =
+    '[ "config"      ::: LogConfig
+       -- ^ Logger configuration that will be used
+     , "defaultName" ::: Name
+       -- ^ Logger name which will be used by default
+     ]
 
--- | Creates a basic 'LoggingParams'
-basicLoggingParams :: Name -> Bool -> LoggingParams
-basicLoggingParams lpDefaultName debug = LoggingParams {..}
+type LoggingParamsRec = Config LoggingParams
+type LoggingParamsRecP = PartialConfig LoggingParams
+
+-- | Creates a basic 'LoggingParams' (Partial)
+basicLoggingParams :: Name -> Bool -> LoggingParamsRecP
+basicLoggingParams defaultName debug = mempty
+    & option #config      ?~ LogConfig {..}
+    & option #defaultName ?~ defaultName
   where
-    syslogConfig = SyslogConfig AutoLocal User (show lpDefaultName)
-    backends = [StdErr, Syslog syslogConfig]
-    minSeverity = if debug then Debug else Info
-    lpConfig = LogConfig {..}
+    syslogConfig = SyslogConfig AutoLocal User (show defaultName)
+    backends     = [StdErr, Syslog syslogConfig]
+    minSeverity  = if debug then Debug else Info
 
 ----------------------------------------------------------------------------
 -- Other
 ----------------------------------------------------------------------------
 
-allocLogging :: LoggingParams -> ComponentM LoggingIO
-allocLogging LoggingParams{..} = do
-    logging <- allocateLogging lpConfig (GivenName lpDefaultName)
+allocLogging :: LoggingParamsRec -> ComponentM LoggingIO
+allocLogging loggingParams = do
+    let config      = loggingParams ^. option #config
+        defaultName = loggingParams ^. option #defaultName
+    logging <- allocateLogging config (GivenName defaultName)
     liftIO $ runRIO logging $ modifyLogName (<> "init" <> "log") $ do
-        let configText = decodeUtf8 (encode lpConfig) :: Text
+        let configText = decodeUtf8 (encode config) :: Text
         logDebug $ "Logging config: "+|configText|+""
     return logging
 
----------------------------------------------------------------------------
--- JSON instances
----------------------------------------------------------------------------
-
-instance FromJSON LoggingParams where
-    parseJSON = withObject "LoggingParams" $ \v -> LoggingParams
-        <$> parseJSON (Object v)
-        -- short-circuiting: avoids adding a "config" key and parses a LogConfig directly
-        <*> v .: "default-name"
-
-instance ToJSON LoggingParams where
-    toJSON LoggingParams {..} = object
-        [ "default-name" .= lpDefaultName
-        -- short-circuiting: the next 2 pairs actually belong to the 'LogConfig'
-        , "backends"     .= backends lpConfig
-        , "min-severity" .= minSeverity lpConfig
-        ]
 ---------------------------------------------------------------------------
 -- Misc
 ---------------------------------------------------------------------------

--- a/docs/config-full-sample.yaml
+++ b/docs/config-full-sample.yaml
@@ -195,7 +195,7 @@ sample:
       botConfig:
         params:
           # Type of botConfig.
-          # - `enabled` - to use a bot with the specified seed and delay. 
+          # - `enabled` - to use a bot with the specified seed and delay.
           # - `closed` - to use no bot.
           paramsType: "disabled"
           enabled:

--- a/docs/config-full-sample.yaml
+++ b/docs/config-full-sample.yaml
@@ -39,15 +39,12 @@ sample:
       distribution:
         - equal: 1000
         - specific:
-          - # Faucet
-            - 3BAyX5pNrN2UzxPZhrFAocCti3nVRUZRk7CZtudT2iLhGH6T1eq5FzqEuk
-            - 1000
-          - # Test key #1, secret: ffRB5uhVEV24NXsYUuw1irt9HF5i5IRWJXHJzagXU8Y=
-            - 3BAyX5pPvmtsKAyDhtfeUZ1beJdFZzHLTHt6nHrzdGcpfagpgeysRNPyMe
-            - 1000
-          - # Test key #2, secret: fOhZOFr6SSnYv1/xfKPPMHdWLdQDboysJ4Q794Gezmw=
-            - 3BAyX5pSiFerJgLsJZ9XyoBDMHPtq3NLqm5AGPcBpba6W644zSiSWy3vVr
-            - 1000
+            # Faucet
+            3BAyX5pNrN2UzxPZhrFAocCti3nVRUZRk7CZtudT2iLhGH6T1eq5FzqEuk: 1000
+            # Test key #1, secret: ffRB5uhVEV24NXsYUuw1irt9HF5i5IRWJXHJzagXU8Y=
+            3BAyX5pPvmtsKAyDhtfeUZ1beJdFZzHLTHt6nHrzdGcpfagpgeysRNPyMe: 1000
+            # Test key #2, secret: fOhZOFr6SSnYv1/xfKPPMHdWLdQDboysJ4Q794Gezmw=
+            3BAyX5pSiFerJgLsJZ9XyoBDMHPtq3NLqm5AGPcBpba6W644zSiSWy3vVr: 1000
 
   # Witness node configuration
   witness:
@@ -57,46 +54,21 @@ sample:
       defaultName: "witness"
       # Logging configuration, specifies the logging settings
       config:
-        # The "use" selector, optional, specifies where to output the logs
-        # Available configuration are "syslog" and "warper"
-        # If "use" has one of these valid values, this config will be used
-        # If both config are defined but "use" is not, "syslog" will be used
-        # If only one of the configs is defined and "use" is not, this config will be used
-        use: syslog
-        # Syslog configuration
-        # See a complete explanation in (loot-log)[https://github.com/serokell/lootbox/blob/master/docs/example/syslog.yaml]
-        syslog:
-          loggers-tree:
-            witness:
-              withPERROR: true
-              min-level: Debug
-              sub-loggers:
-                network:
-                  min-level: Info
-                web:
-                  min-level: Info
-        # Warper configuration
-        # See a complete explanation in (log-warper)[https://github.com/serokell/log-warper/blob/master/logger-config-example.yaml]
-        warper:
-          filePrefix: "run/tmp/witness/logs"
-          loggerTree:
-            handlers:
-              - file: node.log
-            severity: Info+
-            witness:
-              severity: Debug+
-              network:
-                severity: Info+
-              web:
-                severity: Info+
-            init:
-              log:
-                severity: Debug+
+        # List of backends for logging output, available options are:
+        # stdout, stderr, file and syslog
+        backends:
+        - type: stderr
+        - type: syslog
+          app-name: "witness"
+        # Minimum severity, log messages with a lower level are filtered out
+        min-level: Debug
 
     # RocksDB parameters
     db:
       # Path to the database folder
       path: "/var/db/dscp-witness"
+      # Whether DB should be cleaned/removed on start
+      clean: false
 
     # ZeroMQ interface parameters
     network:
@@ -107,54 +79,65 @@ sample:
         - 127.0.0.1:8030:8031
       # Our own address, which is also our unique identifier in the network
       ourAddress: 127.0.0.1:8000:8001
-      # If this option is set, then this address listens for ZMQ connections
-      # instead, whereas `ourAddress` is still used as an unique identifier of node.
-      # Useful when node is behind NAT.
-      internalAddress: 192.168.0.3:8000:8001
 
     # Witness keyfile
     keys:
-      # Type of key parameters:
-      # - `basic`: used when providing a keyfile and related parameters
-      # - `committee`: used when generating secret key from a committee secret
-      type: "committee"
+      params:
+        # Type of choosable key parameters:
+        # - `basic`: used when providing a keyfile and related parameters
+        # - `committee`: used when generating secret key from a committee secret
+        paramsType: "committee"
 
-      # Parameters for type `basic`.
+        # Parameters for type `basic`.
+        basic:
+          # Path to keyfile. If not defined, <APP_DIR>/witness.key is used.
+          path: "witness.key"
+          # If 'true', generate new keyfile on given path, and fail if the
+          # keyfile already exists
+          genNew: false
+          # Keyfile passphrase (optional). If not given, key is encrypted with an
+          # empty passphrase.
+          passphrase: "qwerty123"
 
-      ## Path to keyfile. If not defined, <APP_DIR>/witness.key is used.
-      # path: "witness.key"
-      ## If 'true', generate new keyfile on given path, and fail if the
-      ## keyfile already exists
-      # genNew: false
-      ## Keyfile passphrase (optional). If not given, key is encrypted with an
-      ## empty passphrase.
-      #passphrase: "qwerty123"
-
-      # Parameters for type `committee`. Used together with committee governance params
-      # in order to generate committee keys from seed.
-
-      # Type of committee.
-      # - `open` - open committee, generation seed for committee
-      #    secret keys is known to everybody (given in `core` section of config)
-      # - `closed` - closed committee, only public keys of committee
-      #    members are publicly known.
-      committeeType: "closed"
-      # Index of this node among committee participants.
-      n: 2
-      # Used only when `type` is `committeeClosed`. Secret seed from which
-      # committee secret keys are derived.
-      secret: "UcA3FaXf="
+        # Parameters for type `committee`. Used together with committee governance params
+        # in order to generate committee keys from seed.
+        committee:
+          params:
+            # Type of committee.
+            # - `open` - open committee, generation seed for committee
+            #    secret keys is known to everybody (given in `core` section of config)
+            # - `closed` - closed committee, only public keys of committee
+            #    members are publicly known.
+            paramsType: "closed"
+            # Index of this node among committee participants. Required in both cases
+            participantN: 2
+            closed:
+              # Used only when `type` is `committeeClosed`. Secret seed from which
+              # committee secret keys are derived.
+              secret: "UcA3FaXf="
 
     # Witness (block explorer) HTTP API parameters.
-    # Optional. If not provided, Witness API is not served.
     api:
-      # Address to serve HTTP API from
-      addr: 127.0.0.1:3015
+      # Optional. If not provided, Witness API is not served.
+      maybe:
+        # Type of maybe.
+        # - `just` - to provide a value, in this case an address.
+        # - `nothing` - to provide no value.
+        maybeType: "just"
+        just:
+          # Address to serve HTTP API from
+          addr: 127.0.0.1:3015
 
     # Application directory for witness.
-    # Optional. If not provided, default application data directory
-    # for current OS will be used (e. g. `~/.local/share/disciplina`)
-    appDir: "/home/user/.disciplina"
+    appDir:
+      param:
+        # Type of choosable Application directories:
+        # - `os`: to use the default application data directory for current OS (e. g. `~/.local/share/disciplina`)
+        # - `specific`: to specify another directory
+        paramType: specific
+        specific:
+          # Path to a specific directory
+          path: "/home/user/.disciplina"
 
     # Metrics UDP endpoint.
     # Optional. If not provided, metrics collection is disabled.
@@ -164,36 +147,42 @@ sample:
   educator:
     # Logging config for educator node. See option `witness.logging`.
     logging:
-      defaultName: "educator"
-      config:
-        syslog:
-          loggers-tree:
-            witness:
-              withPERROR: true
-              min-level: Debug
+      default-name: "educator"
+      backends:
+      - type: stderr
+      - type: syslog
+        app-name: "educator"
+      min-level: Debug
 
     # SQLite DB params
     db:
       # DB usage mode. If `null`, in-memory SQLite db is used.
       # Otherwise, it is the object with params for on-disk SQLite connection.
       mode:
-        # Path to database file
-        path: "/var/db/educator.sqlite"
-        # Number of concurrent DB connections.
-        # Optional. If not provided, calculated automatically
-        # accordingly to the number of threads which can run truly
-        # simultaneously on a machine (e. g. number of CPU cores, or
-        # number of CPU cores x 2 when hyperthreading is enabled)
-        connNum: 4
-        # Number of maximum number of threads which wait for DB connection
-        # to be free. Default: 200
-        maxPending: 100
+        # Type of choosable SQLiteDB modes:
+        # - `real`: In given file using given number of connections
+        # - `inMemory`: In memory
+        modeType: real
+        # Parameters for "real" mode only
+        real:
+          # Path to database file
+          path: "/var/db/educator.sqlite"
+          # Number of concurrent DB connections.
+          # Optional. If not provided, calculated automatically
+          # accordingly to the number of threads which can run truly
+          # simultaneously on a machine (e. g. number of CPU cores, or
+          # number of CPU cores x 2 when hyperthreading is enabled)
+          connNum: 4
+          # Number of maximum number of threads which wait for DB connection
+          # to be free. Default: 200
+          maxPending: 100
 
-    # Educator key params. Similar to `witness.keys.base` config section.
+    # Educator key params. Similar to `witness.keys.params.basic` config section.
     keys:
-      path: "educator.key"
-      genNew: false
-      passphrase: "qwerty123"
+      keyParams:
+        path: "educator.key"
+        genNew: false
+        passphrase: "qwerty123"
 
     # Student API params
     api:
@@ -203,12 +192,18 @@ sample:
         addr: 127.0.0.1:4015
       # Educator Bot params.
       # Optional. If not provided, Educator Bot is disabled.
-      botParams:
-        # Random seed which determines bot's actions
-        seed: "GromakNaRechke"
-        # Delay between action trigger and action (e. g. time
-        # between receiving student's submission and posting a grade)
-        operationsDelay: "3s"
+      botConfig:
+        params:
+          # Type of botConfig.
+          # - `enabled` - to use a bot with the specified seed and delay. 
+          # - `closed` - to use no bot.
+          paramsType: "disabled"
+          enabled:
+            # Random seed which determines bot's actions
+            seed: "GromakNaRechke"
+            # Delay between action trigger and action (e. g. time
+            # between receiving student's submission and posting a grade)
+            operationsDelay: "3s"
       # Whether authentication in Student API should be optional
       studentAPINoAuth:
         # If enabled, primary JWT-based authentication becomes optional
@@ -228,20 +223,20 @@ sample:
   faucet:
     # Logging config for faucet node. See option `witness.logging`.
     logging:
-      defaultName: "faucet"
-      config:
-        warper:
-          filePrefix: "run/tmp/educator/logs"
-          loggerTree:
-            handlers:
-              - file: node.log
-            severity: Info+
+      default-name: "faucet"
+      backends:
+      - type: stderr
+      - type: syslog
+        app-name: "faucet"
+      min-level: Debug
 
-    # Faucet config params. See option `witness.keys.base`
+
+    # Faucet config params. See option `witness.keys.params.basic`
     keys:
-      path: "faucet.key"
-      genNew: false
-      passphrase: "qwerty123"
+      keyParams:
+        path: "faucet.key"
+        genNew: false
+        passphrase: "qwerty123"
 
     # Paramerers of Faucet HTTP API
     api:
@@ -259,4 +254,9 @@ sample:
     dryRun: false
 
     # Application directory for faucet. See option `witness.appDir`
-    appDir: "/home/user/.disciplina"
+    appDir:
+      param:
+        # Type of choosable Application directories:
+        # - `os`: to use the default application data directory for current OS (e. g. `~/.local/share/disciplina`)
+        # - `specific`: to specify another directory
+        paramType: os

--- a/educator/src/Dscp/DB/SQLite/Types.hs
+++ b/educator/src/Dscp/DB/SQLite/Types.hs
@@ -1,56 +1,62 @@
+{-# LANGUAGE OverloadedLabels #-}
+
 module Dscp.DB.SQLite.Types
        ( -- * SQLite bindings
-         SQLiteRealParams (..)
-       , srpPathL
-       , srpConnNumL
-       , srpMaxPendingL
-       , SQLiteDBMode (..)
-       , _SQLiteReal
-       , _SQLiteInMemory
+         SQLiteRealParams
+       , SQLiteRealParamsRec
+       , SQLiteRealParamsRecP
+
+       , SQLiteParams
+       , SQLiteParamsRec
+       , SQLiteParamsRecP
+       , defaultSQLiteParams
+
        , SQLiteDB (..)
-       , SQLiteParams (..)
-       , sdpModeL
        ) where
 
 import Control.Concurrent.Chan (Chan)
-import Control.Lens (makeLensesWith, makePrisms)
-import Data.Aeson (FromJSON (..))
-import Data.Aeson.Options (defaultOptions)
-import Data.Aeson.TH (deriveFromJSON)
 import Database.SQLite.Simple (Connection)
-
-import Dscp.Util
+import Loot.Config ((::+), (:::), (::-), Config, PartialConfig, tree, branch,
+                    selection, option, (?~))
 
 ----------------------------------------------------------
 -- SQLite bindings
 ----------------------------------------------------------
 
-data SQLiteRealParams = SQLiteRealParams
-    { srpPath       :: !FilePath
+type SQLiteRealParams =
+   '[ "path"       ::: FilePath
       -- ^ Path to the file with database.
-    , srpConnNum    :: !(Maybe Int)
+    , "connNum"    ::: Maybe Int
       -- ^ Connections pool size.
-    , srpMaxPending :: !Int
+    , "maxPending" ::: Int
       -- ^ Maximal number of requests waiting for a free connection.
-    } deriving (Show, Eq)
+    ]
 
-makeLensesWith postfixLFields ''SQLiteRealParams
+type SQLiteRealParamsRec = Config SQLiteRealParams
+type SQLiteRealParamsRecP = PartialConfig SQLiteRealParams
 
 -- | Database mode.
-data SQLiteDBMode
-    = SQLiteReal !SQLiteRealParams
-      -- ^ In given file using given number of connections
-    | SQLiteInMemory
-      -- ^ In memory
-    deriving (Show, Eq)
+-- Note, there is a reason this contains the whole tree and not just its content
+-- see 'ConfigMaybe' for an explanation.
+type SQLiteParams =
+   '[ "mode" ::+
+       '[ "real"     ::- SQLiteRealParams
+          -- ^ In given file using given number of connections
+        , "inMemory" ::- '[]
+          -- ^ In memory
+        ]
+    ]
 
-makePrisms ''SQLiteDBMode
+type SQLiteParamsRec = Config SQLiteParams
+type SQLiteParamsRecP = PartialConfig SQLiteParams
 
-data SQLiteParams = SQLiteParams
-    { sdpMode :: SQLiteDBMode
-    } deriving (Show, Eq)
+defaultSQLiteParams :: SQLiteParamsRecP
+defaultSQLiteParams = mempty
+    & tree #mode . selection ?~ "real"
+    & tree #mode . branch #real . option #path       ?~ "educator-db"
+    & tree #mode . branch #real . option #connNum    ?~ Nothing
+    & tree #mode . branch #real . option #maxPending ?~ 200
 
-makeLensesWith postfixLFields ''SQLiteParams
 
 data SQLiteDB = SQLiteDB
     { sdConnPool   :: Chan Connection
@@ -63,15 +69,3 @@ data SQLiteDB = SQLiteDB
     , sdMaxPending :: Int
       -- ^ Allowed number of pending threads.
     }
-
-deriveFromJSON defaultOptions ''SQLiteRealParams
-
--- | Isomorphism between @Maybe SQLiteRealParams@ and 'SQLiteDBMode'
-maybeToSQLiteDBLoc :: Maybe SQLiteRealParams -> SQLiteDBMode
-maybeToSQLiteDBLoc Nothing       = SQLiteInMemory
-maybeToSQLiteDBLoc (Just params) = SQLiteReal params
-
-instance FromJSON SQLiteDBMode where
-    parseJSON = fmap maybeToSQLiteDBLoc . parseJSON
-
-deriveFromJSON defaultOptions ''SQLiteParams

--- a/educator/src/Dscp/DB/SQLite/Types.hs
+++ b/educator/src/Dscp/DB/SQLite/Types.hs
@@ -25,11 +25,11 @@ import Loot.Config ((::+), (:::), (::-), Config, PartialConfig, tree, branch,
 
 type SQLiteRealParams =
    '[ "path"       ::: FilePath
-      -- ^ Path to the file with database.
+      -- Path to the file with database.
     , "connNum"    ::: Maybe Int
-      -- ^ Connections pool size.
+      -- Connections pool size.
     , "maxPending" ::: Int
-      -- ^ Maximal number of requests waiting for a free connection.
+      -- Maximal number of requests waiting for a free connection.
     ]
 
 type SQLiteRealParamsRec = Config SQLiteRealParams
@@ -41,9 +41,9 @@ type SQLiteRealParamsRecP = PartialConfig SQLiteRealParams
 type SQLiteParams =
    '[ "mode" ::+
        '[ "real"     ::- SQLiteRealParams
-          -- ^ In given file using given number of connections
+          -- In given file using given number of connections
         , "inMemory" ::- '[]
-          -- ^ In memory
+          -- In memory
         ]
     ]
 

--- a/educator/src/Dscp/Educator/Config.hs
+++ b/educator/src/Dscp/Educator/Config.hs
@@ -24,15 +24,14 @@ import Time (Second, Time)
 import Dscp.Config
 import Dscp.DB.SQLite
 import Dscp.Educator.Launcher.Params
-import Dscp.Educator.Web.Bot.Params
 import Dscp.Educator.Web.Config
 import Dscp.Resource.Keys
 import Dscp.Witness.Config
 
 type EducatorConfig = WitnessConfig ++
     '[ "educator" ::<
-       '[ "db" ::: SQLiteParams
-        , "keys" ::: EducatorKeyParams
+       '[ "db" ::< SQLiteParams
+        , "keys" ::< EducatorKeyParams
         , "api" ::< EducatorWebConfig
         , "publishing" ::<
            '[ "period" ::: Time Second
@@ -47,17 +46,9 @@ type HasEducatorConfig = (Given EducatorConfigRec, HasWitnessConfig)
 
 defaultEducatorConfig :: EducatorConfigRecP
 defaultEducatorConfig = upcast defaultWitnessConfig
-    & sub #educator . option #db ?~ defSqliteParams
-    & sub #educator . option #keys ?~ defKeyParams
-    & sub #educator . sub #api . option #botParams ?~ defBotParams
-  where
-    defSqliteParams = SQLiteParams $ SQLiteReal $ SQLiteRealParams
-        { srpPath = "educator-db"
-        , srpConnNum = Nothing
-        , srpMaxPending = 200
-        }
-    defKeyParams = EducatorKeyParams $ BaseKeyParams Nothing False Nothing
-    defBotParams = EducatorBotParams False "Memes generator" 0
+    & sub #educator . sub #db .~ defaultSQLiteParams
+    & sub #educator . sub #keys . sub #keyParams .~ defaultBaseKeyParams
+    & sub #educator . sub #api . sub #botConfig . tree #params . selection ?~ "disabled"
 
 -- instance (HasEducatorConfig, cfg ~ WitnessConfigRec) => Given cfg where
 --     given = rcast (given @EducatorConfigRec)

--- a/educator/src/Dscp/Educator/DB/Resource.hs
+++ b/educator/src/Dscp/Educator/DB/Resource.hs
@@ -20,7 +20,7 @@ prepareEducatorSchema db = do
     runRIO db $ borrowConnection ensureSchemaIsSetUp
 
 instance AllocResource SQLiteDB where
-    type Deps SQLiteDB = SQLiteParams
+    type Deps SQLiteDB = SQLiteParamsRec
     allocResource p = buildComponentR "SQLite DB" (openSQLiteDB' p) closeSQLiteDB
       where
         openSQLiteDB' p' = do

--- a/educator/src/Dscp/Educator/Launcher/Params.hs
+++ b/educator/src/Dscp/Educator/Launcher/Params.hs
@@ -1,12 +1,17 @@
 module Dscp.Educator.Launcher.Params
-       ( EducatorKeyParams (..)
+       ( EducatorKeyParams
+       , EducatorKeyParamsRec
+       , EducatorKeyParamsRecP
        ) where
 
-import Data.Aeson (FromJSON (..))
+import Loot.Config ((::<), Config, PartialConfig)
 
 import Dscp.Resource.Keys (BaseKeyParams)
 
 -- | Educator key parameters.
-newtype EducatorKeyParams = EducatorKeyParams
-    { unEducatorKeyParams :: BaseKeyParams
-    } deriving (Show, Eq, FromJSON)
+type EducatorKeyParams =
+   '[ "keyParams" ::< BaseKeyParams
+    ]
+
+type EducatorKeyParamsRec = Config EducatorKeyParams
+type EducatorKeyParamsRecP = PartialConfig EducatorKeyParams

--- a/educator/src/Dscp/Educator/Launcher/Resource.hs
+++ b/educator/src/Dscp/Educator/Launcher/Resource.hs
@@ -8,14 +8,12 @@ module Dscp.Educator.Launcher.Resource
        ) where
 
 import Control.Lens (makeLenses)
-import Loot.Config (option, sub)
 
 import Dscp.Config
 import Dscp.DB.SQLite (SQLiteDB)
 import Dscp.Educator.Config
 import Dscp.Educator.DB.Resource ()
 import Dscp.Educator.Launcher.Marker (EducatorNode)
-import Dscp.Educator.Launcher.Params (EducatorKeyParams (..))
 import Dscp.Resource.AppDir
 import Dscp.Resource.Class (AllocResource (..), buildComponentR)
 import Dscp.Resource.Keys (KeyResources (..), linkStore)
@@ -40,8 +38,7 @@ deriveHasLens 'erWitnessResources ''EducatorResources ''NetServResources
 instance AllocResource (KeyResources EducatorNode) where
     type Deps (KeyResources EducatorNode) = (EducatorConfigRec, AppDir)
     allocResource (educatorCfg, appDir) =
-        let EducatorKeyParams baseParams =
-                educatorCfg ^. sub #educator . option #keys
+        let baseParams = educatorCfg ^. sub #educator . sub #keys . sub #keyParams
         in buildComponentR "educator keys"
            (withCoreConfig (rcast educatorCfg) $
                linkStore baseParams appDir)
@@ -54,7 +51,7 @@ instance AllocResource EducatorResources where
             witnessCfg = rcast educatorCfg
         _erWitnessResources <- withWitnessConfig witnessCfg $
                                allocResource witnessCfg
-        _erDB <- allocResource $ cfg ^. option #db
+        _erDB <- allocResource $ cfg ^. sub #db
         let appDir = Witness._wrAppDir _erWitnessResources
         _erKeys <- allocResource (educatorCfg, appDir)
         return EducatorResources {..}

--- a/educator/src/Dscp/Educator/Launcher/Runner.hs
+++ b/educator/src/Dscp/Educator/Launcher/Runner.hs
@@ -7,7 +7,6 @@ module Dscp.Educator.Launcher.Runner
     , launchEducatorRealMode
     ) where
 
-import Loot.Config (option, sub)
 import Loot.Log (MonadLogging)
 
 import Dscp.Config
@@ -45,5 +44,5 @@ launchEducatorRealMode config action =
   where
     appDesc = "Educator (real mode)"
     initParams = InitParams
-        { ipLoggingParams = config ^. sub #witness . option #logging
+        { ipLoggingParams = config ^. sub #witness . sub #logging
         }

--- a/educator/src/Dscp/Educator/Logic/Publishing.hs
+++ b/educator/src/Dscp/Educator/Logic/Publishing.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedLabels #-}
+
 module Dscp.Educator.Logic.Publishing
     ( dumpPrivateBlock
     , updateMempoolWithPublications
@@ -7,6 +9,7 @@ import Fmt (build, fmt, listF, nameF)
 import Loot.Log (logInfo)
 import Snowdrop.Util (OldestFirst (..))
 
+import Dscp.Config (option)
 import Dscp.Core
 import Dscp.DB.SQLite
 import Dscp.Educator.DB
@@ -35,7 +38,7 @@ publishMissingBlocks =
     writingSDLock "add publication to mempool" $ do
         sk <- ourSecretKeyData @EducatorNode
         privTip <- runSdMempool $ getPrivateTipHash (skAddress sk)
-        let feePolicy = fcPublication feeConfig
+        let feePolicy = feeConfig ^. option #publication
 
         OldestFirst blocks <-
             invoke (getPrivateBlocksAfterHash privTip)

--- a/educator/src/Dscp/Educator/TestConfig.hs
+++ b/educator/src/Dscp/Educator/TestConfig.hs
@@ -3,7 +3,6 @@ module Dscp.Educator.TestConfig
     ) where
 
 import Data.Default (def)
-import Loot.Config.Record (finaliseDeferredUnsafe)
 
 import Dscp.Config.Util
 import Dscp.Educator.Config

--- a/educator/src/Dscp/Educator/Web/Bot/Handlers.hs
+++ b/educator/src/Dscp/Educator/Web/Bot/Handlers.hs
@@ -13,7 +13,7 @@ import Dscp.Educator.Web.Types
 
 initializeBot
     :: BotWorkMode ctx m
-    => EducatorBotParams -> (HasBotSetting => m a) -> m a
+    => EducatorBotParamsRec -> (HasBotSetting => m a) -> m a
 initializeBot params m = withBotSetting (mkBotSetting params) $ do
     botPrepareInitialData
     botLog $ logInfo "Educator bot initiated"

--- a/educator/src/Dscp/Educator/Web/Bot/Params.hs
+++ b/educator/src/Dscp/Educator/Web/Bot/Params.hs
@@ -1,30 +1,36 @@
 module Dscp.Educator.Web.Bot.Params
-    ( EducatorBotParams (..)
-    , ebpEnabledL
-    , ebpSeedL
-    , ebpOperationsDelayL
+    ( EducatorBotParams
+    , EducatorBotParamsRec
+    , EducatorBotParamsRecP
+
+    , EducatorBotConfig
+    , EducatorBotConfigRec
+    , EducatorBotConfigRecP
     ) where
 
-import Control.Lens (makeLensesWith)
-import Data.Aeson.Options (defaultOptions)
-import Data.Aeson.TH (deriveFromJSON)
+import Loot.Config ((::+), (::-), (:::), Config, PartialConfig)
 import Time.Units (Microsecond, Time)
 
-import Dscp.Util (postfixLFields)
-import Dscp.Util.Aeson ()
-
 -- | Which params to use when launching bot.
--- Bool flag is used instead of `Maybe` value or custom sum type
--- to allow for specifying default values for bot params in
--- default config even though bot should be disabled by default.
-data EducatorBotParams = EducatorBotParams
-    { ebpEnabled         :: !Bool
-      -- ^ Whether or not the bot is enabled
-    , ebpSeed            :: !Text
+type EducatorBotParams =
+   '[ "seed" ::: Text
       -- ^ Seed to generate initial data (assignments, ...).
-    , ebpOperationsDelay :: !(Time Microsecond)
+    , "operationsDelay" ::: Time Microsecond
       -- ^ Artificial delay in bot operations.
-    } deriving (Show, Eq)
+    ]
 
-makeLensesWith postfixLFields ''EducatorBotParams
-deriveFromJSON defaultOptions ''EducatorBotParams
+type EducatorBotParamsRec = Config EducatorBotParams
+type EducatorBotParamsRecP = PartialConfig EducatorBotParams
+
+-- | Configuration to lauch a bot (or not)
+-- Note, there is a reason this contains the whole tree and not just its content
+-- see 'ConfigMaybe' for an explanation.
+type EducatorBotConfig =
+   '[ "params" ::+
+       '[ "disabled" ::- '[]
+        , "enabled"  ::- EducatorBotParams
+        ]
+    ]
+
+type EducatorBotConfigRec = Config EducatorBotConfig
+type EducatorBotConfigRecP = PartialConfig EducatorBotConfig

--- a/educator/src/Dscp/Educator/Web/Bot/Params.hs
+++ b/educator/src/Dscp/Educator/Web/Bot/Params.hs
@@ -14,9 +14,9 @@ import Time.Units (Microsecond, Time)
 -- | Which params to use when launching bot.
 type EducatorBotParams =
    '[ "seed" ::: Text
-      -- ^ Seed to generate initial data (assignments, ...).
+      -- Seed to generate initial data (assignments, ...).
     , "operationsDelay" ::: Time Microsecond
-      -- ^ Artificial delay in bot operations.
+      -- Artificial delay in bot operations.
     ]
 
 type EducatorBotParamsRec = Config EducatorBotParams

--- a/educator/src/Dscp/Educator/Web/Bot/Setting.hs
+++ b/educator/src/Dscp/Educator/Web/Bot/Setting.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedLabels #-}
+
 -- | Bot data and aspects of behaviour.
 
 module Dscp.Educator.Web.Bot.Setting
@@ -28,6 +30,7 @@ import Loot.Log (ModifyLogName, logError, logInfo, modifyLogName)
 import Time.Units (Microsecond, Time, threadDelay)
 import UnliftIO.Async (async)
 
+import Dscp.Config
 import Dscp.Core
 import Dscp.Crypto.Impl
 import Dscp.DB.SQLite
@@ -101,12 +104,12 @@ data BotSetting = BotSetting
     }
 
 -- | Generate a bot setting.
-mkBotSetting :: EducatorBotParams -> BotSetting
+mkBotSetting :: EducatorBotParamsRec -> BotSetting
 mkBotSetting params =
-  BotSetting{ bsOperationsDelay = ebpOperationsDelay params, ..}
+  BotSetting{ bsOperationsDelay = params ^. option #operationsDelay, ..}
  where
   botGen :: Gen a -> a
-  botGen = detGenG (ebpSeed params)
+  botGen = detGenG (params ^. option #seed)
 
   bsCourses =
     [ (Course 0  , "Patakology", [])
@@ -268,8 +271,8 @@ botProvideAdvancedSetting student = do
 -- | Add a grade immediatelly after student submission.
 botGradeSubmission :: BotWorkMode ctx m => SignedSubmission -> m ()
 botGradeSubmission ssub = do
-    let sub = _ssSubmission ssub
-        contentsH = _sContentsHash sub
+    let subm = _ssSubmission ssub
+        contentsH = _sContentsHash subm
     time <- liftIO getCurrentTime
     let grade = detGenG contentsH genPleasantGrade
     let ptx = PrivateTx

--- a/educator/src/Dscp/Educator/Web/Config.hs
+++ b/educator/src/Dscp/Educator/Web/Config.hs
@@ -6,7 +6,7 @@ module Dscp.Educator.Web.Config
     , EducatorWebConfigRec
     ) where
 
-import Loot.Config ((:::), ConfigKind (Final, Partial), ConfigRec)
+import Loot.Config ((:::), (::<), ConfigKind (Final, Partial), ConfigRec)
 
 import Dscp.Educator.Web.Auth
 import Dscp.Educator.Web.Bot.Params
@@ -15,8 +15,8 @@ import Dscp.Educator.Web.Student.Auth ()
 import Dscp.Web
 
 type EducatorWebConfig =
-    '[ "serverParams"      ::: ServerParams
-     , "botParams"         ::: EducatorBotParams
+    '[ "serverParams"      ::< ServerParams
+     , "botConfig"         ::< EducatorBotConfig
      , "educatorAPINoAuth" ::: NoAuthContext "educator"
      , "studentAPINoAuth"  ::: NoAuthContext "student"
      ]

--- a/educator/src/Dscp/Educator/Workers.hs
+++ b/educator/src/Dscp/Educator/Workers.hs
@@ -6,10 +6,10 @@ module Dscp.Educator.Workers
        ) where
 
 import Fmt ((+||), (||+))
-import Loot.Config (option, sub)
 import Loot.Log (logWarning)
 import Time (minute, ms, sec, toUnit)
 
+import Dscp.Config (option, sub)
 import Dscp.Core
 import Dscp.Educator.Config
 import Dscp.Educator.Launcher.Mode

--- a/educator/tests/Test/Dscp/DB/SQLite/Real/Mode.hs
+++ b/educator/tests/Test/Dscp/DB/SQLite/Real/Mode.hs
@@ -1,22 +1,24 @@
+{-# LANGUAGE OverloadedLabels #-}
+
 module Test.Dscp.DB.SQLite.Real.Mode
     ( runSQLiteMode
     , launchSQLiteMode
     ) where
 
+import Control.Lens ((?~))
 import System.IO.Temp (withSystemTempFile)
 
+import Dscp.Config
 import Dscp.DB.SQLite
 import Dscp.Rio
 
 -- | Test parameters for db which is stored in filesystem.
-testRealSQLiteParams :: FilePath -> SQLiteParams
-testRealSQLiteParams dbPath = SQLiteParams
-    { sdpMode = SQLiteReal SQLiteRealParams
-        { srpPath = dbPath
-        , srpConnNum = Just 5
-        , srpMaxPending = 1000
-        }
-    }
+testRealSQLiteParams :: FilePath -> SQLiteParamsRec
+testRealSQLiteParams dbPath = finaliseDeferredUnsafe $ mempty
+    & tree #mode . selection ?~ "real"
+    & tree #mode . branch #real . option #path       ?~ dbPath
+    & tree #mode . branch #real . option #connNum    ?~ Just 5
+    & tree #mode . branch #real . option #maxPending ?~ 1000
 
 -- | Run an action with context supplied with database stored in the provided file.
 runSQLiteMode :: FilePath -> RIO SQLiteDB a -> IO a

--- a/educator/tests/Test/Dscp/DB/SQLite/Real/Transactions.hs
+++ b/educator/tests/Test/Dscp/DB/SQLite/Real/Transactions.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE QuasiQuotes      #-}
 
 -- | This module tests that our wrapper over SQLite library
 -- allow SQL transactions to work properly.

--- a/educator/tests/Test/Dscp/Educator/Bot/Endpoints.hs
+++ b/educator/tests/Test/Dscp/Educator/Bot/Endpoints.hs
@@ -1,5 +1,9 @@
+{-# LANGUAGE OverloadedLabels #-}
+
 module Test.Dscp.Educator.Bot.Endpoints where
 
+import Control.Lens ((?~))
+import Dscp.Config
 import Dscp.Core.Arbitrary
 import Dscp.Crypto
 import Dscp.Educator.Web.Bot
@@ -19,13 +23,12 @@ studentSK = studentSKEx
 testMakeBotHandlers
     :: (TestEducatorM ~ m, HasWitnessConfig)
     => Text -> m (StudentApiHandlers m)
-testMakeBotHandlers seed =
-    initializeBot
-        EducatorBotParams
-        { ebpEnabled = True
-        , ebpSeed = seed
-        , ebpOperationsDelay = 0
-        } $ pure $ addBotHandlers student (studentApiHandlers student)
+testMakeBotHandlers seed = initializeBot botConfig $ pure $
+    addBotHandlers student (studentApiHandlers student)
+  where
+    botConfig = finaliseDeferredUnsafe $ mempty
+        & option #seed            ?~ seed
+        & option #operationsDelay ?~ 0
 
 spec_StudentApiWithBotQueries :: Spec
 spec_StudentApiWithBotQueries = describe "Basic properties" $ do

--- a/faucet/src/Dscp/Faucet/CLI.hs
+++ b/faucet/src/Dscp/Faucet/CLI.hs
@@ -4,7 +4,7 @@ module Dscp.Faucet.CLI
     ( faucetConfigParser
     ) where
 
-import Loot.Config (OptModParser, (%::), (.::), (.:<), (<*<))
+import Loot.Config (OptModParser, (.::), (.:<), (<*<))
 import Options.Applicative (Parser, flag', help, long, metavar, option)
 
 import Dscp.CommonCLI
@@ -23,11 +23,12 @@ dryRunParser = fmap DryRun . flag' True $
 
 faucetConfigParser :: OptModParser FaucetConfig
 faucetConfigParser = #faucet .:<
-    (#keys %:: baseKeyParamsParser "faucet" <*<
-     #api .:: serverParamsParser "faucet" <*<
+    (#keys .:< baseKeyParamsParser "faucet" <*<
+     #api .:< serverParamsParser "faucet" <*<
      #witnessBackend .:: clientAddressParser "witness-backend" wbHelp <*<
      #transferredAmount .:: transferredAmountParser <*<
      #dryRun .:: dryRunParser <*<
-     #appDir .:: appDirParamParser)
+     #appDir .:< appDirParamParser
+    )
   where
     wbHelp = "Address of witness node to accept faucet transactions"

--- a/faucet/src/Dscp/Faucet/Config.hs
+++ b/faucet/src/Dscp/Faucet/Config.hs
@@ -54,13 +54,13 @@ newtype DryRun = DryRun Bool
 --    [@appDir@] Application directory for witness.
 type FaucetConfig = CoreConfig ++
     '[ "faucet" ::<
-       '[ "logging" ::: LoggingParams
-        , "keys" ::: BaseKeyParams
-        , "api" ::: ServerParams
+       '[ "logging" ::< LoggingParams
+        , "keys" ::< BaseKeyParams
+        , "api" ::< ServerParams
         , "witnessBackend" ::: BaseUrl
         , "transferredAmount" ::: TransferredAmount
         , "dryRun" ::: DryRun
-        , "appDir" ::: AppDirParam
+        , "appDir" ::< AppDirParam
         ]
      ]
 
@@ -71,8 +71,8 @@ type HasFaucetConfig = Given FaucetConfigRec
 
 defaultFaucetConfig :: FaucetConfigRecP
 defaultFaucetConfig = mempty
-    & sub #faucet . option #logging ?~ basicLoggingParams "faucet" False
-    & sub #faucet . option #keys ?~ BaseKeyParams Nothing False Nothing
+    & sub #faucet . sub #logging .~ basicLoggingParams "faucet" False
+    & sub #faucet . sub #keys .~ defaultBaseKeyParams
     & sub #faucet . option #dryRun ?~ DryRun False
 
 faucetConfig :: HasFaucetConfig => FaucetConfigRec

--- a/faucet/src/Dscp/Faucet/Launcher/Resource.hs
+++ b/faucet/src/Dscp/Faucet/Launcher/Resource.hs
@@ -33,7 +33,7 @@ makeLenses ''FaucetResources
 instance AllocResource (KeyResources FaucetApp) where
     type Deps (KeyResources FaucetApp) = (FaucetConfigRec, AppDir)
     allocResource (faucetCfg, appDir) =
-        let baseParams = faucetCfg ^. sub #faucet . option #keys
+        let baseParams = faucetCfg ^. sub #faucet . sub #keys
         in buildComponentR "faucet keys"
            (withCoreConfig (rcast faucetCfg) $
                linkStore baseParams appDir)
@@ -44,7 +44,7 @@ instance AllocResource FaucetResources where
     allocResource faucetCfg = do
         let cfg = faucetCfg ^. sub #faucet
         _frLogging <- view (lensOf @(Logging IO))
-        _frAppDir <- allocResource $ cfg ^. option #appDir
+        _frAppDir <- allocResource $ cfg ^. sub #appDir
         _frKeys <- allocResource (faucetCfg, _frAppDir)
         _frWitnessClient <- allocResource $ cfg ^. option #witnessBackend
         return FaucetResources{..}

--- a/faucet/src/Dscp/Faucet/Launcher/Runner.hs
+++ b/faucet/src/Dscp/Faucet/Launcher/Runner.hs
@@ -39,5 +39,5 @@ launchFaucetRealMode config action =
   where
     appDesc = "Faucet (real mode)"
     initParams = InitParams
-        { ipLoggingParams = config ^. sub #faucet . option #logging
+        { ipLoggingParams = config ^. sub #faucet . sub #logging
         }

--- a/faucet/src/Dscp/Faucet/Web/Logic.hs
+++ b/faucet/src/Dscp/Faucet/Web/Logic.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedLabels #-}
+
 -- | Faucet backend logic.
 
 module Dscp.Faucet.Web.Logic
@@ -64,7 +66,7 @@ faucetTransferMoneyTo dest = do
         when (balance < transfer) $
             throwM SourceAccountExhausted
 
-        let feePolicy = fcMoney $ giveL @FaucetConfig @FeeConfig
+        let feePolicy = faucetConfig ^. sub #core . sub #fee . option #money
             nonce = fromIntegral $ aiCurrentNonce sourceState
             outs = one (TxOut dest transfer)
             txWitnessed = createTxw feePolicy sk nonce outs

--- a/faucet/src/Dscp/Faucet/Web/Server.hs
+++ b/faucet/src/Dscp/Faucet/Web/Server.hs
@@ -22,7 +22,7 @@ import Dscp.Faucet.Launcher (FaucetRealMode, FaucetWorkMode)
 import Dscp.Faucet.Web.API (FaucetAPI, faucetAPI)
 import Dscp.Faucet.Web.Handlers (convertFaucetApiHandler, faucetApiHandlers)
 import Dscp.Util.Servant (LoggingApi, methodsCoveringAPI)
-import Dscp.Web (ServerParams (..), serveWeb)
+import Dscp.Web (serveWeb)
 import Dscp.Web.Server (buildServantLogConfig)
 
 type FaucetWebAPI = "api" :> "faucet" :> FaucetAPI
@@ -46,7 +46,7 @@ faucetCors = cors $ const $ Just $
 
 serveFaucetAPIReal :: HasFaucetConfig => FaucetRealMode ()
 serveFaucetAPIReal = do
-    let ServerParams {..} = faucetConfig ^. sub #faucet . option #api
+    let spAddr = faucetConfig ^. sub #faucet . sub #api . option #addr
     logInfo $ "Serving faucet API on "+|spAddr|+""
     ctx <- ask
     lc <- buildServantLogConfig (<> "web")

--- a/multi-educator/src/Dscp/MultiEducator/CLI.hs
+++ b/multi-educator/src/Dscp/MultiEducator/CLI.hs
@@ -8,7 +8,7 @@ module Dscp.MultiEducator.CLI
     , multiEducatorConfigParser
     ) where
 
-import Loot.Config (OptModParser, uplift, (%::), (.::), (.:<), (<*<))
+import Loot.Config (OptModParser, uplift, (.::), (.:<), (<*<))
 import Options.Applicative (Parser, help, long, metavar, strOption)
 
 import Dscp.Educator.CLI (educatorWebConfigParser, publishingPeriodParser, sqliteParamsParser)
@@ -26,7 +26,7 @@ multiEducatorConfigParser :: OptModParser MultiEducatorConfig
 multiEducatorConfigParser =
     uplift witnessConfigParser <*<
     #educator .:<
-        (#db %:: sqliteParamsParser <*<
+        (#db .:< sqliteParamsParser <*<
          #keys .:: multiEducatorKeyParamsParser <*<
          #api .:< educatorWebConfigParser <*<
          #publishing .:<

--- a/multi-educator/src/Dscp/MultiEducator/Config.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Config.hs
@@ -22,14 +22,13 @@ import Time (Second, Time)
 
 import Dscp.Config
 import Dscp.DB.SQLite
-import Dscp.Educator.Web.Bot.Params
 import Dscp.Educator.Web.Config
 import Dscp.MultiEducator.Launcher.Params (MultiEducatorKeyParams)
 import Dscp.Witness.Config
 
 type MultiEducatorConfig = WitnessConfig ++
     '[ "educator" ::<
-       '[ "db" ::: SQLiteParams
+       '[ "db" ::< SQLiteParams
         , "keys" ::: MultiEducatorKeyParams
         , "api" ::< EducatorWebConfig
         , "publishing" ::<
@@ -45,15 +44,8 @@ type HasMultiEducatorConfig = Given MultiEducatorConfigRec
 
 defaultMultiEducatorConfig :: MultiEducatorConfigRecP
 defaultMultiEducatorConfig = upcast defaultWitnessConfig
-    & sub #educator . option #db ?~ defSqliteParams
-    & sub #educator . sub #api . option #botParams ?~ defBotParams
-  where
-    defSqliteParams = SQLiteParams $ SQLiteReal $ SQLiteRealParams
-        { srpPath = "educator-db"
-        , srpConnNum = Nothing
-        , srpMaxPending = 200
-        }
-    defBotParams = EducatorBotParams False "Memes generator" 0
+    & sub #educator . sub #db .~ defaultSQLiteParams
+    & sub #educator . sub #api . sub #botConfig . tree #params . selection ?~ "disabled"
 
 -- instance (HasEducatorConfig, cfg ~ WitnessConfigRec) => Given cfg where
 --     given = rcast (given @EducatorConfigRec)

--- a/multi-educator/src/Dscp/MultiEducator/Launcher/Entry.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Launcher/Entry.hs
@@ -7,10 +7,10 @@ module Dscp.MultiEducator.Launcher.Entry
     ) where
 
 import Control.Concurrent (threadDelay)
-import Loot.Config (option, sub)
 import Loot.Log (logInfo)
 import UnliftIO.Async (async)
 
+import Dscp.Config (sub, tree, branch, whenConfigJust)
 import Dscp.MultiEducator.Config
 import Dscp.MultiEducator.Launcher.Mode
 import Dscp.MultiEducator.Web.Server
@@ -21,13 +21,13 @@ import Dscp.Witness.Web.Server
 educatorEntry :: MultiCombinedWorkMode ctx m => m ()
 educatorEntry =
     withServer . withWitnessBackground $ do
-        let witnessApiParams = witnessConfig ^. sub #witness . option #api
+        let witnessApiParams = witnessConfig ^. sub #witness . sub #api
             educatorServerParams = multiEducatorConfig ^.
-                sub #educator . sub #api . option #serverParams
+                sub #educator . sub #api . sub #serverParams
             separateWitnessServer =
-                witnessApiParams /=
+                witnessApiParams ^. tree #maybe . branch #just /=
                 Just educatorServerParams
-        whenJust witnessApiParams $ \serverParams ->
+        whenConfigJust witnessApiParams $ \serverParams ->
             when separateWitnessServer $ do
                 logInfo "Forking witness API server"
                 void . async $

--- a/multi-educator/src/Dscp/MultiEducator/Launcher/Params.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Launcher/Params.hs
@@ -8,4 +8,4 @@ import Data.Aeson (FromJSON (..))
 newtype MultiEducatorKeyParams = MultiEducatorKeyParams
     { unMultiEducatorKeyParams :: FilePath
       -- ^ Educator key folder
-    } deriving (Show, FromJSON)
+    } deriving (Eq, Show, FromJSON)

--- a/multi-educator/src/Dscp/MultiEducator/Launcher/Runner.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Launcher/Runner.hs
@@ -7,7 +7,6 @@ module Dscp.MultiEducator.Launcher.Runner
     , launchEducatorRealMode
     ) where
 
-import Loot.Config (option, sub)
 import Loot.Log (MonadLogging)
 
 import Dscp.Config
@@ -45,5 +44,5 @@ launchEducatorRealMode config action =
   where
     appDesc = "Educator (real mode)"
     initParams = InitParams
-        { ipLoggingParams = config ^. sub #witness . option #logging
+        { ipLoggingParams = config ^. sub #witness . sub #logging
         }

--- a/multi-educator/tests/Main.hs
+++ b/multi-educator/tests/Main.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF tasty-discover -optF --tree-display #-}

--- a/multi-educator/tests/Test/Dscp/MultiEducator/CLI.hs
+++ b/multi-educator/tests/Test/Dscp/MultiEducator/CLI.hs
@@ -1,0 +1,9 @@
+module Test.Dscp.MultiEducator.CLI where
+
+import Dscp.MultiEducator.CLI
+import Dscp.Util.Test
+
+spec_MultiEducatorCli :: Spec
+spec_MultiEducatorCli = describe "MultiEducator CLI interface" $
+    it "should not yield any default values if no CLI params are provided" $
+        (runCliArgs multiEducatorConfigParser [] <*> pure mempty) `shouldBe` Just mempty

--- a/scripts/launch/demo.sh
+++ b/scripts/launch/demo.sh
@@ -89,6 +89,8 @@ function witness_args {
     --db-path $witness_dir/witness.db
     --db-clean
     --comm-n $index
+    --comm-open
+    --witness-keys-comm
     --metrics-server 127.0.0.1:8125
     $peers
     "

--- a/scripts/launch/node.sh
+++ b/scripts/launch/node.sh
@@ -108,6 +108,8 @@ witness_params="
 --db-path $tmp_files/witness.db
 --witness-listen $witness_web_addr
 --comm-n 0
+--comm-open
+--witness-keys-comm
 --metrics-server 127.0.0.1:8125
 "
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -62,7 +62,7 @@ extra-deps:
 - primitive-0.6.4.0
 
 - git: https://github.com/serokell/lootbox.git
-  commit: b66d53bf42e88d44184046f3450ab2f01bd9c8b6
+  commit: ec3caaedd6b41e783e3266c7f15e5598576f6aa5
   subdirs:
     - code/base
     - code/config

--- a/wallet/src/Dscp/Wallet/Backend.hs
+++ b/wallet/src/Dscp/Wallet/Backend.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedLabels #-}
+
 module Dscp.Wallet.Backend
        ( WalletFace(..)
        , createWalletFace
@@ -6,6 +8,7 @@ module Dscp.Wallet.Backend
 import Control.Exception (throwIO)
 import Control.Monad.Component (ComponentM, buildComponent_)
 
+import Dscp.Config (option)
 import Dscp.Core
 import Dscp.Crypto
 import Dscp.Wallet.Face
@@ -88,7 +91,7 @@ sendTx wc sendEvent eSecretKey mPassPhrase (toList -> outs) = do
     nonce <- fromIntegral . unNonce . aiCurrentNonce <$>
              wGetAccount wc (skAddress secretData) False
 
-    let txWitnessed = createTxw (fcMoney feeConfig) secretData nonce outs
+    let txWitnessed = createTxw (feeConfig ^. option #money) secretData nonce outs
 
     sendLogEvent sendEvent $
         "Sending transaction: {"

--- a/witness/src/Dscp/CommonCLI.hs
+++ b/witness/src/Dscp/CommonCLI.hs
@@ -110,7 +110,7 @@ clientAddressParser pName helpTxt =
     help helpTxt
 
 serverParamsParser :: String -> OptModParser ServerParams
-serverParamsParser desc = 
+serverParamsParser desc =
     #addr .:: networkAddressParser (map toLower desc <> "-listen")
         ("Host/port for serving " <> desc <> " API. If executable supports \
          \multiple APIs, they are allowed to have the same port.")

--- a/witness/src/Dscp/CommonCLI.hs
+++ b/witness/src/Dscp/CommonCLI.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE ApplicativeDo #-}
-{-# LANGUAGE QuasiQuotes   #-}
+{-# LANGUAGE ApplicativeDo    #-}
+{-# LANGUAGE QuasiQuotes      #-}
+{-# LANGUAGE OverloadedLabels #-}
 
 -- | Common CLI params.
 
@@ -18,20 +19,21 @@ module Dscp.CommonCLI
 
 import Data.Char (toLower)
 import Data.Version (showVersion)
-import Loot.Config.CLI (ModParser, (..:), (<*<))
+import Loot.Config.CLI (OptModParser, (.::), (.:+), (.:-), (<*<))
 import Options.Applicative (Parser, ReadM, auto, eitherReader, flag', help, infoOption, long,
                             maybeReader, metavar, option, str, strOption)
 import Servant.Client (BaseUrl (..), parseBaseUrl)
 import Text.InterpolatedString.Perl6 (qc)
 import Time (KnownRatName, Time, unitsP)
 
+import Dscp.Config (selectBranchParser)
 import Dscp.Core.Foundation
 import Dscp.Crypto (PassPhrase)
 import Dscp.Crypto (mkPassPhrase)
 import Dscp.Resource.AppDir
 import Dscp.Resource.Keys
 import Dscp.Util
-import Dscp.Web (NetworkAddress (..), ServerParams (..), parseNetAddr)
+import Dscp.Web (NetworkAddress (..), ServerParams, parseNetAddr)
 import Paths_disciplina_witness (version)
 
 versionOption :: Parser (a -> a)
@@ -39,11 +41,11 @@ versionOption = infoOption ("disciplina-" <> (showVersion version)) $
     long "version" <>
     help "Show version."
 
-baseKeyParamsParser :: Text -> ModParser BaseKeyParams
+baseKeyParamsParser :: Text -> OptModParser BaseKeyParams
 baseKeyParamsParser who =
-    bkpPathL       ..: kpKeyPathParser <*<
-    bkpGenNewL     ..: kpGenKeyParser <*<
-    bkpPassphraseL ..: kpPassphraseParser
+    #path       .:: kpKeyPathParser <*<
+    #genNew     .:: kpGenKeyParser <*<
+    #passphrase .:: kpPassphraseParser
   where
     kpKeyPathParser = fmap Just . strOption $
          long [qc|{who}-keyfile|] <>
@@ -59,17 +61,16 @@ baseKeyParamsParser who =
          metavar "PASSWORD" <>
          help "Password of secret key."
 
-appDirParamParser :: Parser AppDirParam
-appDirParamParser =
-    AppDirectorySpecific <$> specificP <|>
-    AppDirectoryOS <$ osP
+appDirParamParser :: OptModParser AppDirParam
+appDirParamParser = #param .:+
+    selectBranchParser #paramType osP "specific" (#specific .:- (#path .:: specificP))
   where
     specificP = strOption $
       long "appdir" <>
       metavar "FILEPATH" <>
       help "Path to application folder. To use OS-specific default folder \
            \(e. g. '%APPDIR%/Disciplina'), provide `--os-appdir` flag instead."
-    osP = flag' () $
+    osP = flag' "os" $
       long "os-appdir" <>
       help "Use OS-specific default application folder. To use custom application \
            \folder, provide `--appdir` option instead."
@@ -108,9 +109,8 @@ clientAddressParser pName helpTxt =
     metavar "URL" <>
     help helpTxt
 
-serverParamsParser :: String -> Parser ServerParams
-serverParamsParser desc = do
-    spAddr <- networkAddressParser (map toLower desc <> "-listen")
+serverParamsParser :: String -> OptModParser ServerParams
+serverParamsParser desc = 
+    #addr .:: networkAddressParser (map toLower desc <> "-listen")
         ("Host/port for serving " <> desc <> " API. If executable supports \
          \multiple APIs, they are allowed to have the same port.")
-    return ServerParams{..}

--- a/witness/src/Dscp/DB/Rocks/Real/Functions.hs
+++ b/witness/src/Dscp/DB/Rocks/Real/Functions.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Dscp.DB.Rocks.Real.Functions
@@ -38,7 +39,8 @@ import Loot.Base.HasLens (HasLens')
 import System.Directory (doesDirectoryExist, removeDirectoryRecursive)
 import UnliftIO (MonadUnliftIO)
 
-import Dscp.DB.Rocks.Real.Types (DB (..), RocksDB (..), RocksDBParams (..))
+import Dscp.Config
+import Dscp.DB.Rocks.Real.Types (DB (..), RocksDB (..), RocksDBParamsRec)
 import Dscp.Util
 import Dscp.Util.Serialise
 
@@ -72,8 +74,10 @@ openRocksDB path = do
 closeRocksDB :: MonadIO m => DB -> m ()
 closeRocksDB = Rocks.close . rocksDB
 
-openNodeDB :: MonadIO m => RocksDBParams -> m RocksDB
-openNodeDB RocksDBParams{..} = liftIO $ do
+openNodeDB :: MonadIO m => RocksDBParamsRec -> m RocksDB
+openNodeDB rocksDBParams = liftIO $ do
+    let rdpPath  = rocksDBParams ^. option #path
+        rdpClean = rocksDBParams ^. option #clean
     dirExists <- doesDirectoryExist rdpPath
 
     when (rdpClean && dirExists) $ do

--- a/witness/src/Dscp/DB/Rocks/Real/Types.hs
+++ b/witness/src/Dscp/DB/Rocks/Real/Types.hs
@@ -1,21 +1,18 @@
 module Dscp.DB.Rocks.Real.Types
        ( MonadRealDB
        , DB (..)
-       , RocksDBParams (..)
-       , rdpPathL
-       , rdpCleanL
+       , RocksDBParams
+       , RocksDBParamsRec
+       , RocksDBParamsRecP
        , RocksDB (..)
        , rdDatabase
        , Rocks.BatchOp (..)
        ) where
 
-import Control.Lens (makeLenses, makeLensesWith)
-import Data.Aeson.Options (defaultOptions)
-import Data.Aeson.TH (deriveFromJSON)
+import Control.Lens (makeLenses)
 import qualified Database.RocksDB as Rocks
 import Loot.Base.HasLens (HasLens')
-
-import Dscp.Util (postfixLFields)
+import Loot.Config ((:::), Config, PartialConfig)
 
 -- | Set of constraints necessary to operate on real DB.
 type MonadRealDB ctx m =
@@ -34,17 +31,19 @@ data DB = DB
     }
 
 -- | Set of parameters provided on opening connection.
-data RocksDBParams = RocksDBParams
-    { rdpPath  :: !FilePath
+type RocksDBParams =
+   '[ "path"  ::: FilePath
       -- ^ Path to the database
-    , rdpClean :: !Bool
+    , "clean" ::: Bool
       -- ^ Whether DB should be cleaned/removed on start.
-    } deriving (Show, Eq)
+    ]
+
+type RocksDBParamsRec = Config RocksDBParams
+type RocksDBParamsRecP = PartialConfig RocksDBParams
+
 
 data RocksDB = RocksDB
     { _rdDatabase :: !DB
     }
 
-makeLensesWith postfixLFields ''RocksDBParams
 makeLenses ''RocksDB
-deriveFromJSON defaultOptions ''RocksDBParams

--- a/witness/src/Dscp/DB/Rocks/Real/Types.hs
+++ b/witness/src/Dscp/DB/Rocks/Real/Types.hs
@@ -33,9 +33,9 @@ data DB = DB
 -- | Set of parameters provided on opening connection.
 type RocksDBParams =
    '[ "path"  ::: FilePath
-      -- ^ Path to the database
+      -- Path to the database
     , "clean" ::: Bool
-      -- ^ Whether DB should be cleaned/removed on start.
+      -- Whether DB should be cleaned/removed on start.
     ]
 
 type RocksDBParamsRec = Config RocksDBParams

--- a/witness/src/Dscp/Resource/Keys/Types.hs
+++ b/witness/src/Dscp/Resource/Keys/Types.hs
@@ -38,14 +38,14 @@ import Dscp.Util.Aeson (Base64Encoded, EncodeSerialised (..), Versioned)
 -- | Contains all parameters required for manipulating with secret key.
 type BaseKeyParams =
    '[ "path"       ::: Maybe FilePath
-      -- ^ Path to file with secret key.
+      -- Path to file with secret key.
       -- If not specified, some default OS-dependent path is used.
     , "genNew"     ::: Bool
-      -- ^ When 'True', file with secret key is expected to be
+      -- When 'True', file with secret key is expected to be
       -- absent and will be generated from scratch.
     , "passphrase" ::: Maybe PassPhrase
       -- When 'False', file should be present and it will be used.
-      -- ^ Password of encrypted secret key stored on disk.
+      -- Password of encrypted secret key stored on disk.
     ]
 
 type BaseKeyParamsRec = Config BaseKeyParams
@@ -63,13 +63,13 @@ defaultBaseKeyParams = mempty
 type CommitteeParams =
    '[ "params" ::+
        '[ "participantN" ::: Integer
-          -- ^ This is necessary to both types of committee
+          -- This is necessary to both types of committee
         , "open" ::- '[]
-          -- ^ In open committee you become participant n/N.
+          -- In open committee you become participant n/N.
         , "closed" ::-
            '[ "secret" ::: CommitteeSecret
             ]
-          -- ^ In closed committee you should provide a (common) secret and your index.
+          -- In closed committee you should provide a (common) secret and your index.
         ]
     ]
 

--- a/witness/src/Dscp/Resource/Network.hs
+++ b/witness/src/Dscp/Resource/Network.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedLabels #-}
+
 -- | ZMQ TCP Networking resource allocation.
 
 module Dscp.Resource.Network
@@ -10,7 +12,9 @@ module Dscp.Resource.Network
     , NetCliParams(..)
     , NetCliResources(..)
 
-    , NetServParams(..)
+    , NetServParams
+    , NetServParamsRec
+    , NetServParamsRecP
     , NetServResources(..)
     ) where
 
@@ -21,6 +25,7 @@ import Data.Aeson.TH (deriveFromJSON)
 import Data.Default (def)
 import Data.Reflection (Given (given), give)
 import Loot.Base.HasLens (HasLens (..))
+import Loot.Config ((:::), Config, PartialConfig, option)
 import Loot.Log (Logging)
 import Loot.Network.ZMQ (ZTGlobalEnv, ZTNetCliEnv, ZTNetServEnv, ZTNodeId, createNetCliEnv,
                          createNetServEnv, parseZTNodeId, termNetCliEnv, termNetServEnv,
@@ -100,12 +105,15 @@ instance WithNetLogging => AllocResource NetCliResources where
 ----------------------------------------------------------------------------
 
 -- | Server networking params.
-data NetServParams = NetServParams
-    { nsPeers      :: ![ZTNodeId]
+type NetServParams =
+   '[ "peers"      ::: [ZTNodeId]
       -- ^ Peers we should connect to
-    , nsOurAddress :: !ZTNodeId
+    , "ourAddress" ::: ZTNodeId
       -- ^ Our binding address
-    } deriving (Show, Eq)
+    ]
+
+type NetServParamsRec = Config NetServParams
+type NetServParamsRecP = PartialConfig NetServParams
 
 -- | Resources needed for ZMQ TCP client + server.
 data NetServResources = NetServResources
@@ -121,14 +129,14 @@ instance HasLens ZTNetCliEnv NetServResources ZTNetCliEnv where lensOf = nsClien
 instance HasLens ZTNetServEnv NetServResources ZTNetServEnv where lensOf = nsServerEnv
 
 instance WithNetLogging => AllocResource NetServResources where
-    type Deps NetServResources = NetServParams
-    allocResource NetServParams {..} =
+    type Deps NetServResources = NetServParamsRec
+    allocResource netServParams =
         buildComponentR "netcli" allocate release
       where
         allocate = liftIO $ do
             global <- ztGlobalEnv (unNetLogging netLogging)
-            cli <- createNetCliEnv global def nsPeers
-            serv <- createNetServEnv global def nsOurAddress
+            cli <- createNetCliEnv global def $ netServParams ^. option #peers
+            serv <- createNetServEnv global def $ netServParams ^. option #ourAddress
 
             pure $ NetServResources global cli serv
         release NetServResources{..} = liftIO $ do
@@ -145,4 +153,3 @@ instance FromJSON ZTNodeId where
         either fail pure . parseZTNodeId . toString
 
 deriveFromJSON defaultOptions ''NetCliParams
-deriveFromJSON defaultOptions ''NetServParams

--- a/witness/src/Dscp/Resource/Network.hs
+++ b/witness/src/Dscp/Resource/Network.hs
@@ -107,9 +107,9 @@ instance WithNetLogging => AllocResource NetCliResources where
 -- | Server networking params.
 type NetServParams =
    '[ "peers"      ::: [ZTNodeId]
-      -- ^ Peers we should connect to
+      -- Peers we should connect to
     , "ourAddress" ::: ZTNodeId
-      -- ^ Our binding address
+      -- Our binding address
     ]
 
 type NetServParamsRec = Config NetServParams

--- a/witness/src/Dscp/Resource/Rocks.hs
+++ b/witness/src/Dscp/Resource/Rocks.hs
@@ -10,5 +10,5 @@ import Dscp.Resource.Class (AllocResource (..), buildComponentR)
 ----------------------------------------------------------------------------
 
 instance AllocResource RocksDB where
-    type Deps RocksDB = RocksDBParams
+    type Deps RocksDB = RocksDBParamsRec
     allocResource p = buildComponentR "RocksDB" (openNodeDB p) closeNodeDB

--- a/witness/src/Dscp/Snowdrop/Expanders.hs
+++ b/witness/src/Dscp/Snowdrop/Expanders.hs
@@ -372,7 +372,7 @@ seqExpandersBlockMetaTx =
                   throwLocalError SlotIdIsNotIncreased
                   { bmeProvidedSlotId = hSlotId header, bmeTipSlotId = hSlotId prevHeader }
 
-            let GovCommittee com = gcGovernance $ giveL @CoreConfig
+            let GovCommittee com = genesisGovernance
             unless (committeeOwnsSlot com issuerAddr (hSlotId header)) $
                 throwLocalError $ IssuerDoesNotOwnSlot
                 { bmrSlotId = hSlotId header, bmrIssuer = issuerAddr }

--- a/witness/src/Dscp/Web/Aeson.hs
+++ b/witness/src/Dscp/Web/Aeson.hs
@@ -4,12 +4,9 @@
 module Dscp.Web.Aeson () where
 
 import Data.Aeson (FromJSON (..), ToJSON (..), Value (..), withText)
-import Data.Aeson.Options (defaultOptions)
-import Data.Aeson.TH (deriveJSON)
 
 import Dscp.Util (leftToFail)
 import Dscp.Web.Metrics
-import Dscp.Web.Params
 import Dscp.Web.Types
 
 instance ToJSON NetworkAddress where
@@ -22,5 +19,3 @@ instance ToJSON MetricsEndpoint where
     toJSON = toJSON . fmap endpointToAddr . unMetricsEndpoint
 instance FromJSON MetricsEndpoint where
     parseJSON = fmap (MetricsEndpoint . fmap addrToEndpoint) . parseJSON
-
-deriveJSON defaultOptions ''ServerParams

--- a/witness/src/Dscp/Web/Params.hs
+++ b/witness/src/Dscp/Web/Params.hs
@@ -1,12 +1,19 @@
 -- | Utils for serving HTTP APIs
 
 module Dscp.Web.Params
-       ( ServerParams (..)
+       ( ServerParams
+       , ServerParamsRec
+       , ServerParamsRecP
        ) where
+
+import Loot.Config ((:::), Config, PartialConfig)
 
 import Dscp.Web.Types
 
 -- | Params needed to start (servant) server.
-data ServerParams = ServerParams
-    { spAddr :: !NetworkAddress
-    } deriving (Eq, Show, Generic)
+type ServerParams =
+   '[ "addr" ::: NetworkAddress
+    ]
+
+type ServerParamsRec = Config ServerParams
+type ServerParamsRecP = PartialConfig ServerParams

--- a/witness/src/Dscp/Witness/Config.hs
+++ b/witness/src/Dscp/Witness/Config.hs
@@ -18,26 +18,26 @@ module Dscp.Witness.Config
 
 import Control.Lens ((?~))
 import Data.Reflection (Given (..), give)
-import Loot.Config ((:::), (::<), ConfigKind (Final, Partial), ConfigRec, option, sub)
+import Loot.Config ((:::), (::<), ConfigKind (Final, Partial), ConfigRec)
 
 import Dscp.Config
 import Dscp.Core.Config
-import Dscp.DB.Rocks.Real.Types (RocksDBParams (..))
-import Dscp.Resource.AppDir (AppDirParam (..))
-import Dscp.Resource.Keys (BaseKeyParams (..))
-import Dscp.Resource.Logging (LoggingParams (..), basicLoggingParams)
+import Dscp.DB.Rocks.Real.Types
+import Dscp.Resource.AppDir (AppDirParam)
+import Dscp.Resource.Keys.Types (defaultBaseKeyParams)
+import Dscp.Resource.Logging (LoggingParams, basicLoggingParams)
 import Dscp.Resource.Network (NetServParams)
 import Dscp.Web (MetricsEndpoint (..), ServerParams)
-import Dscp.Witness.Keys (WitnessKeyParams (..))
+import Dscp.Witness.Keys
 
 type WitnessConfig = CoreConfig ++
     '[ "witness" ::<
-       '[ "logging" ::: LoggingParams
-        , "db" ::: RocksDBParams
-        , "network" ::: NetServParams
-        , "keys" ::: WitnessKeyParams
-        , "api" ::: Maybe ServerParams
-        , "appDir" ::: AppDirParam
+       '[ "logging" ::< LoggingParams
+        , "db" ::< RocksDBParams
+        , "network" ::< NetServParams
+        , "keys" ::< WitnessKeyParams
+        , "api" ::< ConfigMaybe ServerParams
+        , "appDir" ::< AppDirParam
         , "metricsEndpoint" ::: MetricsEndpoint
         ]
      ]
@@ -58,12 +58,21 @@ instance HasWitnessConfig => Given CoreConfigRec where
 
 defaultWitnessConfig :: WitnessConfigRecP
 defaultWitnessConfig = mempty
-    & sub #witness . option #logging ?~ basicLoggingParams "witness" False
-    & sub #witness . option #db ?~ RocksDBParams "witness-db" False
-    & sub #witness . option #keys ?~ Basic (BaseKeyParams Nothing False Nothing)
-    & sub #witness . option #api ?~ Nothing
-    & sub #witness . option #appDir ?~ AppDirectoryOS
+    & sub #witness . sub #logging .~ basicLoggingParams "witness" False
+    & sub #witness . sub #db .~ rocksDBParams
+    & sub #witness . sub #keys .~ keysParams
+    & sub #witness . sub #api . tree #maybe . selection ?~ "nothing"
+    & sub #witness . sub #appDir . tree #param . selection ?~ "os"
     & sub #witness . option #metricsEndpoint ?~ MetricsEndpoint Nothing
+  where
+    keysParams :: WitnessKeyParamsRecP
+    keysParams = mempty
+        & tree #params . selection ?~ "basic"
+        & tree #params . branch #basic .~ defaultBaseKeyParams
+    rocksDBParams :: RocksDBParamsRecP
+    rocksDBParams = mempty
+        & option #path  ?~ "witness-db"
+        & option #clean ?~ False
 
 witnessConfig :: HasWitnessConfig => WitnessConfigRec
 witnessConfig = given

--- a/witness/src/Dscp/Witness/Keys.hs
+++ b/witness/src/Dscp/Witness/Keys.hs
@@ -1,29 +1,26 @@
 {-# LANGUAGE StrictData #-}
 
 module Dscp.Witness.Keys
-       ( WitnessKeyParams (..)
-       , _Basic
-       , _Committee
+       ( WitnessKeyParams
+       , WitnessKeyParamsRec
+       , WitnessKeyParamsRecP
        ) where
 
-import Control.Lens (makePrisms)
-import Data.Aeson (FromJSON (..), Value (..), withObject, (.:))
+import Loot.Config ((::+), (::-), Config, PartialConfig)
 
 import Dscp.Resource.Keys
 
 -- | Witness key parameters.
-data WitnessKeyParams
-    = Basic BaseKeyParams       -- ^ Basic key management with a keyfile
-    | Committee CommitteeParams -- ^ Generate a key from committee params
-    deriving (Show, Eq)
+-- Note, there is a reason this contains the whole tree and not just its content
+-- see 'ConfigMaybe' for an explanation.
+type WitnessKeyParams =
+   '[ "params" ::+
+       '[ "basic" ::- BaseKeyParams
+          -- ^ Basic key management with a keyfile
+        , "committee" ::- CommitteeParams
+          -- ^ Generate a key from committee params
+        ]
+    ]
 
-makePrisms ''WitnessKeyParams
-
--- | JSON instance (for configuration specs)
-instance FromJSON WitnessKeyParams where
-    parseJSON = withObject "WitnessKeyParams" $ \o -> do
-        typ :: Text <- o .: "type"
-        case typ of
-            "basic"     -> Basic <$> parseJSON (Object o)
-            "committee" -> Committee <$> parseJSON (Object o)
-            _           -> fail $ "Unrecognized key params type: " ++ toString typ
+type WitnessKeyParamsRec = Config WitnessKeyParams
+type WitnessKeyParamsRecP = PartialConfig WitnessKeyParams

--- a/witness/src/Dscp/Witness/Keys.hs
+++ b/witness/src/Dscp/Witness/Keys.hs
@@ -16,9 +16,9 @@ import Dscp.Resource.Keys
 type WitnessKeyParams =
    '[ "params" ::+
        '[ "basic" ::- BaseKeyParams
-          -- ^ Basic key management with a keyfile
+          -- Basic key management with a keyfile
         , "committee" ::- CommitteeParams
-          -- ^ Generate a key from committee params
+          -- Generate a key from committee params
         ]
     ]
 

--- a/witness/src/Dscp/Witness/Launcher/Entry.hs
+++ b/witness/src/Dscp/Witness/Launcher/Entry.hs
@@ -9,11 +9,11 @@ module Dscp.Witness.Launcher.Entry
 
 import Control.Concurrent (threadDelay)
 import Fmt ((+|), (|+))
-import Loot.Config (option, sub)
 import Loot.Log (logDebug, logInfo)
 import Time (sec)
 import UnliftIO.Async (async, cancel)
 
+import Dscp.Config (sub, whenConfigJust)
 import Dscp.Network (runListener, runWorker, withServer)
 import Dscp.Util.TimeLimit
 import Dscp.Witness.Config
@@ -50,8 +50,8 @@ withWitnessBackground cont = do
 witnessEntry :: FullWitnessWorkMode ctx m => m ()
 witnessEntry =
     withServer. withWitnessBackground $ do
-        let mServerParams = witnessConfig ^. sub #witness . option #api
-        whenJust mServerParams $ \serverParams -> do
+        let mServerParams = witnessConfig ^. sub #witness . sub #api
+        whenConfigJust mServerParams $ \serverParams -> do
             logInfo "Forking witness API server"
             void . async $
                 serveWitnessAPIReal serverParams

--- a/witness/src/Dscp/Witness/Launcher/Runner.hs
+++ b/witness/src/Dscp/Witness/Launcher/Runner.hs
@@ -8,9 +8,9 @@ module Dscp.Witness.Launcher.Runner
     , launchWitnessRealMode
     ) where
 
-import Loot.Config (option, sub)
 import Loot.Log (MonadLogging)
 
+import Dscp.Config (sub)
 import Dscp.Resource.Class (AllocResource (..), InitParams (..))
 import Dscp.Resource.Functions
 import Dscp.Resource.Keys (krPublicKey)
@@ -62,5 +62,5 @@ launchWitnessRealMode config action =
   where
     appDesc = "Witness (real mode)"
     initParams = InitParams
-        { ipLoggingParams = config ^. sub #witness . option #logging
+        { ipLoggingParams = config ^. sub #witness . sub #logging
         }

--- a/witness/src/Dscp/Witness/Listeners/Listener.hs
+++ b/witness/src/Dscp/Witness/Listeners/Listener.hs
@@ -18,7 +18,6 @@ import Dscp.Network.Wrapped
 import Dscp.Resource.Keys (ourPublicKey)
 import Dscp.Snowdrop
 import Dscp.Util.Timing
-import Dscp.Witness.Config
 import Dscp.Witness.Launcher.Context
 import Dscp.Witness.Logic
 import Dscp.Witness.Messages
@@ -47,7 +46,7 @@ blockIssuingListener =
   where
     action :: ListenerEnv NetTag -> m ()
     action btq = do
-        let GovCommittee committee = gcGovernance $ giveL @WitnessConfig @GenesisConfig
+        let GovCommittee committee = genesisGovernance
         slotId <- waitUntilNextSlot
         ourAddr <- mkAddr <$> ourPublicKey @WitnessNode
         logInfo $ "New slot has just started: " +| slotId |+ ""

--- a/witness/src/Dscp/Witness/Web/Server.hs
+++ b/witness/src/Dscp/Witness/Web/Server.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedLabels #-}
+
 -- | Functions to serve wallet API.
 
 module Dscp.Witness.Web.Server
@@ -15,8 +17,9 @@ import Network.Wai.Middleware.Cors (CorsResourcePolicy (..), cors, simpleCorsRes
 import Servant (Handler, Server, StdMethod (..), hoistServer, serve, throwError)
 import UnliftIO (UnliftIO (..), askUnliftIO)
 
+import Dscp.Config (option)
 import Dscp.Util.Servant (LoggingApi, ServantLogConfig (..), methodsCoveringAPI)
-import Dscp.Web (ServerParams (..), buildServantLogConfig, serveWeb)
+import Dscp.Web (ServerParamsRec, buildServantLogConfig, serveWeb)
 import Dscp.Web.Class
 import Dscp.Witness.Launcher.Context
 import Dscp.Witness.Web.API (WitnessAPI, witnessAPI)
@@ -51,8 +54,9 @@ witnessCors = cors $ const $ Just $
     , corsRequestHeaders = [hContentType]
     }
 
-serveWitnessAPIReal :: WitnessWorkMode ctx m => ServerParams -> m ()
-serveWitnessAPIReal ServerParams{..} = do
+serveWitnessAPIReal :: WitnessWorkMode ctx m => ServerParamsRec -> m ()
+serveWitnessAPIReal serverParams = do
+    let spAddr = serverParams ^. option #addr
     logInfo $ "Serving wallet API on "+|spAddr|+""
     unliftIO <- askUnliftIO
     lc <- buildServantLogConfig (<> "web")

--- a/witness/src/Dscp/Witness/Workers/Worker.hs
+++ b/witness/src/Dscp/Witness/Workers/Worker.hs
@@ -12,11 +12,11 @@ import qualified Data.HashMap.Strict as HashMap
 import qualified Data.List.NonEmpty as NE
 import Fmt (listF, listF', (+|), (+||), (|+), (||+))
 import Loot.Base.HasLens (lensOf)
-import Loot.Config (option, sub)
 import Loot.Log (logDebug, logInfo, logWarning)
 import Time (ms, sec, threadDelay)
 import UnliftIO.Exception (withException)
 
+import Dscp.Config (option, sub)
 import Dscp.Core
 import Dscp.Crypto
 import Dscp.Network.Wrapped

--- a/witness/tests/Test/Dscp/Witness/Explorer/Explorer.hs
+++ b/witness/tests/Test/Dscp/Witness/Explorer/Explorer.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedLabels #-}
 module Test.Dscp.Witness.Explorer.Explorer where
 
 import Data.Default (def)
@@ -7,6 +8,7 @@ import GHC.Exts (fromList)
 import Test.QuickCheck (arbitraryBoundedEnum, shuffle)
 import Test.QuickCheck.Monadic (pre)
 
+import Dscp.Config (option)
 import Dscp.Core
 import Dscp.Crypto
 import Dscp.Snowdrop.Configuration
@@ -27,7 +29,7 @@ createAndSubmitTx
 createAndSubmitTx sk outs = do
     account <- runSdReadM @'ChainAndMempool $
         fromMaybe def <$> getAccountMaybe (skAddress sk)
-    let txw = createTxw (fcMoney feeConfig) sk (aNonce account) outs
+    let txw = createTxw (feeConfig ^. option #money) sk (aNonce account) outs
     addTxToMempool (GMoneyTxWitnessed txw)
     return $ twTx txw
 
@@ -55,7 +57,7 @@ createAndSubmitPub sk sig = do
         tx = PublicationTx
             { ptAuthor = skAddress sk
             , ptFeesAmount = unFees $
-                calcFeePub (fcPublication feeConfig) ptHeader
+                calcFeePub (feeConfig ^. option #publication) ptHeader
             , ptHeader
             }
         txw = signPubTx sk tx

--- a/witness/tests/Test/Dscp/Witness/Tx/MoneyTx.hs
+++ b/witness/tests/Test/Dscp/Witness/Tx/MoneyTx.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedLabels #-}
+
 module Test.Dscp.Witness.Tx.MoneyTx where
 
 import Control.Lens (makeLenses, makeLensesWith, traversed)
@@ -8,6 +10,7 @@ import qualified GHC.Exts as Exts
 import Test.QuickCheck.Monadic (pre)
 import qualified Text.Show
 
+import Dscp.Config (option)
 import Dscp.Core
 import Dscp.Crypto
 import Dscp.Snowdrop
@@ -40,7 +43,7 @@ properSteps = TxCreationSteps
     , _tcsTx = \txInAcc txInValue txOuts' ->
         Tx{ txInAcc, txInValue, txOuts = txOuts' }
     , _tcsWitness = TxWitness
-    , _tcsFixFees = fixFees (fcMoney feeConfig)
+    , _tcsFixFees = fixFees (feeConfig ^. option #money)
     }
 
 -- | Exact values for transaction.
@@ -207,7 +210,7 @@ spec_Money_tx_application = do
             txData <- pick genSafeTxData
             let Coin outSum = leftToPanic $ sumCoins $ map txOutValue $
                               toList (tdOuts txData)
-            Coin minFee <- case fcMoney feeConfig of
+            Coin minFee <- case feeConfig ^. option #money of
                 LinearFeePolicy FeeCoefficients{..} -> pure fcMinimal
             inVal <- pick $ choose (outSum, outSum + minFee - 1)
 

--- a/witness/tests/Test/Dscp/Witness/Tx/PublicationTx.hs
+++ b/witness/tests/Test/Dscp/Witness/Tx/PublicationTx.hs
@@ -1,9 +1,12 @@
+{-# LANGUAGE OverloadedLabels #-}
+
 module Test.Dscp.Witness.Tx.PublicationTx where
 
 import Control.Lens (forOf, _last)
 import qualified GHC.Exts as Exts
 import Test.QuickCheck.Monadic (pre)
 
+import Dscp.Config (option)
 import Dscp.Core
 import Dscp.Crypto
 import Dscp.Resource.Keys
@@ -33,7 +36,8 @@ genPublicationChain n secret
                         }
                 in PublicationTx
                 { ptAuthor = addr
-                , ptFeesAmount = unFees $ calcFeePub (fcPublication feeConfig) ptHeader
+                , ptFeesAmount = unFees $
+                    calcFeePub (feeConfig ^. option #publication) ptHeader
                 , ptHeader
                 }
 


### PR DESCRIPTION
### Description

This PR aims at replacing as many configuration-specific data types as possible with equivalent `loot-config` types (`vinyl` records).

I have tried to make as little changes as possible to usage logic, CLI args handling and configuration hierarchy; the differences there are only the ones that seemed necessary.

### YT issue

https://issues.serokell.io/issue/DSCP-393

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
