### PR TITLE
release.nix: Export disciplina-tools

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -26,6 +26,7 @@ rec {
     paths = with project; map haskell.lib.justStaticExecutables [
       disciplina-educator
       disciplina-faucet
+      disciplina-tools
       disciplina-witness
     ];
   };

--- a/release.nix
+++ b/release.nix
@@ -30,6 +30,8 @@ rec {
     ];
   };
 
+  inherit (project) disciplina-tools;
+
   disciplina-config = runCommand "disciplina-config.yaml" {} "cp ${./config.yaml} $out";
 
   disciplina-haddock = with lib;


### PR DESCRIPTION
### Description

This is required to make it possible to use `disciplinta-tools` (in particular, `dscp-keygen` during deployment.

### YT issue

https://issues.serokell.io/issue/OPS-623

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).