### PR TITLE
[DSCP-342] Show git revision at startup

### DIFF
--- a/core/package.yaml
+++ b/core/package.yaml
@@ -27,6 +27,7 @@ library:
     - exceptions
     - fmt
     - generic-arbitrary
+    - gitrev
     - hashable
     - hspec
     - http-types

--- a/core/src/Dscp/Resource/AppDir.hs
+++ b/core/src/Dscp/Resource/AppDir.hs
@@ -10,9 +10,10 @@ module Dscp.Resource.AppDir
 
 import Data.Aeson (FromJSON (..), ToJSON (..))
 import Fmt ((+|), (|+))
+import Loot.Log (MonadLogging, logInfo)
 import System.Directory (XdgDirectory (XdgData), createDirectoryIfMissing, getXdgDirectory)
 import System.Environment (lookupEnv)
-import System.IO.Error (catchIOError, isDoesNotExistError, ioError)
+import System.IO.Error (catchIOError, ioError, isDoesNotExistError)
 
 import Dscp.Resource.Class (AllocResource (..), buildComponentR)
 import Dscp.System (appName)
@@ -40,14 +41,14 @@ getOSAppDir = liftIO $
 
 -- | Create application directory if absent.
 prepareAppDir
-    :: MonadIO m
+    :: (MonadIO m, MonadLogging m)
     => AppDirParam -> m AppDir
 prepareAppDir param = do
     appDir <- case param of
         AppDirectoryOS            -> getOSAppDir
         AppDirectorySpecific path -> pure path
     -- we would unlikely have logging context here
-    putTextLn $ "Application home directory will be at "+|appDir|+""
+    logInfo $ "Application home directory will be at "+|appDir|+""
     liftIO $ createDirectoryIfMissing True appDir
     return appDir
 

--- a/core/src/Dscp/System/Other.hs
+++ b/core/src/Dscp/System/Other.hs
@@ -4,12 +4,17 @@ module Dscp.System.Other
       -- * Application
       appName
 
+      -- * Git
+    , gitInfo
+
       -- * OS-dependent operations
     , IsPosix
     , whenPosix
     ) where
 
 import Data.Reflection (Given, give)
+import qualified Development.GitRev as Git
+import Fmt ((+|))
 import System.Info (os)
 
 ---------------------------------------------------------------------
@@ -21,6 +26,22 @@ appName :: IsString s => s
 appName = "disciplina"
 {-# SPECIALIZE appName :: String #-}
 {-# SPECIALIZE appName :: Text #-}
+
+---------------------------------------------------------------------
+-- Git
+---------------------------------------------------------------------
+
+-- | Human-readable description of git revision which this project is built with.
+--
+-- This variable can show outdated info until the module containing it is recompiled,
+-- i.e. change of git revision does not force recompilation on itself.
+-- Thus in development builds produced text may be incorrect.
+gitInfo :: IsString s => s
+gitInfo = fromString $
+    "Git revision: " +| $(Git.gitCommitCount) +| "-th commit at "
+                     +| $(Git.gitBranch) +| " branch - "
+                     +| $(Git.gitCommitDate) +| " - "
+                     +| $(Git.gitDescribe)
 
 ---------------------------------------------------------------------
 -- OS-dependent operations

--- a/witness/src/Dscp/Witness/Launcher/Entry.hs
+++ b/witness/src/Dscp/Witness/Launcher/Entry.hs
@@ -28,7 +28,6 @@ withWitnessBackground :: FullWitnessWorkMode ctx m => m () -> m ()
 withWitnessBackground cont = do
     initStorage
 
-    -- todo git revision
     logInfo $ "Genesis header: " +| genesisHeader |+ ""
 
     workers <- witnessWorkers


### PR DESCRIPTION
### Description

Show in witness, (multi-)educator & faucet.

Looks like:
![screenshot from 2019-01-05 20-48-07](https://user-images.githubusercontent.com/5394217/50727384-41fee300-112b-11e9-93c9-bb47596d9131.png)

### YT issue

https://issues.serokell.io/issue/DSCP-342

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
