### PR TITLE
[DSCP-439] Advanced warnings

### DIFF
--- a/core/src/Dscp/Core/Aeson.hs
+++ b/core/src/Dscp/Core/Aeson.hs
@@ -95,7 +95,6 @@ instance FromJSON Governance where
         "committeeClosed" -> do
             commParticipants <- o .: "participants"
             return $ GovCommittee (CommitteeClosed {..})
-        "governanceOpen" -> return GovOpen
         _ -> fail "Governance type is invalid"
 
 instance ToJSON Coin where

--- a/core/src/Dscp/Core/Genesis.hs
+++ b/core/src/Dscp/Core/Genesis.hs
@@ -107,7 +107,6 @@ formGenesisInfo genesisConfig =
   where
     govAddresses = case genesisConfig ^. option #governance of
         GovCommittee com -> committeeAddrs com
-        GovOpen          -> error "formGenesisInfo: open governance is not implemented"
 
     genesisAddrMap = distrToMap (Just $ NE.fromList govAddresses) $
         genesisConfig ^. option #distribution

--- a/core/src/Dscp/Core/Governance.hs
+++ b/core/src/Dscp/Core/Governance.hs
@@ -21,7 +21,7 @@ import Dscp.Crypto
 -- | Governance type.
 data Governance
     = GovCommittee Committee -- ^ Fixed set of leaders.
-    | GovOpen                -- ^ Open governance
+    -- | GovOpen                -- ^ Open governance
     deriving (Eq, Show, Generic)
 
 ----------------------------------------------------------------------------

--- a/core/src/Dscp/Core/Slotting.hs
+++ b/core/src/Dscp/Core/Slotting.hs
@@ -32,7 +32,7 @@ getSlotSince (SlotId i) = i * slotLength
 remainingTillNextSlot :: (HasCoreConfig, HasTime ctx m) => m Word64
 remainingTillNextSlot = do
     curTime <- getCurTimeMcs
-    return $ fromIntegral $ slotLength - (curTime `mod` slotLength)
+    return $ slotLength - (curTime `mod` slotLength)
 
 waitUntilNextSlot :: (HasCoreConfig, HasTime ctx m) => m SlotId
 waitUntilNextSlot = do

--- a/core/src/Dscp/Crypto/MerkleTree.hs
+++ b/core/src/Dscp/Crypto/MerkleTree.hs
@@ -57,6 +57,7 @@ import qualified GHC.Exts as Exts (IsList (..))
 import qualified Text.Show
 
 import Dscp.Crypto.Impl
+import Dscp.Util
 
 -- | Data type for root of sized merkle tree.
 data MerkleSignature a = MerkleSignature
@@ -183,7 +184,7 @@ instance HasHash a => Exts.IsList (MerkleTree a) where
 nodeFromList :: HasHash a => NonEmpty a -> MerkleNode a
 nodeFromList lst@(a :| as) = tree
   where
-    (tree, []) = go (0, uLen - 1) `runState` (a : as)
+    (tree, assert_ null -> ()) = go (0, uLen - 1) `runState` (a : as)
 
     uLen = length lst
 

--- a/core/src/Dscp/Util.hs
+++ b/core/src/Dscp/Util.hs
@@ -18,6 +18,7 @@ module Dscp.Util
          -- * Error handling
        , assert
        , assertJust
+       , assert_
 
          -- * Maybe conversions
        , nothingToThrow
@@ -70,6 +71,7 @@ module Dscp.Util
        ) where
 
 import Codec.Serialise (Serialise, serialise)
+import qualified Control.Exception as E
 import Control.Lens (Getter, LensRules, lens, lensField, lensRules, mappingNamer, to)
 import Control.Monad.Except (MonadError (..))
 import Data.ByteArray (ByteArrayAccess)
