### PR TITLE
[OPS-698] Include DB schema in distribution, fix example config

### DIFF
--- a/docs/config-full-sample.yaml
+++ b/docs/config-full-sample.yaml
@@ -156,19 +156,17 @@ sample:
 
     # SQL DB params
     db:
-      # Params for connection to Postgres server.
-      mode:
-        # Connection string to Postgres server.
-        connString: "postgresql:///disciplina-educator"
-        # Number of concurrent DB connections.
-        # Optional. If not provided, calculated automatically
-        # accordingly to the number of threads which can run truly
-        # simultaneously on a machine (e. g. number of CPU cores, or
-        # number of CPU cores x 2 when hyperthreading is enabled)
-        connNum: 4
-        # Number of maximum number of threads which wait for DB connection
-        # to be free. Default: 200
-        maxPending: 100
+      # Connection string to Postgres server.
+      connString: "postgresql:///disciplina-educator"
+      # Number of concurrent DB connections.
+      # Optional. If not provided, calculated automatically
+      # accordingly to the number of threads which can run truly
+      # simultaneously on a machine (e. g. number of CPU cores, or
+      # number of CPU cores x 2 when hyperthreading is enabled)
+      connNum: 4
+      # Number of maximum number of threads which wait for DB connection
+      # to be free. Default: 200
+      maxPending: 100
 
     # Educator key params. Similar to `witness.keys.params.basic` config section.
     keys:

--- a/educator/package.yaml
+++ b/educator/package.yaml
@@ -107,3 +107,6 @@ executables:
       - disciplina-educator
       - loot-log
       - optparse-applicative
+
+data-files:
+  - database/*.sql

--- a/release.nix
+++ b/release.nix
@@ -18,20 +18,27 @@ let
       ${source}
     '';
   };
-in
 
-rec {
-  disciplina = symlinkJoin {
-    name = "disciplina";
-    paths = with project; map haskell.lib.justStaticExecutables [
+  justDataOutputs = drv: lib.optional (drv ? data) drv.data;
+
+  server-packages = with project; [
       disciplina-educator
       disciplina-faucet
       disciplina-tools
       disciplina-witness
-    ];
+  ];
+in
+
+project // rec {
+  disciplina = symlinkJoin {
+    name = "disciplina";
+    paths = map haskell.lib.justStaticExecutables server-packages;
   };
 
-  inherit (project) disciplina-tools;
+  disciplina-data = symlinkJoin {
+    name = "disciplina-data";
+    paths = lib.concatMap justDataOutputs server-packages;
+  };
 
   disciplina-config = runCommand "disciplina-config.yaml" {} "cp ${./config.yaml} $out";
 


### PR DESCRIPTION
### Description

This PR contains changes required for deploying Educator alongside a postgres database:

* Fix example config
* Add .sql files to data-files in educator
* Provide a derivation with data outputs
* Export all local packages from release.nix

### YT issue

https://issues.serokell.io/issue/OPS-698

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).