### PR TITLE
[DSCP-472] Consider `onlyCount` parameters in Educator API

### DIFF
--- a/core/src/Dscp/Util.hs
+++ b/core/src/Dscp/Util.hs
@@ -10,6 +10,7 @@ module Dscp.Util
        , Seed (..)
        , execUnmasked
        , fromIntegralChecked
+       , groupToAssoc
 
          -- * Exceptions processing
        , wrapRethrow
@@ -77,7 +78,9 @@ import Control.Monad.Except (MonadError (..))
 import Data.ByteArray (ByteArrayAccess)
 import Data.ByteArray.Encoding (Base (..), convertFromBase, convertToBase)
 import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Map as M
 import Data.Typeable (typeRep)
+import qualified GHC.Exts as Exts
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import UnliftIO (MonadUnliftIO)
 import qualified UnliftIO.Async as UIO
@@ -154,6 +157,12 @@ fromIntegralChecked x =
     in if fromIntegral r == x
           then r
           else error "Integral overflow"
+
+groupToAssoc :: Ord k => [(k, v)] -> [(k, NonEmpty v)]
+groupToAssoc =
+    M.toList . fmap Exts.fromList . foldl' push M.empty
+  where
+    push acc a = M.insertWith (++) (fst a) [snd a] acc
 
 -----------------------------------------------------------
 -- Exceptions processing

--- a/educator/src/Dscp/DB/SQL/Util/Common.hs
+++ b/educator/src/Dscp/DB/SQL/Util/Common.hs
@@ -30,7 +30,7 @@ import Prelude hiding (_1, _2)
 import Data.Coerce (coerce)
 import qualified Database.Beam.Backend.SQL as Beam
 import Database.Beam.Migrate (HasDefaultSqlDataType (..))
-import Database.Beam.Postgres as BeamReexport (PgJSONB (..))
+import Database.Beam.Postgres as BeamReexport (PgJSONB (..), arrayOf_)
 import qualified Database.Beam.Postgres as Beam
 import Database.Beam.Query as BeamReexport (QExpr, QGenExpr (..), aggregate_, all_, as_, asc_,
                                             countAll_, default_, delete, desc_, exists_, filter_,

--- a/educator/src/Dscp/Educator/Web/Educator/Error.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Error.hs
@@ -22,7 +22,7 @@ import Dscp.Educator.DB (DomainError)
 import Servant (ServantErr (..), err400, err503)
 import Servant.Util (SimpleJSON)
 
-import Dscp.Educator.Web.Util
+import Dscp.Educator.Web.Instances
 import Dscp.Web.Class
 
 -- | Any error backend may return.

--- a/educator/src/Dscp/Educator/Web/Educator/Handlers.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Handlers.hs
@@ -66,9 +66,10 @@ educatorApiHandlers =
 
       -- Assignments
 
-    , eGetAssignments = \afCourse afStudent afIsFinal _afSince afOnlyCount pagination ->
-            fmap (mkCountedList afOnlyCount) $ invoke $
-            educatorGetAssignments def{ afCourse, afStudent, afIsFinal } pagination
+    , eGetAssignments = \afCourse afStudent afIsFinal _afSince onlyCount pagination ->
+            invoke $ educatorGetAssignments
+                def{ afCourse, afStudent, afIsFinal }
+                onlyCount pagination
 
     , eAddAssignment = \_autoAssign na -> do
         void . transact $ createAssignment (requestToAssignment na)
@@ -77,11 +78,10 @@ educatorApiHandlers =
       -- Submissions
 
     , eGetSubmissions = \sfCourse sfStudent sfAssignmentHash _sfIsGraded _sfSince
-                         sfOnlyCount pagination ->
-            fmap (mkCountedList sfOnlyCount) $ invoke $
-            educatorGetSubmissions
+                         onlyCount pagination ->
+            invoke $ educatorGetSubmissions
                 def{ sfCourse, sfStudent, sfAssignmentHash }
-                pagination
+                onlyCount pagination
 
     , eGetSubmission =
         invoke ... educatorGetSubmission
@@ -99,9 +99,10 @@ educatorApiHandlers =
 
       -- Proofs
 
-    , eGetProofs = \pfCourse pfStudent pfAssignment pfOnlyCount ->
-            fmap (mkCountedList pfOnlyCount) $ transact $
-            commonGetProofs def{ pfCourse, pfStudent, pfAssignment }
+    , eGetProofs = \pfCourse pfStudent pfAssignment onlyCount ->
+            fmap (mkCountedList onlyCount) . transact $
+            commonGetProofs
+                def{ pfCourse, pfStudent, pfAssignment }
 
       -- Certificates
     , eGetCertificates = \sorting pagination onlyCount ->

--- a/educator/src/Dscp/Educator/Web/Educator/Handlers.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Handlers.hs
@@ -32,7 +32,7 @@ educatorApiHandlers =
       -- Students
 
     , eGetStudents = \mCourse _mIsEnrolled onlyCount pagination ->
-        fmap (mkCountedList onlyCount) $ invoke $ educatorGetStudents mCourse pagination
+        invoke $ educatorGetStudents mCourse onlyCount pagination
 
     , eAddStudent = \(NewStudent student) ->
         void . invoke $ createStudent student
@@ -52,7 +52,7 @@ educatorApiHandlers =
       -- Courses
 
     , eGetCourses = \mStudent onlyCount pagination ->
-        fmap (mkCountedList onlyCount) $ invoke $ educatorGetCourses mStudent pagination
+        invoke $ educatorGetCourses mStudent onlyCount pagination
 
     , eAddCourse = \(NewCourse mcid desc subjects) ->
         transact $ createCourse CourseDetails
@@ -92,8 +92,7 @@ educatorApiHandlers =
       -- Grades
 
     , eGetGrades = \course student assignment isFinalF _since onlyCount ->
-            fmap (mkCountedList onlyCount) $ invoke $
-            educatorGetGrades course student assignment isFinalF
+            invoke $ educatorGetGrades course student assignment isFinalF onlyCount
 
     , eAddGrade = \(NewGrade subH grade) ->
             transact $ educatorPostGrade subH grade

--- a/educator/src/Dscp/Educator/Web/Educator/Types.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Types.hs
@@ -16,6 +16,7 @@ module Dscp.Educator.Web.Educator.Types
       -- * Responses
     , Counted (..)
     , mkCountedList
+    , toCountedList
     , EducatorInfo (..)
     , CourseEducatorInfo (..)
     , AssignmentEducatorInfo (..)
@@ -30,6 +31,7 @@ module Dscp.Educator.Web.Educator.Types
     , educatorLiftAssignment
     , educatorLiftSubmission
     , requestToAssignment
+    , educatorCourseInfoFromRow
     , educatorAssignmentInfoFromRow
     , educatorSubmissionInfoFromRow
     ) where