@@ -179,6 +181,11 @@ assert action message = unlessM action $ throwM message
 
 assertJust :: (MonadThrow m, Exception e) => m (Maybe a) -> e -> m a
 assertJust action message = whenNothingM action $ throwM message
+
+-- | Ensure given condition holds.
+-- You have to force evaluation of result in order for check to take effect.
+assert_ :: HasCallStack => (a -> Bool) -> a -> ()
+assert_ predicate value = E.assert (predicate value) ()
 
 -----------------------------------------------------------
 -- Maybe conversions

--- a/educator/src/Dscp/Educator/DB/Queries.hs
+++ b/educator/src/Dscp/Educator/DB/Queries.hs
@@ -236,7 +236,9 @@ getProvenStudentTransactions filters = do
             return (blockIdx, (privateTx, submission))
       where
         rearrange (bi, (tx, sub)) =
-            let TxBlockIdx txIdx = trIdx tx
+            let txIdx = case trIdx tx of
+                    TxInMempool    -> error "impossible"
+                    TxBlockIdx idx -> idx
             in (bi, (txIdx, privateTxFromRow (tx, sub)))
 
     getMerkleTreeAndHash :: BlockIdx -> DBT t m (PrivateHeaderHash, EmptyMerkleTree PrivateTx)

--- a/faucet/src/Dscp/Faucet/Web/Logic.hs
+++ b/faucet/src/Dscp/Faucet/Web/Logic.hs
@@ -67,7 +67,7 @@ faucetTransferMoneyTo dest = do
             throwM SourceAccountExhausted
 
         let feePolicy = faucetConfig ^. sub #core . sub #fee . option #money
-            nonce = fromIntegral $ aiCurrentNonce sourceState
+            nonce = aiCurrentNonce sourceState
             outs = one (TxOut dest transfer)
             txWitnessed = createTxw feePolicy sk nonce outs
 

--- a/hpack/definitions.yaml
+++ b/hpack/definitions.yaml
@@ -52,6 +52,7 @@ _definitions:
         - -Wall
         - -fno-warn-orphans
         - -Werror
+        - -Widentities
 
   _utils:
     - &lib-common

--- a/hpack/definitions.yaml
+++ b/hpack/definitions.yaml
@@ -51,12 +51,15 @@ _definitions:
     - &ghc-options
         - -Wall
         - -fno-warn-orphans
-        - -Werror
         - -Widentities
+        - -Werror
 
   _utils:
     - &lib-common
         source-dirs: src
+
+        ghc-options:
+          - -Wincomplete-uni-patterns
 
     - &test-common
         main:        Main.hs
@@ -78,3 +81,4 @@ _definitions:
         ghc-options:
           - -threaded
           - -O2
+          - -Wincomplete-uni-patterns

--- a/hpack/definitions.yaml
+++ b/hpack/definitions.yaml
@@ -52,6 +52,7 @@ _definitions:
         - -Wall
         - -fno-warn-orphans
         - -Widentities
+        - -Wincomplete-record-updates
         - -Werror
 
   _utils:

--- a/witness/src/Dscp/Snowdrop/Expanders.hs
+++ b/witness/src/Dscp/Snowdrop/Expanders.hs
@@ -157,7 +157,7 @@ seqExpandersPublicationTx feesReceiverAddr (Fees minFee) =
             when (headerWasEarlier || headerIsLast) $
                 throwLocalError PublicationLocalLoop
 
-            let feeAmount = fromIntegral $ coinToInteger ptFeesAmount
+            let feeAmount = coinToInteger ptFeesAmount
             maybePub <- queryOne (PublicationsOf ptAuthor)
             mFeesReceiver <- queryOne (AccountId feesReceiverAddr)
 

--- a/witness/src/Dscp/Snowdrop/Expanders.hs
+++ b/witness/src/Dscp/Snowdrop/Expanders.hs
@@ -113,9 +113,13 @@ seqExpandersGTx
     -> GTxWitnessed
     -> SeqExpanders Exceptions Ids Proofs Values ctx GTxWitnessed
 seqExpandersGTx addr minFee (GMoneyTxWitnessed _) =
