### PR TITLE
[DSCP-444] Add endpoints for certificate generator to Educator API spec

### DIFF
--- a/core/src/Dscp/Core/Aeson.hs
+++ b/core/src/Dscp/Core/Aeson.hs
@@ -55,6 +55,17 @@ instance FromJSON DocumentType where
         "offline" -> pure Offline
         other -> fail $ "invalid constructor: " ++ toString other
 
+instance ToJSON EducationForm where
+    toJSON Fulltime = String "fulltime"
+    toJSON Parttime = String "parttime"
+    toJSON Fullpart = String "fullpart"
+instance FromJSON EducationForm where
+    parseJSON = withText "EducationForm" $ \case
+        "fulltime" -> pure Fulltime
+        "parttime" -> pure Parttime
+        "fullpart" -> pure Fullpart
+        other -> fail $ "invalid constructor: " ++ toString other
+
 instance ToJSON Address where
     toJSON = String . toText
 instance FromJSON Address where
@@ -192,6 +203,7 @@ deriving instance FromJSON GenesisDistribution
 deriveJSON defaultOptions ''Assignment
 deriveJSON defaultOptions ''Submission
 deriveJSON defaultOptions ''SignedSubmission
+deriveJSON defaultOptions ''CertificateMeta
 deriveJSON defaultOptions ''PrivateTx
 deriveJSON defaultOptions ''PrivateBlockHeader
 deriveJSON defaultOptions ''Header

--- a/core/src/Dscp/Core/Arbitrary.hs
+++ b/core/src/Dscp/Core/Arbitrary.hs
@@ -45,7 +45,7 @@ import Data.Time.Clock (UTCTime, getCurrentTime)
 import Fmt ((+||), (||+))
 import qualified GHC.Exts as Exts
 import GHC.IO.Unsafe (unsafePerformIO)
-import Test.QuickCheck (resize)
+import Test.QuickCheck (arbitraryBoundedEnum, resize)
 import Test.QuickCheck.Arbitrary.Generic (genericArbitrary, genericShrink)
 import qualified Text.Show
 
@@ -113,6 +113,13 @@ instance Arbitrary DocumentType where
 
 genCommonDocumentType :: Gen DocumentType
 genCommonDocumentType = frequency [(5, pure Offline), (1, pure Online)]
+
+instance Arbitrary EducationForm where
+    arbitrary = arbitraryBoundedEnum
+
+instance Arbitrary CertificateMeta where
+    arbitrary = genericArbitrary
+    shrink = genericShrink
 
 instance Arbitrary PrivateTx where
     arbitrary = PrivateTx <$> arbitrary <*> arbitrary <*> arbitrary

--- a/core/src/Dscp/Core/Foundation/Educator.hs
+++ b/core/src/Dscp/Core/Foundation/Educator.hs
@@ -27,6 +27,8 @@ module Dscp.Core.Foundation.Educator
     , SubmissionSig
     , SignedSubmission (..)
     , SubmissionWitness (..)
+    , CertificateMeta (..)
+    , EducationForm (..)
     , documentType
     , _aDocumentType
     , aDocumentType
@@ -93,6 +95,7 @@ import Control.Exception as E
 import Control.Lens (Getter, makeLenses, to)
 import qualified Data.ByteArray as BA
 import qualified Data.Text as T
+import Data.Time.Calendar (Day (..))
 import Data.Time.Clock (UTCTime (..), diffTimeToPicoseconds, picosecondsToDiffTime)
 import Fmt (build, genericF, mapF, (+|), (|+))
 
@@ -319,6 +322,39 @@ instance Buildable () where
 
 instance Buildable DocumentType where
     build = genericF
+
+-- | Datatype containing info about a certificate issued by Educator.
+data CertificateMeta = CertificateMeta
+    { cmStudentName      :: !ItemDesc
+    , cmStudentBirthDate :: !Day
+    , cmStartYear        :: !Int
+    , cmEndYear          :: !Int
+    , cmEducationForm    :: !EducationForm
+    , cmNumber           :: !Integer
+    , cmIssueDate        :: !Day
+    , cmTitle            :: !ItemDesc
+    , cmMajor            :: !ItemDesc
+    , cmSpecialization   :: !(Maybe ItemDesc)
+    } deriving (Show, Eq, Generic)
+
+data EducationForm = Fulltime | Parttime | Fullpart
+    deriving (Show, Eq, Generic, Enum, Bounded)
+
+instance Buildable EducationForm where
+    build = show
+
+instance Buildable CertificateMeta where
+    build CertificateMeta {..} =
+        "{ studentName = "+|cmStudentName|+
+        ", studentBirthDate = "+|cmStudentBirthDate|+
+        ", startYear = "+|cmStartYear|+
+        ", endYear = "+|cmEndYear|+
+        ", educationForm = "+|cmEducationForm|+
+        ", number = "+|cmNumber|+
+        ", issueDate = "+|cmIssueDate|+
+        ", title = "+|cmTitle|+
+        ", major = "+|cmMajor|+
+        ", specialization = "+|cmSpecialization|+" }"
 
 ----------------------------------------------------------------------------
 -- Transactions

