### PR TITLE
[DSCP-433] Add tests on Educator API grade endpoints

### DIFF
--- a/core/src/Dscp/Core/Foundation/Educator.hs
+++ b/core/src/Dscp/Core/Foundation/Educator.hs
@@ -37,6 +37,7 @@ module Dscp.Core.Foundation.Educator
 
     -- * Private transactions
     , PrivateTx (..)
+    , _ptSubmission
     , PrivateTxWitness (..)
     , PrivateTxAux (..)
 
@@ -279,6 +280,9 @@ data PrivateTx = PrivateTx
     , _ptTime             :: !UTCTime
     -- ^ Timestamp for this transaction
     } deriving (Show, Eq, Ord, Generic)
+
+_ptSubmission :: PrivateTx -> Submission
+_ptSubmission = _ssSubmission . _ptSignedSubmission
 
 type PrivateTxId = Hash PrivateTx
 

--- a/educator/src/Dscp/Educator/Web/Educator/Handlers.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Handlers.hs
@@ -88,8 +88,9 @@ educatorApiHandlers =
 
       -- Grades
 
-    , eGetGrades = \course student assignment isFinalF _since _onlyCount ->
-        invoke $ educatorGetGrades course student assignment isFinalF
+    , eGetGrades = \gfCourse gfStudent gfAssignmentHash gfIsFinal _since _onlyCount ->
+        invoke $ educatorGetGrades
+            def{ gfCourse, gfStudent, gfAssignmentHash, gfIsFinal }
 
     , eAddGrade = \(NewGrade subH grade) ->
         transactW $ educatorPostGrade subH grade


### PR DESCRIPTION
### Description

I.e. `getGrades` and `postGrade`.

### YT issue

https://issues.serokell.io/issue/DSCP-433

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
