### PR TITLE
[DSCP-143] Introduce pagination to Student and Educator APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ that you have installed the following native dependencies:
 - GMP
 - OpenSSL
 - pkg-config
+- Postgres
 - RocksDB
 - ZeroMQ
 - zlib

--- a/educator/src/Dscp/Educator/Web/Bot/Handlers.hs
+++ b/educator/src/Dscp/Educator/Web/Bot/Handlers.hs
@@ -27,25 +27,25 @@ addBotHandlers student StudentApiEndpoints{..} = botEndpoints
   where
     botEndpoints :: (BotWorkMode ctx m, HasBotSetting) => StudentApiHandlers m
     botEndpoints = StudentApiEndpoints
-        { sGetCourses = \isEnrolledF onlyCount sorting -> do
+        { sGetCourses = \isEnrolledF onlyCount sorting pagination -> do
             botProvideInitSetting student
-            sGetCourses isEnrolledF onlyCount sorting
+            sGetCourses isEnrolledF onlyCount sorting pagination
 
         , sGetCourse = \course -> do
             botProvideInitSetting student
             sGetCourse course
 
-        , sGetAssignments = \courseIdF docTypeF isFinalF onlyCount sorting -> do
+        , sGetAssignments = \courseIdF docTypeF isFinalF onlyCount sorting pagination -> do
             botProvideInitSetting student
-            sGetAssignments courseIdF docTypeF isFinalF onlyCount sorting
+            sGetAssignments courseIdF docTypeF isFinalF onlyCount sorting pagination
 
         , sGetAssignment = \assignH -> do
             botProvideInitSetting student
             sGetAssignment assignH
 
-        , sGetSubmissions = \courseF assignHF docTypeF onlyCount sorting -> do
+        , sGetSubmissions = \courseF assignHF docTypeF onlyCount sorting pagination -> do
             botProvideInitSetting student
-            sGetSubmissions courseF assignHF docTypeF onlyCount sorting
+            sGetSubmissions courseF assignHF docTypeF onlyCount sorting pagination
 
         , sGetSubmission = \subH -> do
             botProvideInitSetting student
@@ -58,7 +58,7 @@ addBotHandlers student StudentApiEndpoints{..} = botEndpoints
             delayed $ do
                 requestToSignedSubmission newSub >>= botGradeSubmission
 
-                allAssigns <- sGetAssignments Nothing Nothing Nothing False def
+                allAssigns <- sGetAssignments Nothing Nothing Nothing False def def
                 botProvideUnlockedAssignments student res allAssigns
 
             -- Easter egg: once a couple of courses is completed,
@@ -67,7 +67,7 @@ addBotHandlers student StudentApiEndpoints{..} = botEndpoints
             -- Frontend team can still unlock courses quickly if they need
             -- because assignments for first two courses are fixed disregard
             -- the seed.
-            courses <- sGetCourses (Just $ IsEnrolled True) False def
+            courses <- sGetCourses (Just $ IsEnrolled True) False def def
             when (length (filter ciIsFinished courses) >= 2) $
                 botProvideAdvancedSetting student
 

--- a/educator/src/Dscp/Educator/Web/Educator/API.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/API.hs
@@ -12,7 +12,7 @@ module Dscp.Educator.Web.Educator.API
 import Network.HTTP.Media.MediaType ((//))
 import Servant
 import Servant.Generic
-import Servant.Util (SortingParamsOf)
+import Servant.Util (PaginationParams, PaginationSettings (DefPageSize), SortingParamsOf)
 
 import Dscp.Core
 import Dscp.Crypto
@@ -90,6 +90,7 @@ type GetStudents
     :> QueryParam "course" Course
     :> QueryParam "isEnrolled" IsEnrolled
     :> QueryFlag "onlyCount"
+    :> PaginationParams ('DefPageSize 100)
     :> Summary "Get a list of all registered students' addresses"
     :> Get '[DSON] (Counted StudentInfo)
 
@@ -144,6 +145,7 @@ type GetCourses
     = "courses"
     :> QueryParam "student" Student
     :> QueryFlag "onlyCount"
+    :> PaginationParams ('DefPageSize 100)
     :> Summary "Get all courses"
     :> Get '[DSON] (Counted CourseEducatorInfo)
 
@@ -170,6 +172,7 @@ type GetAssignments
     :> QueryParam "isFinal" IsFinal
     :> QueryParam "since" Timestamp
     :> QueryFlag "onlyCount"
+    :> PaginationParams ('DefPageSize 100)
     :> Summary "Get all assignments"
     :> Get '[DSON] (Counted AssignmentEducatorInfo)
 
@@ -192,6 +195,7 @@ type GetSubmissions
     :> QueryParam "isGraded" IsGraded
     :> QueryParam "since" Timestamp
     :> QueryFlag "onlyCount"
+    :> PaginationParams ('DefPageSize 100)
     :> Summary "Get all submissions"
     :> Description "Gets a list of all submissions done by all students. \
                   \This method is inaccessible by students."
@@ -254,9 +258,8 @@ type GetProofs
 
 type GetCertificates
     = "certificates"
-    :> QueryParam "offset" Int
-    :> QueryParam "limit" Int
     :> SortingParamsOf Certificate
+    :> PaginationParams ('DefPageSize 100)
     :> QueryFlag "onlyCount"
     :> Summary "Get the list of certificates created by Educator"
     :> Description "Gets all the certificates created by Educator. Each \

--- a/educator/src/Dscp/Educator/Web/Student/API.hs
+++ b/educator/src/Dscp/Educator/Web/Student/API.hs
@@ -12,7 +12,7 @@ module Dscp.Educator.Web.Student.API
 
 import Servant
 import Servant.Generic
-import Servant.Util (SortingParamsOf)
+import Servant.Util (PaginationParams, PaginationSettings (DefPageSize), SortingParamsOf)
 
 import qualified Dscp.Core as Core
 import Dscp.Crypto (Hash)
@@ -56,9 +56,10 @@ type GetCourses
     = "courses"
     :> QueryParam "isEnrolled" IsEnrolled
     :> QueryFlag "onlyCount"
+    :> SortingParamsOf CourseStudentInfo
+    :> PaginationParams ('DefPageSize 100)
     :> Summary "Get Educator's courses"
     :> Description "Gets a list of Educator's courses, both enrolled and available."
-    :> SortingParamsOf CourseStudentInfo
     :> Verb 'GET 200 '[DSON] [CourseStudentInfo]
 
 type GetCourse
@@ -77,10 +78,11 @@ type GetAssignments
     :> QueryParam "type" Core.DocumentType
     :> QueryParam "isFinal" IsFinal
     :> QueryFlag "onlyCount"
+    :> SortingParamsOf AssignmentStudentInfo
+    :> PaginationParams ('DefPageSize 100)
     :> Summary "Get student's assignments"
     :> Description "Gets a list of student's assignments. Filter parameters are \
                    \used to specify specific course, type, etc."
-    :> SortingParamsOf AssignmentStudentInfo
     :> Verb 'GET 200 '[DSON] [AssignmentStudentInfo]
 
 type GetAssignment
@@ -100,10 +102,11 @@ type GetSubmissions
     :> QueryParam "assignment" (Hash Core.Assignment)
     :> QueryParam "type" Core.DocumentType
     :> QueryFlag "onlyCount"
+    :> SortingParamsOf SubmissionStudentInfo
+    :> PaginationParams ('DefPageSize 100)
     :> Summary "Get student's submissions"
     :> Description "Gets a list of student's submissions. Filter parameters are \
                    \used to specify specific course, assignment, etc."
-    :> SortingParamsOf SubmissionStudentInfo
     :> Verb 'GET 200 '[DSON] [SubmissionStudentInfo]
 
 type AddSubmission

--- a/educator/src/Dscp/Educator/Web/Student/Handlers.hs
+++ b/educator/src/Dscp/Educator/Web/Student/Handlers.hs
@@ -29,30 +29,31 @@ studentApiHandlers student =
     {
       -- Courses
 
-      sGetCourses = \isEnrolledF _onlyCount sorting ->
-        transact $ studentGetCourses student isEnrolledF sorting
+      sGetCourses = \isEnrolledF _onlyCount sorting pagination ->
+        transact $ studentGetCourses student isEnrolledF sorting pagination
 
     , sGetCourse = \course ->
         transact $ studentGetCourse student course
 
       -- Assignments
 
-    , sGetAssignments = \afCourse afDocType afIsFinal _onlyCount sorting ->
+    , sGetAssignments = \afCourse afDocType afIsFinal _onlyCount sorting pagination ->
         transact $
             studentGetAssignments student
                 def{ afCourse, afDocType, afIsFinal }
-                sorting
+                sorting pagination
 
     , sGetAssignment = \assignH ->
         transact $ studentGetAssignment student assignH
 
-      -- Submissions`
+      -- Submissions
 
-    , sGetSubmissions = \sfCourse sfAssignmentHash sfDocType _onlyCount sorting ->
+    , sGetSubmissions = \sfCourse sfAssignmentHash sfDocType _onlyCount sorting
+                         pagination ->
         invoke $
         studentGetSubmissions student
             def{ sfCourse, sfAssignmentHash, sfDocType }
-            sorting
+            sorting pagination
 
     , sAddSubmission = \newSub ->
         studentMakeSubmissionVerified student newSub

--- a/educator/tests/Test/Dscp/Educator/Bot/Endpoints.hs
+++ b/educator/tests/Test/Dscp/Educator/Bot/Endpoints.hs
@@ -38,13 +38,13 @@ spec_StudentApiWithBotQueries = specWithTempPostgresServer $ do
     it "Student gets assigned on courses on first request" $
         educatorProperty $ \seed -> do
             StudentApiEndpoints{..} <- testMakeBotHandlers seed
-            courses <- sGetCourses Nothing False def
+            courses <- sGetCourses Nothing False def def
             return (not $ null courses)
 
     it "Student gets some assignments on first request" $
         educatorProperty $ \seed -> do
             StudentApiEndpoints{..} <- testMakeBotHandlers seed
-            assignments <- sGetAssignments Nothing Nothing Nothing False def
+            assignments <- sGetAssignments Nothing Nothing Nothing False def def
             return (not $ null assignments)
 
     it "Submissions are graded automatically" $
@@ -58,6 +58,6 @@ spec_StudentApiWithBotQueries = specWithTempPostgresServer $ do
             submissions <- lift $ do
                 StudentApiEndpoints{..} <- testMakeBotHandlers seed
                 void $ sAddSubmission (signedSubmissionToRequest sigsub)
-                sGetSubmissions Nothing Nothing Nothing False def
+                sGetSubmissions Nothing Nothing Nothing False def def
             [submission] <- pure submissions
             return (isJust $ siGrade submission)

--- a/specs/disciplina/educator/api/educator.yaml
+++ b/specs/disciplina/educator/api/educator.yaml
@@ -89,6 +89,8 @@ paths:
           required: false
           schema:
             type: boolean
+        - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Limit'
         - $ref: '#/components/parameters/OnlyCount'
       responses:
         200:
@@ -298,6 +300,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/StudentFilter'
         - $ref: '#/components/parameters/OnlyCount'
+        - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Limit'
       responses:
         200:
           description: A list of all courses
@@ -388,6 +392,8 @@ paths:
         - $ref: '#/components/parameters/StudentFilter'
         - $ref: '#/components/parameters/SinceFilter'
         - $ref: '#/components/parameters/OnlyCount'
+        - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Limit'
         - in: query
           name: isFinal
           description: Return only final/non-final assignments of the course
@@ -461,6 +467,8 @@ paths:
         - $ref: '#/components/parameters/AssignmentFilter'
         - $ref: '#/components/parameters/SinceFilter'
         - $ref: '#/components/parameters/OnlyCount'
+        - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Limit'
         - in: query
           name: isGraded
           description: Return only submissions with/without grade

--- a/specs/disciplina/educator/api/student.yaml
+++ b/specs/disciplina/educator/api/student.yaml
@@ -56,6 +56,8 @@ paths:
           schema:
             $ref: '#/components/schemas/SortingSpec'
         - $ref: '#/components/parameters/OnlyCount'
+        - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Limit'
       responses:
         200:
           description: Successful operation
@@ -131,6 +133,8 @@ paths:
           description: Select only final/non-final assignments
           schema:
             type: boolean
+        - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Limit'
       responses:
         200:
           description: Successful operation
@@ -188,6 +192,8 @@ paths:
         - $ref: '#/components/parameters/AssignmentFilter'
         - $ref: '#/components/parameters/DocumentTypeFilter'
         - $ref: '#/components/parameters/OnlyCount'
+        - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Limit'
         - in: query
           name: sortBy
           description: Allows to sort on grades (`grade` field).
@@ -404,6 +410,22 @@ components:
       allowEmptyValue: true
       schema:
         type: boolean
+    Offset:
+      in: query
+      name: offset
+      description: Pagination parameter. How many items to skip from the beginning.
+      required: false
+      schema:
+        type: integer
+        format: int32
+    Limit:
+      in: query
+      name: limit
+      description: Pagination parameter. Maximum number of items to return.
+      required: false
+      schema:
+        type: integer
+        format: int32
 
   responses:
     Unauthorized:

--- a/stack.yaml
+++ b/stack.yaml
@@ -31,7 +31,7 @@ extra-deps:
 
 
 - git: https://github.com/serokell/servant-util.git
-  commit: c504caf8bc7a668cdcab329796b3e1a1962b7dd7
+  commit: 8a8e1ba5ea1109a6ab8d7274ecaf9e9382176866
   subdirs:
     - servant-util
     - servant-util-beam-pg

--- a/stack.yaml
+++ b/stack.yaml
@@ -31,7 +31,7 @@ extra-deps:
 
 
 - git: https://github.com/serokell/servant-util.git
-  commit: c84803a4a66fd1cb0e6623fdcc71b1203c17b426
+  commit: c504caf8bc7a668cdcab329796b3e1a1962b7dd7
   subdirs:
     - servant-util
     - servant-util-beam-pg

--- a/tools/package.yaml
+++ b/tools/package.yaml
@@ -50,6 +50,7 @@ executables:
       - aeson-pretty
       - bytestring
       - containers
+      - data-default
       - disciplina-core
       - disciplina-witness
       - disciplina-educator

--- a/tools/src/faircv/Client.hs
+++ b/tools/src/faircv/Client.hs
@@ -2,13 +2,14 @@ module Client where
 
 import Data.Traversable (for)
 
+import Data.Default (def)
 import Dscp.Core
 import Dscp.Crypto
 import Dscp.Educator.Web.Student
 import Dscp.Educator.Web.Types
-import Dscp.Witness.Web.Client
 import Dscp.Util
 import Dscp.Util.Aeson
+import Dscp.Witness.Web.Client
 
 import Test.QuickCheck
 
@@ -26,7 +27,7 @@ getProofs sc = do
 
 getAssignments :: StudentApiClient -> IO [AssignmentStudentInfo]
 getAssignments sc = do
-    hashes <- map aiHash <$> sGetAssignments sc Nothing Nothing Nothing False
+    hashes <- map aiHash <$> sGetAssignments sc Nothing Nothing Nothing False def
     for hashes $ sGetAssignment sc
 
 makeRandomSubmissionForAssignment :: SecretKey -> Hash Assignment -> IO NewSubmission
@@ -54,7 +55,7 @@ sendSubmission sc sub = do
 
 getAllCourses :: StudentApiClient -> IO [Course]
 getAllCourses sc = do
-    map ciId <$> sGetCourses sc Nothing False
+    map ciId <$> sGetCourses sc Nothing False def
 
 
 getFairCV :: IO FairCV


### PR DESCRIPTION
### Description

Endpoints like `getCourses`, `getAssignments` and `getSubmissions` now use pagination.

Endpoints like `getProofs` and `getGrades` left intact because in their case
keyset pagination fits better (new entries may appear without actions from client side),
and this pagination is not yet implemented.

**Do not merge** before dependency not on `master` of `servant-util` is fixed.

### YT issue

https://issues.serokell.io/issue/DSCP-143

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