--- a/core/src/Dscp/Core/Foundation/Instances.hs
+++ b/core/src/Dscp/Core/Foundation/Instances.hs
@@ -5,6 +5,7 @@ module Dscp.Core.Foundation.Instances where
 import Codec.Serialise (Serialise (..))
 import Codec.Serialise.Decoding (decodeListLen, decodeWord)
 import Codec.Serialise.Encoding (encodeListLen, encodeWord)
+import Data.Time.Calendar (Day (..))
 
 import Dscp.Core.Foundation.Coin
 import Dscp.Core.Foundation.Educator
@@ -42,7 +43,6 @@ instance HasId PrivateTx where
 deriving instance Serialise Course
 deriving instance Serialise Subject
 
-
 instance Serialise Grade
 instance Serialise ATGNode
 instance Serialise ATGEdge
@@ -56,6 +56,13 @@ instance Serialise AssignmentType
 instance Serialise SubmissionWitness
 instance Serialise SignedSubmission
 instance Serialise DocumentType
+
+instance Serialise Day where
+    encode = encode . toModifiedJulianDay
+    decode = ModifiedJulianDay <$> decode
+
+instance Serialise EducationForm
+instance Serialise CertificateMeta
 
 instance Serialise Submission where
     encode (Submission s c a) = mconcat

--- a/core/tests/Test/Dscp/Core/Serialise.hs
+++ b/core/tests/Test/Dscp/Core/Serialise.hs
@@ -15,6 +15,8 @@ spec_coreSerialise = describe "Core datatypes binary serialisation" $ do
     serialiseRoundtripProp @Submission
     serialiseRoundtripProp @SubmissionWitness
     serialiseRoundtripProp @SignedSubmission
+    serialiseRoundtripProp @EducationForm
+    serialiseRoundtripProp @CertificateMeta
     serialiseRoundtripProp @ATGSubjectChange
     serialiseRoundtripProp @ATGDelta
     serialiseRoundtripProp @PrivateBlockHeader
@@ -31,6 +33,8 @@ spec_coreAeson = describe "Core datatypes JSON serialisation" $ do
     aesonRoundtripProp @Submission
     aesonRoundtripProp @SubmissionWitness
     aesonRoundtripProp @SignedSubmission
+    aesonRoundtripProp @EducationForm
+    aesonRoundtripProp @CertificateMeta
     aesonRoundtripProp @ATGSubjectChange
     aesonRoundtripProp @ATGDelta
     aesonRoundtripProp @Tx

--- a/educator/package.yaml
+++ b/educator/package.yaml
@@ -27,6 +27,7 @@ library:
     - interpolatedstring-perl6
     - jose
     - http-types
+    - http-media
     - lens
     - loot-base
     - loot-config