@@ -127,6 +129,10 @@ mkCountedList :: Bool -> [a] -> Counted a
 mkCountedList onlyCount ls =
     Counted (L.genericLength ls) (if onlyCount then Nothing else Just ls)
 
+-- | Makes a 'Counted' from a list
+toCountedList :: [a] -> Counted a
+toCountedList = mkCountedList False
+
 ---------------------------------------------------------------------------
 -- Sorting
 ---------------------------------------------------------------------------
@@ -167,6 +173,14 @@ requestToAssignment NewAssignment{..} =
     , _aContentsHash = naContentsHash
     , _aType = naIsFinal ^. from assignmentTypeRaw
     , _aDesc = naDesc
+    }
+
+educatorCourseInfoFromRow :: (Course, ItemDesc, Vector Subject) -> CourseEducatorInfo
+educatorCourseInfoFromRow (ciId, ciDesc, toList -> ciSubjects) =
+    CourseEducatorInfo
+    { ciId
+    , ciDesc
+    , ciSubjects
     }
 
 educatorAssignmentInfoFromRow :: AssignmentRow -> AssignmentEducatorInfo

--- a/educator/src/Dscp/Educator/Web/Educator/Types.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Types.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE StrictData #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE StrictData    #-}
 
 -- | Types specific to educator API.
 
@@ -117,7 +118,7 @@ mkCertificate meta = Certificate (hash meta) meta
 data Counted a = Counted
     { cCount :: Int
     , cItems :: Maybe [a]
-    } deriving (Show, Eq, Generic)
+    } deriving (Show, Eq, Functor, Generic)
 
 -- | Makes a 'Counted' from a list, omitting the list itself if
 -- @onlyCount@ flag is set
@@ -300,10 +301,10 @@ instance Buildable (ForResponseLog [Certificate]) where
 instance Buildable (ForResponseLog [a]) =>
          Buildable (ForResponseLog (Counted a)) where
     build (ForResponseLog (Counted n mbLs)) =
-        "Counted { n = "+|n|+", items = "+|mbItems mbLs|+" }"
+        "Counted { n = "+|n|+", items: "+|mbItems mbLs|+" }"
       where
         mbItems Nothing   = "omitted"
