### PR TITLE
[DSCP-289] Fix bot + no auth case

### DIFF
--- a/educator/src/Dscp/Educator/Web/Auth.hs
+++ b/educator/src/Dscp/Educator/Web/Auth.hs
@@ -17,6 +17,7 @@ module Dscp.Educator.Web.Auth
        , NoAuth
        , NoAuthData
        , NoAuthContext (..)
+       , whenNoAuth
 
        , authBearerToken
        , authTimeout
@@ -354,6 +355,11 @@ instance FromJSON (NoAuthData s) => FromJSON (NoAuthContext s) where
 instance AuthHasSwagger (NoAuth s) where
     authNameDoc = "NoAuth"
     authSecurityDoc = NoAuthSwaggerInfo
+
+whenNoAuth :: Monad m => NoAuthContext s -> (NoAuthData s -> m ()) -> m ()
+whenNoAuth ctx action = case ctx of
+    NoAuthOnContext c -> action c
+    NoAuthOffContext -> pass
 
 ---------------------------------------------------------------------------
 -- Documentation

--- a/educator/src/Dscp/Educator/Web/Bot/Setting.hs
+++ b/educator/src/Dscp/Educator/Web/Bot/Setting.hs
@@ -256,8 +256,10 @@ botProvideCourses student courses = do
 -- | Remember student and add minimal set of courses.
 botProvideInitSetting :: (BotWorkMode ctx m, HasBotSetting) => Student -> m ()
 botProvideInitSetting student = do
-    maybePresent $ do
+    maybePresent $
         void . invoke $ createStudent student
+
+    maybePresent $ do
         botProvideCourses student (bsBasicCourses botSetting)
         botLog . logInfo $ "Registered student " +| student |+ ""
 


### PR DESCRIPTION
### Description

I dunno how did it happen, but bot didn't register new students when request is performed
without authentication (when authentication is made optional). :unamused: 

This case is fixed. The case when authentication is optional but credentials are provided nevertheless is also retested.

### YT issue

https://issues.serokell.io/issue/DSCP-289

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