--- a/educator/src/Dscp/Educator/Web/Educator/API.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/API.hs
@@ -12,6 +12,7 @@ module Dscp.Educator.Web.Educator.API
 import Network.HTTP.Media.MediaType ((//))
 import Servant
 import Servant.Generic
+import Servant.Util (SortingParamsOf)
 
 import Dscp.Core
 import Dscp.Crypto
@@ -255,7 +256,7 @@ type GetCertificates
     = "certificates"
     :> QueryParam "offset" Int
     :> QueryParam "limit" Int
-    :> QueryParam "order" Int
+    :> SortingParamsOf Certificate
     :> QueryFlag "onlyCount"
     :> Summary "Get the list of certificates created by Educator"
     :> Description "Gets all the certificates created by Educator. Each \

--- a/educator/src/Dscp/Educator/Web/Educator/API.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/API.hs
@@ -73,7 +73,7 @@ type GetStudents
     :> QueryParam "isEnrolled" IsEnrolled
     :> QueryFlag "onlyCount"
     :> Summary "Get a list of all registered students' addresses"
-    :> Get '[DSON] [StudentInfo]
+    :> Get '[DSON] (Counted StudentInfo)
 
 type AddStudent
     = "students"
@@ -127,7 +127,7 @@ type GetCourses
     :> QueryParam "student" Student
     :> QueryFlag "onlyCount"
     :> Summary "Get all courses"
-    :> Get '[DSON] [CourseEducatorInfo]
+    :> Get '[DSON] (Counted CourseEducatorInfo)
 
 type AddCourse
     = "courses"
@@ -153,7 +153,7 @@ type GetAssignments
     :> QueryParam "since" Timestamp
     :> QueryFlag "onlyCount"
     :> Summary "Get all assignments"
-    :> Get '[DSON] [AssignmentEducatorInfo]
+    :> Get '[DSON] (Counted AssignmentEducatorInfo)
 
 type AddAssignment
     = "assignments"
@@ -177,7 +177,7 @@ type GetSubmissions
     :> Summary "Get all submissions"
     :> Description "Gets a list of all submissions done by all students. \
                   \This method is inaccessible by students."
-    :> Get '[DSON] [SubmissionEducatorInfo]
+    :> Get '[DSON] (Counted SubmissionEducatorInfo)
 
 type GetSubmission
     = "submissions" :> Capture "submission" (Hash Submission)
@@ -206,7 +206,7 @@ type GetGrades
     :> QueryFlag "onlyCount"
     :> Summary "Get all grades"
     :> Description "Gets a list of all grades performed by all students."
-    :> Get '[DSON] [GradeInfo]
+    :> Get '[DSON] (Counted GradeInfo)
 
 type AddGrade
     = "grades"
@@ -228,4 +228,4 @@ type GetProofs
     :> Summary "Get proofs of all student's activity"
     :> Description "Gets all private transactions related to a student \
                     \together with corresponding Merkle proofs."
-    :> Get '[DSON] [BlkProofInfo]
+    :> Get '[DSON] (Counted BlkProofInfo)

--- a/educator/src/Dscp/Educator/Web/Educator/Arbitrary.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Arbitrary.hs
@@ -3,12 +3,16 @@
 module Dscp.Educator.Web.Educator.Arbitrary
     ( educatorCourseInfoEx
     , educatorSubmissionInfoEx
+    , certificateListEx
     ) where
+
+import Test.QuickCheck (vectorOf)
 
 import Dscp.Core
 import Dscp.Crypto
 import Dscp.Educator.Web.Arbitrary
 import Dscp.Educator.Web.Educator.Types
+import Dscp.Util.Test
 
 educatorCourseInfoEx :: CourseEducatorInfo
 educatorCourseInfoEx =
@@ -27,3 +31,6 @@ educatorSubmissionInfoEx =
     , siGrade = Just gradeInfoEx
     , siWitness = submissionWitnessEx
     }
+
+certificateListEx :: [Certificate]
+certificateListEx = detGen 123 $ vectorOf 200 $ mkCertificate <$> arbitrary

--- a/educator/src/Dscp/Educator/Web/Educator/Client/Logic.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Client/Logic.hs
@@ -41,6 +41,9 @@ hoistEducatorApiClient nat es = EducatorApiEndpoints
     , eGetGrades               = nat ... eGetGrades es
     , eAddGrade                = nat ... eAddGrade es
     , eGetProofs               = nat ... eGetProofs es
+    , eGetCertificates         = nat ... eGetCertificates es
+    , eGetCertificate          = nat ... eGetCertificate es
+    , eAddCertificate          = nat ... eAddCertificate es
     }
 
 -- | Creates a new @'EducatorApiClient'@ connecting to a given @'BaseUrl'@

--- a/educator/src/Dscp/Educator/Web/Educator/Error.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Error.hs
@@ -82,10 +82,10 @@ instance FromServantErr EducatorAPIError
 -- Other
 ---------------------------------------------------------------------------
 
-data FaucetDecodeErrTag
-instance Reifies FaucetDecodeErrTag String where
+data EducatorDecodeErrTag
+instance Reifies EducatorDecodeErrTag String where
     reflect _ = decodeUtf8 . errBody $ toServantErr InvalidFormat
 
 -- | Marker like 'JSON' for servant, but returns just "InvalidFormat" on
 -- decoding error.