-        mbItems (Just ls) = build (ForResponseLog ls)
+        mbItems (Just ls) = "\n" <> build (ForResponseLog ls)
 
 ---------------------------------------------------------------------------
 -- JSON instances

--- a/educator/src/Dscp/Educator/Web/Educator/Types.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Types.hs
@@ -38,6 +38,7 @@ import Control.Lens (from)
 import Data.Aeson (FromJSON (..), ToJSON (..), Value (..), withText)
 import Data.Aeson.Options (defaultOptions)
 import Data.Aeson.TH (deriveJSON)
+import qualified Data.List as L
 import Data.Time.Calendar (Day)
 import Fmt (build, listF, (+|), (|+))
 import Pdf.Scanner (PDFBody (..))
@@ -116,7 +117,7 @@ mkCertificate meta = Certificate (hash meta) meta
 
 -- | Special wrapper for list which includes its length
 data Counted a = Counted
-    { cCount :: Int
+    { cCount :: Word32
     , cItems :: Maybe [a]
     } deriving (Show, Eq, Functor, Generic)
 
@@ -124,7 +125,7 @@ data Counted a = Counted
 -- @onlyCount@ flag is set
 mkCountedList :: Bool -> [a] -> Counted a
 mkCountedList onlyCount ls =
-    Counted (length ls) (if onlyCount then Nothing else Just ls)
+    Counted (L.genericLength ls) (if onlyCount then Nothing else Just ls)
 
 ---------------------------------------------------------------------------
 -- Sorting

--- a/educator/src/Dscp/Educator/Web/Instances.hs
+++ b/educator/src/Dscp/Educator/Web/Instances.hs
@@ -2,7 +2,7 @@
 
 -- | Utils for educator servers.
 
-module Dscp.Educator.Web.Util
+module Dscp.Educator.Web.Instances
      ( domainErrorToShortJSON
      , domainToServantErrNoReason
      ) where

--- a/educator/src/Dscp/Educator/Web/Logic.hs
+++ b/educator/src/Dscp/Educator/Web/Logic.hs
@@ -22,16 +22,15 @@ commonGetProofs
     :: MonadEducatorWebQuery m
     => GetProvenStudentTransactionsFilters
     -> DBT 'WithinTx m [BlkProofInfo]
-commonGetProofs filters = do
-    rawProofs <- getProvenStudentTransactions filters
-    return
-        [ BlkProofInfo
-          { bpiBlockHash = bHash
-          , bpiMtreeSerialized = EncodeSerialised mtree
-          , bpiTxs = txs
-          }
-        | (bHash, mtree, txs) <- rawProofs
-        ]
+commonGetProofs filters =
+    map toBlkProofInfo <$> getProvenStudentTransactions filters
+  where
+    toBlkProofInfo (bHash, mtree, txs) =
+        BlkProofInfo
+        { bpiBlockHash = bHash
+        , bpiMtreeSerialized = EncodeSerialised mtree
+        , bpiTxs = txs
+        }
 
 getEducatorStatus
     :: MonadEducatorWeb ctx m

--- a/educator/src/Dscp/Educator/Web/Student/Error.hs
+++ b/educator/src/Dscp/Educator/Web/Student/Error.hs
@@ -23,7 +23,7 @@ import Servant.Util (SimpleJSON)
 import Dscp.Core.Validation
 import Dscp.DB.SQL (SQLRequestsNumberExceeded)
 import Dscp.Educator.DB (DomainError (..))
-import Dscp.Educator.Web.Util
+import Dscp.Educator.Web.Instances
 import Dscp.Web.Class
 
 -- | Any error backend may return.

--- a/educator/src/Dscp/Educator/Web/Student/Handlers.hs
+++ b/educator/src/Dscp/Educator/Web/Student/Handlers.hs
@@ -67,7 +67,8 @@ studentApiHandlers student =
       -- Proofs
 
     , sGetProofs = \pfSince _onlyCount ->
-        transact $ commonGetProofs def{ pfSince, pfStudent = Just student }
+        transact $ commonGetProofs
+            def{ pfSince, pfStudent = Just student }
     }
 
 convertStudentApiHandler

--- a/educator/src/Dscp/Educator/Web/Util.hs
+++ b/educator/src/Dscp/Educator/Web/Util.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF autoexporter -Wno-dodgy-exports -Wno-unused-imports #-}