-    flip contramap (seqExpandersBalanceTx addr minFee) $ \(GMoneyTxWitnessed tx) -> tx
+    flip contramap (seqExpandersBalanceTx addr minFee) $ \case
+        GMoneyTxWitnessed tx -> tx
+        _ -> error "impossible"
 seqExpandersGTx addr minFee (GPublicationTxWitnessed _) =
-    flip contramap (seqExpandersPublicationTx addr minFee) $ \(GPublicationTxWitnessed ptx) -> ptx
+    flip contramap (seqExpandersPublicationTx addr minFee) $ \case
+        GPublicationTxWitnessed ptx -> ptx
+        _ -> error "impossible"
 
 ----------------------------------------------------------------------------
 -- Publication tx
@@ -310,7 +314,7 @@ seqExpandersBalanceTx feesReceiverAddr (Fees minimalFees) =
                 -- Current key we're interested in
                 let k = inj feesReceiverAccountId
                     updated =
-                        Map.adjust (fmap (\(AccountOutVal x) -> AccountOutVal $ addFee x)) k changes
+                        Map.adjust (fmap $ mapAccountOutVal addFee) k changes
                 in case Map.lookup k changes of
                     Nothing      -> Map.insert k (inj feesReceiverUpd) changes
                     Just (New _) -> updated
@@ -320,6 +324,11 @@ seqExpandersBalanceTx feesReceiverAddr (Fees minimalFees) =
 
         pure $ mkDiffCS changesWithFees
   where
+    mapAccountOutVal :: HasCallStack => (Account -> Account) -> Values -> Values
+    mapAccountOutVal f = \case
+        AccountOutVal x -> AccountOutVal (f x)
+        other -> error $ "expected AccountOutVal, got " +| show @Text other |+ ""
+
     -- Account prefixes are used during the computation to access current balance
     inP  = Set.fromList [accountPrefix, txOfPrefix]
     -- Expander returns account changes only

--- a/witness/src/Dscp/Snowdrop/Storage/PluginBased.hs
+++ b/witness/src/Dscp/Snowdrop/Storage/PluginBased.hs
@@ -39,7 +39,7 @@ blockActions plugin =
 
     iterImpl :: Prefix -> b -> ((Ids, Values) -> b -> b) -> n b
     iterImpl (Prefix prefix) accum folder =
-        DB.pIterate plugin (fromIntegral prefix) accum (flip folder)
+        DB.pIterate plugin prefix accum (flip folder)
 
     applyImpl :: SumChangeSet Ids Values -> n ()
     applyImpl cs =

--- a/witness/src/Dscp/Web/Class.hs
+++ b/witness/src/Dscp/Web/Class.hs
@@ -59,8 +59,7 @@ class HasErrorTag e => FromServantErr e where
     fromServantError :: ServantError -> Maybe e
     default fromServantError :: FromJSON e => ServantError -> Maybe e
     fromServantError err = do
-        _ <- error $ fromString $ "Servant err: " ++ show err
-        let FailureResponse Response{..} = err
+        FailureResponse Response{..} <- pure err
         errResponse <- decode @(ErrResponse e) responseBody
         return $ erContent errResponse
               ?: error "fromServantError: no error content"


### PR DESCRIPTION
### Description

Adds some useful warnings, one per commit.

The most arguable one IMO is `-Wincomplete-uni-patterns`. I find it generally good, in particular, because now I can safely add constructors to datatypes without being afraid of breaking any pattern-matches in lamdas and `let`s. The price is - this makes us explicitly throw errors in several places where incomplete patterns fit the best thus making the code ugly.

I removed `GovOpen` constructor because it's effectively not supported anyway.
 
### YT issue

https://issues.serokell.io/issue/DSCP-439

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