-type DSON = SimpleJSON FaucetDecodeErrTag
+type DSON = SimpleJSON EducatorDecodeErrTag

--- a/educator/src/Dscp/Educator/Web/Educator/Handlers.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Handlers.hs
@@ -100,6 +100,16 @@ educatorApiHandlers =
     , eGetProofs = \pfCourse pfStudent pfAssignment pfOnlyCount ->
             fmap (mkCountedList pfOnlyCount) $ transact $
             commonGetProofs def{ pfCourse, pfStudent, pfAssignment }
+
+      -- Certificates
+    , eGetCertificates = \_offset _limit _order _onlyCount ->
+            error "not implemented"
+
+    , eGetCertificate = \_id ->
+            error "not implemented"
+
+    , eAddCertificate = \_fullInfo ->
+            error "not implemented"
     }
 
 convertEducatorApiHandler

--- a/educator/src/Dscp/Educator/Web/Educator/Handlers.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Handlers.hs
@@ -31,8 +31,8 @@ educatorApiHandlers =
 
       -- Students
 
-    , eGetStudents = \mCourse _mIsEnrolled _onlyCount ->
-        invoke $ educatorGetStudents mCourse
+    , eGetStudents = \mCourse _mIsEnrolled onlyCount ->
+        fmap (mkCountedList onlyCount) $ invoke $ educatorGetStudents mCourse
 
     , eAddStudent = \(NewStudent student) ->
         void . invoke $ createStudent student
@@ -51,8 +51,8 @@ educatorApiHandlers =
 
       -- Courses
 
-    , eGetCourses = \mStudent _onlyCount ->
-        invoke $ educatorGetCourses mStudent
+    , eGetCourses = \mStudent onlyCount ->
+        fmap (mkCountedList onlyCount) $ invoke $ educatorGetCourses mStudent
 
     , eAddCourse = \(NewCourse mcid desc subjects) ->
         transact $ createCourse CourseDetails
@@ -66,9 +66,9 @@ educatorApiHandlers =
 
       -- Assignments
 
-    , eGetAssignments = \afCourse afStudent afIsFinal _afSince _afOnlyCount ->
-        invoke $ educatorGetAssignments
-            def{ afCourse, afStudent, afIsFinal }
+    , eGetAssignments = \afCourse afStudent afIsFinal _afSince afOnlyCount ->
+            fmap (mkCountedList afOnlyCount) $ invoke $
+            educatorGetAssignments def{ afCourse, afStudent, afIsFinal }
 
     , eAddAssignment = \_autoAssign na -> do
         void . transact $ createAssignment (requestToAssignment na)
@@ -76,9 +76,9 @@ educatorApiHandlers =
 
       -- Submissions
 
-    , eGetSubmissions = \sfCourse sfStudent sfAssignmentHash _sfIsGraded _sfSince _sfOnlyCount ->
-        invoke $ educatorGetSubmissions
-            def{ sfCourse, sfStudent, sfAssignmentHash }
+    , eGetSubmissions = \sfCourse sfStudent sfAssignmentHash _sfIsGraded _sfSince sfOnlyCount ->
+            fmap (mkCountedList sfOnlyCount) $ invoke $
+            educatorGetSubmissions def{ sfCourse, sfStudent, sfAssignmentHash }
 
     , eGetSubmission =
         invoke ... educatorGetSubmission
@@ -88,17 +88,18 @@ educatorApiHandlers =
 
       -- Grades
 
-    , eGetGrades = \course student assignment isFinalF _since _onlyCount ->
-        invoke $ educatorGetGrades course student assignment isFinalF
+    , eGetGrades = \course student assignment isFinalF _since onlyCount ->
+            fmap (mkCountedList onlyCount) $ invoke $
+            educatorGetGrades course student assignment isFinalF
 
     , eAddGrade = \(NewGrade subH grade) ->
-        transact $ educatorPostGrade subH grade
+            transact $ educatorPostGrade subH grade
 
       -- Proofs
 
-    , eGetProofs = \pfCourse pfStudent pfAssignment _pfOnlyCount ->
-        transact $ commonGetProofs
-            def{ pfCourse, pfStudent, pfAssignment }
+    , eGetProofs = \pfCourse pfStudent pfAssignment pfOnlyCount ->
+            fmap (mkCountedList pfOnlyCount) $ transact $
+            commonGetProofs def{ pfCourse, pfStudent, pfAssignment }
     }
 
 convertEducatorApiHandler