--- a/educator/src/Dscp/Educator/Web/Util/Count.hs
+++ b/educator/src/Dscp/Educator/Web/Util/Count.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# OPTIONS_GHC -Wno-partial-type-signatures #-}
+
+-- | Implementation of response length counting.
+module Dscp.Educator.Web.Util.Count
+    ( counting_
+    , countPaginate_
+    , runCountedSelect
+    , runCountedSelectMap
+    ) where
+
+import Database.Beam.Backend (FromBackendRow)
+import Database.Beam.Backend.SQL (Sql92SelectSelectTableSyntax, Sql92SelectTableExpressionSyntax)
+import Database.Beam.Postgres (Postgres)
+import Database.Beam.Postgres.Syntax (PgSelectSyntax)
+import Database.Beam.Query (Q, QGenExpr, SqlSelect, just_, nothing_)
+import Database.Beam.Query.Internal (ProjectibleWithPredicate, QNested, QValueContext, ValueContext)
+import Database.Beam.Schema (C, Nullable)
+import Servant.Util (PaginationSpec)
+import Servant.Util.Beam.Postgres (paginate_)
+
+import Dscp.DB.SQL
+import Dscp.Educator.Web.Educator.Types
+
+
+-- | Helper Beam-style type which keeps either response length or response itself.
+type CountedT a f = (C (Nullable f) Int, C (Nullable f) a)
+
+-- | Modify a query so that, when 'True' is passed, only response length is returned.
+counting_
+    :: ( f ~ QGenExpr QValueContext exprSyntax
+       , exprSyntax ~ Sql92SelectTableExpressionSyntax (Sql92SelectSelectTableSyntax select)
+       , _
+       )
+    => Bool
+    -> (forall s0. ProjectibleWithPredicate ValueContext exprSyntax (f (QNested s0) a) =>
+                   Q select db s0 (f s0 a))
+    -> (Q select db s (CountedT a (f s)))
+counting_ countOnly query
+    | countOnly = do
+        count <- just_ <$> aggregate_ (\_ -> countAll_) query
+        return (count, nothing_)
+    | otherwise = query <&> \q -> (nothing_, just_ q)
+
+-- | Like 'counting_', disables pagination when flag is 'True'.
+countPaginate_
+    :: ( f ~ QGenExpr QValueContext exprSyntax
+       , exprSyntax ~ Sql92SelectTableExpressionSyntax (Sql92SelectSelectTableSyntax select)
+       , _)
+    => Bool
+    -> PaginationSpec
+    -> (forall s0. Q select db s0 (f s0 a))
+    -> (Q select db s (CountedT a (f s)))
+countPaginate_ countOnly pagination
+    | countOnly = counting_ countOnly
+    | otherwise = \query -> counting_ countOnly $ paginate_ pagination query
+
+-- | Interpret a counted response returned by 'runSelect'.
+fromBeamCounted :: [CountedT a Identity] -> Counted a
+fromBeamCounted = \case
+    [] -> Counted{ cCount = 0, cItems = Just [] }  -- TODO: is it ok to show both diregard "onlyCount" value?
+    ((Just c, _) : _) -> Counted{ cCount = c, cItems = Nothing }
+    cs -> Counted
+          { cCount = length cs
+          , cItems = Just $ map (fromMaybe (error ":shrug:") . snd) cs
+          }
+
+-- | Counting version of 'runSelectMap', couple it with 'counting_' or similar functions.
+runCountedSelectMap
+    :: (MonadIO m, FromBackendRow Postgres a)
+    => (a -> b)
+    -> SqlSelect PgSelectSyntax (CountedT a Identity)
+    -> DBT t m (Counted b)
+runCountedSelectMap f = fmap (fmap f . fromBeamCounted) . runSelect
+
+-- | Counting version of 'runSelect', couple it with 'counting_' or similar functions.
+runCountedSelect
+    :: (MonadIO m, FromBackendRow Postgres a)
+    => SqlSelect PgSelectSyntax (CountedT a Identity)
+    -> DBT t m (Counted a)
+runCountedSelect = runCountedSelectMap id

--- a/educator/tests/Test/Dscp/Educator/Web/Educator/Queries.hs
+++ b/educator/tests/Test/Dscp/Educator/Web/Educator/Queries.hs
@@ -31,7 +31,7 @@ spec_Educator_API_queries = specWithTempPostgresServer $ do
             students <- pickSmall listUnique
             lift $ forM_ students createStudent
 
-            students' <- lift $ educatorGetStudents Nothing def
+            (cItems -> Just students') <- lift $ educatorGetStudents Nothing False def
             return $ sort students' === sort (map StudentInfo students)
 
         it "Filtering works" $ sqlPropertyM $ do


### PR DESCRIPTION
### Description

After two days of trying this is the best I came to.
Once the overall design is approved I fill fix tests.

### YT issue

https://issues.serokell.io/issue/DSCP-472

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
