### PR TITLE
[DSCP-483] Moved insertion point to before startxref

### DIFF
--- a/pdfs/src/Pdf/Scanner.hs
+++ b/pdfs/src/Pdf/Scanner.hs
@@ -58,7 +58,7 @@ insertAt place what text =
     in   before <> what <> after
 
 insertionMark :: LBS.ByteString
-insertionMark = "\ntrailer"
+insertionMark = "\nstartxref"
 
 fairCVStartMark :: LBS.ByteString
 fairCVStartMark = text <> ":" <> show (hash text)


### PR DESCRIPTION
### Description

Fixing PDF generator and injector not working together.

### YT issue

https://issues.serokell.io/issue/DSCP-483

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [ ] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [ ] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [ ] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [ ] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [ ] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [ ] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [ ] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [ ] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