--- a/educator/src/Dscp/Educator/Web/Educator/Handlers.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Handlers.hs
@@ -12,6 +12,7 @@ import UnliftIO (UnliftIO (..))
 import Dscp.DB.SQL
 import Dscp.Educator.DB
 import Dscp.Educator.Web.Educator.API
+import Dscp.Educator.Web.Educator.Arbitrary
 import Dscp.Educator.Web.Educator.Error
 import Dscp.Educator.Web.Educator.Queries
 import Dscp.Educator.Web.Educator.Types
@@ -102,14 +103,15 @@ educatorApiHandlers =
             commonGetProofs def{ pfCourse, pfStudent, pfAssignment }
 
       -- Certificates
-    , eGetCertificates = \_offset _limit _sorting _onlyCount ->
-            error "not implemented"
+    , eGetCertificates = \offset limit _sorting onlyCount ->
+            pure $ mkCountedList onlyCount $
+            take (fromMaybe 100 limit) $ drop (fromMaybe 0 offset) certificateListEx
 
     , eGetCertificate = \_id ->
-            error "not implemented"
+            pure "<THIS IS NOT A PDF YET>"
 
-    , eAddCertificate = \_fullInfo ->
-            error "not implemented"
+    , eAddCertificate = \(CertificateFullInfo meta _) ->
+            pure $ mkCertificate meta
     }
 
 convertEducatorApiHandler

--- a/educator/src/Dscp/Educator/Web/Educator/Handlers.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Handlers.hs
@@ -102,7 +102,7 @@ educatorApiHandlers =
             commonGetProofs def{ pfCourse, pfStudent, pfAssignment }
 
       -- Certificates
-    , eGetCertificates = \_offset _limit _order _onlyCount ->
+    , eGetCertificates = \_offset _limit _sorting _onlyCount ->
             error "not implemented"
 
     , eGetCertificate = \_id ->

--- a/educator/src/Dscp/Educator/Web/Educator/Types.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Types.hs
@@ -37,7 +37,7 @@ import Data.Aeson (FromJSON (..), ToJSON (..), Value (..), withText)
 import Data.Aeson.Options (defaultOptions)
 import Data.Aeson.TH (deriveJSON)
 import Fmt (build, listF, (+|), (|+))
-import Servant.Util (ForResponseLog (..), buildListForResponse)
+import Servant.Util (type (?:), ForResponseLog (..), SortingParamTypesOf, buildListForResponse)
 
 import Dscp.Core
 import Dscp.Crypto
@@ -143,6 +143,13 @@ data Counted a = Counted
 mkCountedList :: Bool -> [a] -> Counted a
 mkCountedList onlyCount ls =
     Counted (length ls) (if onlyCount then Nothing else Just ls)
+
+---------------------------------------------------------------------------
+-- Sorting
+---------------------------------------------------------------------------
+
+type instance SortingParamTypesOf Certificate =
+    ["createdAt" ?: Timestamp, "student" ?: ItemDesc]
 
 ---------------------------------------------------------------------------
 -- Simple conversions

--- a/educator/src/Dscp/Educator/Web/Educator/Types.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Types.hs
@@ -22,6 +22,7 @@ module Dscp.Educator.Web.Educator.Types
     , Certificate (..)
     , CertificateGrade (..)
     , CertificateFullInfo (..)
+    , mkCertificate
     , eaDocumentType
 
       -- * Conversions
@@ -132,14 +133,18 @@ data CertificateFullInfo = CertificateFullInfo
 data Language = EN | RU
     deriving (Show, Eq, Generic)
 
+-- | Makes a 'Certificate' from 'CertificateMeta'.
+mkCertificate :: CertificateMeta -> Certificate
+mkCertificate meta = Certificate (hash meta) meta
+
 -- | Special wrapper for list which includes its length
 data Counted a = Counted
     { cCount :: Int
     , cItems :: Maybe [a]
     } deriving (Show, Eq, Generic)
 
--- | Makes a @Counted@ from a list, omitting the list itself if
--- 'onlyCount' flag is set
+-- | Makes a 'Counted' from a list, omitting the list itself if
+-- @onlyCount@ flag is set
 mkCountedList :: Bool -> [a] -> Counted a
 mkCountedList onlyCount ls =
     Counted (length ls) (if onlyCount then Nothing else Just ls)

