### PR TITLE
[DSCP-418] Repin `serokell-closure`

### DIFF
--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,4 +1,5 @@
 import (fetchGit {
   url = https://github.com/serokell/serokell-closure;
-  rev = "0d4aaf0b596efab48a9fde7d47066f26f36c8b3f";
+  rev = "5d00f8fb8de242ed0c39db9992d0dde0f6df3c15";
+  ref = "20181218192002";
 })


### PR DESCRIPTION
### Description
As part of the work done for DSCP-418, some changes were made to the closure. To maintain consistency, I'm repinning for Disciplina as well.

The only relevant thing to devs here is that we no longer use `all-cabal-hashes` so you no longer have to poke ops when your dependencies are too new.

### YT issue

https://issues.serokell.io/issue/DSCP-418

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).