### PR TITLE
[DSCP-427] Port Disciplina to fresh AVL+ impl

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -29,7 +29,7 @@ extra-deps:
 - beam-sqlite-0.3.2.3
 
 - git: https://github.com/serokell/auth-data-structures.git
-  commit: 4a95f4dd32a82195f49ceb0113c9f05bc260ca7d
+  commit: b04bb2f5b30ebd28f0064a68509b51792e0316b5
 
 - git: https://github.com/serokell/direct-sqlite.git
   commit: 333a2b2cf113e115ea2ec450dc706d3f47ee54e4

--- a/witness/src/Dscp/Witness/AVL/Hash.hs
+++ b/witness/src/Dscp/Witness/AVL/Hash.hs
@@ -4,11 +4,10 @@ module Dscp.Witness.AVL.Hash
     ( AvlHash (..)
     ) where
 
-import Codec.Serialise (Serialise (..))
-import qualified Codec.Serialise as S
+import Codec.Serialise (Serialise (..), serialise)
 import Control.Monad.Free (Free (..))
-import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Tree.AVL as AVL
+import qualified Data.ByteString.Lazy as BSL
 import Snowdrop.Execution ()
 
 import Dscp.Crypto (Hash, unsafeHash)
@@ -17,13 +16,19 @@ import Dscp.Crypto (Hash, unsafeHash)
 newtype AvlHash = AvlHash { unAvlHash :: Hash () } deriving (Eq, Ord, Show, Generic)
 instance Serialise AvlHash
 
-instance (Serialise (f (Free f a)), Serialise a) => Serialise (Free f a)
+instance {-# OVERLAPPING #-} (Serialise h, Serialise k, Serialise v) => Serialise (AVL.Map h k v) where
+    encode = encode . AVL.beforeSerialise
+    decode = AVL.afterDeserialise <$> decode
 
-instance Serialise AVL.Tilt
-instance Serialise b => Serialise (AVL.WithBounds b)
-instance (Serialise h, Serialise k, Serialise v, Serialise r) => Serialise (AVL.MapLayer h k v r)
+instance (Serialise a, Serialise (f (Free f a))) => Serialise (Free f a)
 
-instance (Serialise k, Serialise v) => AVL.Hash AvlHash k v where
-    hashOf =
-        AvlHash .
-        (unsafeHash :: ByteString -> Hash ()) . BSL.toStrict . S.serialise
+-- instance Serialise AVL.Tilt
+-- instance Serialise b => Serialise (AVL.WithBounds b)
+instance (Serialise h, Serialise k, Serialise v, Serialise r, Serialise t) => Serialise (AVL.MapLayerTemplate t h k v r)
+
+instance Serialise x => AVL.ProvidesHash x AvlHash where
+    getHash
+        = AvlHash
+        . (unsafeHash :: ByteString -> Hash ())
+        . BSL.toStrict
+        . serialise


### PR DESCRIPTION
### Description

Even though AVL+ storage is functioning, it's currently useless because we don't use it for block validation

#### Acceptance Criteria

Header type contains AVL+ root hash which should match with the state root after applying the block
The validation of the block should end in comparison between the AVL+ root contained in the block and root of AVLChgAccum yielded by transactions expander

### YT issue

https://issues.serokell.io/issue/DSCP-411

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [ ] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [ ] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [ ] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [ ] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [ ] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [ ] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [ ] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [ ] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