--- a/specs/disciplina/educator/api/educator.yaml
+++ b/specs/disciplina/educator/api/educator.yaml
@@ -1104,7 +1104,8 @@ components:
     CertificateMeta:
       type: object
       required:
-        - student
+        - studentName
+        - studentBirthDate
         - startYear
         - endYear
         - educationForm
@@ -1113,17 +1114,11 @@ components:
         - title
         - major
       properties:
-        student:
-          type: object
-          required:
-            - name
-            - birthDate
-          properties:
-            name:
-              type: string
-            birthDate:
-              type: string
-              format: date
+        studentName:
+          type: string
+        studentBirthDate:
+          type: string
+          format: date
         startYear:
           type: integer
           format: int32
@@ -1132,7 +1127,7 @@ components:
           format: int32
         educationForm:
           type: string
-          enum: [fulltime, parttime]
+          enum: [fulltime, parttime, fullpart]
         number:
           type: string
         issueDate:

--- a/specs/disciplina/educator/api/educator.yaml
+++ b/specs/disciplina/educator/api/educator.yaml
@@ -102,7 +102,7 @@ paths:
                 properties:
                   count:
                     $ref: '#/components/schemas/Count'
-                  students:
+                  items:
                     type: array
                     items:
                       $ref: '#/components/schemas/Student'
@@ -310,7 +310,7 @@ paths:
                 properties:
                   count:
                     $ref: '#/components/schemas/Count'
-                  courses:
+                  items:
                     type: array
                     items:
                       $ref: '#/components/schemas/Course'
@@ -406,7 +406,7 @@ paths:
                 properties:
                   count:
                     $ref: '#/components/schemas/Count'
-                  assignments:
+                  items:
                     type: array
                     items:
                       $ref: '#/components/schemas/Assignment'
@@ -479,7 +479,7 @@ paths:
                 properties:
                   count:
                     $ref: '#/components/schemas/Count'
-                  submissions:
+                  items:
                     type: array
                     items:
                       $ref: '#/components/schemas/Submission'
@@ -580,7 +580,7 @@ paths:
                 properties:
                   count:
                     $ref: '#/components/schemas/Count'
-                  grades:
+                  items:
                     type: array
                     items:
                       $ref: '#/components/schemas/Grade'
@@ -641,7 +641,7 @@ paths:
                 properties:
                   count:
                     $ref: '#/components/schemas/Count'
-                  proofs:
+                  items:
                     type: array
                     items:
                       $ref: '#/components/schemas/Proof'
@@ -686,7 +686,7 @@ paths:
                 properties:
                   count:
                     $ref: '#/components/schemas/Count'
-                  certificates:
+                  items:
                     type: array
                     items:
                       $ref: '#/components/schemas/Certificate'

--- a/specs/disciplina/educator/api/educator.yaml
+++ b/specs/disciplina/educator/api/educator.yaml
@@ -35,6 +35,8 @@ tags:
     description: Methods for working with grades
   - name: Proofs
     description: Methods for working with proofs
+  - name: Certificates
+    description: Methods for working with FairCV certificates
 paths:
   /status:
     get:
@@ -657,6 +659,112 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrResponse'
+
+  /certificates:
+    get:
+      tags:
+        - Certificates
+      summary: Get the list of certificates created by Educator
+      description: >-
+        Gets all the certificates created by Educator. Each entry contains
+        certificate metadata and certificate ID.
+      operationId: getCertificates
+      parameters:
+        - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Order'
+        - $ref: '#/components/parameters/OnlyCount'
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - count
+                properties:
+                  count:
+                    $ref: '#/components/schemas/Count'
+                  certificates:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Certificate'
+        401:
+          $ref: '#/components/responses/Unauthorized'
+    post:
+      tags:
+        - Certificates
+      summary: Create a new certificate
+      description: >-
+        Creates a new certificate given metadata and the grades.
+      operationId: addCertificate
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - meta
+                - grades
+              properties:
+                meta:
+                  $ref: '#/components/schemas/CertificateMeta'
+                grades:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/CertificateGrade'
+        description: Content of the certificate
+        required: true
+      responses:
+        201:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Certificate'
+        400:
+          description: Request body is invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
+        401:
+          $ref: '#/components/responses/Unauthorized'
+
+  /certificate/{certificate}:
+    get:
+      tags:
+        - Certificates
+      summary: Get the certificate by ID
+      description: >-
+        Gets the PDF certificate with FairCV JSON included as metadata by ID
+      operationId: getCertificate
+      parameters:
+        - $ref: '#/components/parameters/Certificate'
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+        400:
+          description: Course ID is invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        404:
+          description: Certificate with given ID not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
+
 components:
   parameters:
     # Path parameters
