### PR TITLE
[DSCP-143] Fix dependency on servant-util :(

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -31,7 +31,7 @@ extra-deps:
 
 
 - git: https://github.com/serokell/servant-util.git
-  commit: 8a8e1ba5ea1109a6ab8d7274ecaf9e9382176866
+  commit: 15adfc61a9c0ae6c2656507cad3a70fd2eef20b2
   subdirs:
     - servant-util
     - servant-util-beam-pg


### PR DESCRIPTION
### Description

So that it depends on `master`.
After all sufferings, I took to make CI work I forgot to merge the `servant-util`'s branch with pagination to master.

### YT issue

https://issues.serokell.io/issue/DSCP-143

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
