### PR TITLE
[DSCP-289] Prepare student initial settings in auth hook

### DIFF
--- a/educator/src/Dscp/Educator/Web/Auth.hs
+++ b/educator/src/Dscp/Educator/Web/Auth.hs
@@ -47,7 +47,6 @@ import Servant.Server.Internal.RoutingApplication (DelayedIO, addAuthCheck, dela
 import Servant.Util (ApiCanLogArg (..), ApiHasArgClass (..))
 
 import Dscp.Crypto
-
 import Dscp.Util
 import Dscp.Util.Type
 import Dscp.Util.Servant
@@ -92,7 +91,7 @@ instance ( HasServer api ctx
                 _ -> delayedFailFatal $ err401 { errHeaders = [("WWW-Authenticate", authMsg)] }
 
 instance ApiHasArgClass (Auth' auths res) where
-    apiArgName = const "Authenticate"
+    apiArgName = const "authenticated"
 
 instance ApiCanLogArg (Auth' auths res)
 

--- a/educator/src/Dscp/Educator/Web/Server.hs
+++ b/educator/src/Dscp/Educator/Web/Server.hs
@@ -24,17 +24,18 @@ import UnliftIO (askUnliftIO)
 
 import Dscp.Config
 import Dscp.Core (mkAddr)
-import Dscp.DB.SQL (SQL, invoke)
+import Dscp.DB.SQL
 import Dscp.Educator.Config
 import Dscp.Educator.DB (existsStudent)
 import Dscp.Educator.Launcher.Mode (EducatorNode, EducatorWorkMode)
 import Dscp.Educator.Web.Auth
-import Dscp.Educator.Web.Bot (EducatorBotConfigRec, addBotHandlers, initializeBot)
+import Dscp.Educator.Web.Bot
 import Dscp.Educator.Web.Educator (EducatorPublicKey (..), ProtectedEducatorAPI,
                                    convertEducatorApiHandler, educatorApiHandlers,
                                    protectedEducatorAPI)
 import Dscp.Educator.Web.Student (ProtectedStudentAPI, StudentCheckAction (..),
                                   convertStudentApiHandler, rawStudentAPI, studentApiHandlers)
+import Dscp.Educator.Web.Student.Auth (mkStudentActionM)
 import Dscp.Resource.Keys (KeyResources, krPublicKey)
 import Dscp.Web (buildServantLogConfig, serveWeb)
 import Dscp.Web.Metrics (responseTimeMetric)
@@ -58,40 +59,41 @@ mkEducatorApiServer nat =
         nat
         (\() -> toServant educatorApiHandlers)
 
+-- | Create these two:
+-- 1. An action which checks whether or not the
+--    student is a valid API user.
+--    If bot is enabled, all students are allowed to use API and get automatically
+--    registered.
+-- 2. Server implementation itself.
 mkStudentApiServer
     :: forall ctx m. EducatorWorkMode ctx m
     => (forall x. m x -> Handler x)
     -> EducatorBotConfigRec
-    -> m (Server ProtectedStudentAPI)
+    -> m (StudentCheckAction, Server ProtectedStudentAPI)
 mkStudentApiServer nat botConfig = case botConfig ^. tree #params . selection of
-    "enabled" -> initializeBot (botConfig ^. tree #params . peekBranch #enabled) $
-        return $ \student ->
-            getServer . addBotHandlers student .
-            studentApiHandlers $ student
-    "disabled" -> return $ getServer . studentApiHandlers
-    sel -> error $ "unknown EducatorBotConfig type: " <> fromString sel
+    "enabled" ->
+        initializeBot (botConfig ^. tree #params . peekBranch #enabled) $ do
+            let server student =
+                    getServer . addBotHandlers student $
+                    studentApiHandlers student
+            checkAction <- mkStudentActionM $ \pk -> do
+                let student = mkAddr pk
+                botProvideInitSetting student
+                return True
+            return (checkAction, server)
+    "disabled" -> do
+        let server = getServer . studentApiHandlers
+        checkAction <- mkStudentActionM $ \pk ->
+              let addr = mkAddr pk
+              in invoke $ existsStudent addr
+        return (checkAction, server)
+    other -> error $ "unknown EducatorBotConfig type: " <> fromString other
   where
     getServer handlers = hoistServerWithContext
         rawStudentAPI
         (Proxy :: Proxy '[StudentCheckAction])
         nat
         (toServant handlers)
-
--- | Create an action which checks whether or not the
--- student is a valid API user.
--- If bot is enabled, all students are allowed to use API.
-createStudentCheckAction
-    :: forall ctx m. EducatorWorkMode ctx m
-    => EducatorBotConfigRec
-    -> m StudentCheckAction
-createStudentCheckAction botConfig = case botConfig ^. tree #params . selection of
-    "enabled"  -> return . StudentCheckAction . const $ pure True
-    "disabled" -> do
-          db <- view (lensOf @SQL)
-          return . StudentCheckAction $ \pk ->
-              let addr = mkAddr pk
-              in runReaderT (invoke $ existsStudent addr) db
-    sel -> error $ "unknown EducatorBotConfig type: " <> fromString sel
 
 -- | CORS is enabled to ease development for frontend team.
 educatorCors :: Middleware
@@ -111,19 +113,20 @@ serveEducatorAPIsReal withWitnessApi = do
         botConfig         = webCfg ^. sub #botConfig
         educatorAPINoAuth = webCfg ^. option #educatorAPINoAuth
         studentAPINoAuth  = webCfg ^. option #studentAPINoAuth
+    unliftIO <- askUnliftIO
 
     educatorKeyResources <- view (lensOf @(KeyResources EducatorNode))
-    studentCheckAction <- createStudentCheckAction botConfig
+    (studentCheckAction, studentApiServer) <-
+          mkStudentApiServer (convertStudentApiHandler unliftIO) botConfig
+
     let educatorPublicKey = EducatorPublicKey $ educatorKeyResources ^. krPublicKey
     let srvCtx = educatorPublicKey :. educatorAPINoAuth :.
                  studentCheckAction :. studentAPINoAuth :.
                  EmptyContext
 
     logInfo $ "Serving Student API on "+|serverAddress|+""
-    unliftIO <- askUnliftIO
     lc <- buildServantLogConfig (<> "web")
     let educatorApiServer = mkEducatorApiServer (convertEducatorApiHandler unliftIO)
-    studentApiServer <- mkStudentApiServer (convertStudentApiHandler unliftIO) botConfig
     let witnessApiServer = if withWitnessApi
           then mkWitnessAPIServer (convertWitnessHandler unliftIO)
           else throwAll err405{ errBody = "Witness API disabled at this port" }

--- a/educator/tests/Test/Dscp/Educator/Bot/Endpoints.hs
+++ b/educator/tests/Test/Dscp/Educator/Bot/Endpoints.hs
@@ -10,6 +10,7 @@ import Dscp.Core.Arbitrary
 import Dscp.Crypto
 import Dscp.Educator.Web.Bot
 import Dscp.Educator.Web.Student
+import Dscp.Educator.Web.Types
 import Dscp.Util.Test
 import Test.QuickCheck.Monadic (pick)
 
@@ -35,13 +36,15 @@ spec_StudentApiWithBotQueries :: Spec
 spec_StudentApiWithBotQueries = specWithTempPostgresServer $ do
     it "Student gets assigned on courses on first request" $
         educatorProperty $ \seed -> do
-            StudentApiEndpoints{..} <- initializeBot (testBotParams seed) (pure testBotHandlers)
-            courses <- sGetCourses Nothing False def def
+            StudentApiEndpoints{..} <- initializeBot (testBotParams seed) $
+                                       testBotHandlers <$ botProvideInitSetting student
+            courses <- sGetCourses (Just (IsEnrolled True)) False def def
             return (not $ null courses)
 
     it "Student gets some assignments on first request" $
         educatorProperty $ \seed -> do
-            StudentApiEndpoints{..} <- initializeBot (testBotParams seed) (pure testBotHandlers)
+            StudentApiEndpoints{..} <- initializeBot (testBotParams seed) $
+                                       testBotHandlers <$ botProvideInitSetting student
             assignments <- sGetAssignments Nothing Nothing Nothing False def def
             return (not $ null assignments)
 


### PR DESCRIPTION
### Description

Instead of modifying each bot endpoint to register new students, we'd better do that
in authentication hook.

I'm not sure which kind of tests should be written here.
I didn't test this PR yet even manually since I can't remove `--student-api-no-auth` flag (need to fix that one day).

### YT issue

https://issues.serokell.io/issue/DSCP-289

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [ ] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