@@ -685,6 +793,13 @@ components:
       in: path
       name: submission
       description: Submission hash
+      required: true
+      schema:
+        $ref: '#/components/schemas/Hash'
+    Certificate:
+      in: path
+      name: certificate
+      description: Certificate ID (hash)
       required: true
       schema:
         $ref: '#/components/schemas/Hash'
@@ -726,6 +841,30 @@ components:
       allowEmptyValue: true
       schema:
         type: boolean
+    Offset:
+      in: query
+      name: offset
+      description: Pagination parameter. How many items to skip from the beginning.
+      required: false
+      schema:
+        type: integer
+        format: int32
+    Limit:
+      in: query
+      name: limit
+      description: Pagination parameter. Maximum number of items to return.
+      required: false
+      schema:
+        type: integer
+        format: int32
+    Order:
+      in: query
+      name: order
+      description: Return results in ascending or descending order (ascending by default).
+      required: false
+      schema:
+        type: string
+        enum: [asc, desc]
 
   responses:
     Unauthorized:
@@ -755,6 +894,10 @@ components:
       description: >-
         Time in ISO format.
         Value is automatically rounded to microseconds precision.
+    Count:
+      type: integer
+      format: int32
+      description: Count of items returned
 
     # Entities
     Student:
@@ -948,6 +1091,79 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Transaction'
+    Certificate:
+      type: object
+      required:
+        - id
+        - meta
+      properties:
+        id:
+          $ref: '#/components/schemas/Hash'
+        meta:
+          $ref: '#/components/schemas/CertificateMeta'
+    CertificateMeta:
+      type: object
+      required:
+        - student
+        - startYear
+        - endYear
+        - educationForm
+        - number
+        - issueDate
+        - title
+        - major
+      properties:
+        student:
+          type: object
+          required:
+            - name
+            - birthDate
+          properties:
+            name:
+              type: string
+            birthDate:
+              type: string
+              format: date
+        startYear:
+          type: integer
+          format: int32
+        endYear:
+          type: integer
+          format: int32
+        educationForm:
+          type: string
+          enum: [fulltime, parttime]
+        number:
+          type: string
+        issueDate:
+          type: string
+          format: date
+        title:
+          type: string
+        major:
+          type: string
+        specialization:
+          type: string
+    CertificateGrade:
+      type: object
+      required:
+        - subject
+        - grade
+      properties:
+        subject:
+          type: string
+        lang:
+          type: string
+          enum: [en, ru]
+        hours:
+          type: integer
+          format: int32
+        credits:
+          type: integer
+          format: int32
+        grade:
+          type: integer
+          format: int32
 
     # Errors
     ErrResponse:

--- a/specs/disciplina/educator/api/educator.yaml
+++ b/specs/disciplina/educator/api/educator.yaml
@@ -672,7 +672,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/Offset'
         - $ref: '#/components/parameters/Limit'
-        - $ref: '#/components/parameters/Order'
+        - $ref: '#/components/parameters/SortingSpec'
         - $ref: '#/components/parameters/OnlyCount'
       responses:
         200:
@@ -857,14 +857,18 @@ components:
       schema:
         type: integer
         format: int32
-    Order:
+    SortingSpec:
       in: query
-      name: order
-      description: Return results in ascending or descending order (ascending by default).
+      name: sortBy
+      description: >-
+        Allows to sort on certificate creation date (`createdAt` field) and
+        student's name (`student` field).
       required: false
+      allowEmptyValue: true
       schema:
         type: string
-        enum: [asc, desc]
+        description: How to sort responses.
+        example: asc(field1),desc(field2)
 
   responses:
     Unauthorized:


### PR DESCRIPTION
### Description

This PR adds endpoints required for Certificate Generator app to Educator API. This includes only updates to the spec and Servant API types, not business logic itself.

Important notes:
- Posted grade is still a number from 0 to 100. It is supposed that those numbers would be obtained from regular grades using simple correspondence (e. g. 2 -> 10, 3 -> 40, 4 -> 70, 5 -> 100, "passed" -> 100, "failed" -> 0). 

### YT issue

https://issues.serokell.io/issue/DSCP-444

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [ ] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [ ] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [ ] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [ ] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [ ] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
