### PR TITLE
[DSCP-485] Multi educator workers

### DIFF
--- a/core/src/Dscp/Resource/AppDir.hs
+++ b/core/src/Dscp/Resource/AppDir.hs
@@ -9,13 +9,13 @@ module Dscp.Resource.AppDir
        , AppDirParamRec
        , AppDirParamRecP
 
-       , AppDir
+       , AppDir (..)
        , getOSAppDir
        ) where
 
 import Fmt ((+|), (|+))
+import Loot.Config ((::+), (::-), (:::), Config, PartialConfig)
 import Loot.Log (MonadLogging, logInfo)
-import Loot.Config ((:::), (::-), (::+), Config, PartialConfig)
 import System.Directory (XdgDirectory (XdgData), createDirectoryIfMissing, getXdgDirectory)
 import System.Environment (lookupEnv)
 import System.IO.Error (catchIOError, ioError, isDoesNotExistError)
@@ -40,7 +40,7 @@ type AppDirParamRec = Config AppDirParam
 type AppDirParamRecP = PartialConfig AppDirParam
 
 
-type AppDir = FilePath
+newtype AppDir = AppDir FilePath
 
 -- | Return folder for this application, which will be within directory next to
 -- other applications in the system, e.g. "~/.local/share/disciplina".
@@ -66,7 +66,7 @@ prepareAppDir dirConfig = do
     -- we would unlikely have logging context here
     logInfo $ "Application home directory will be at "+|appDir|+""
     liftIO $ createDirectoryIfMissing True appDir
-    return appDir
+    return $ AppDir appDir
 
 instance AllocResource AppDir where
     type Deps AppDir = AppDirParamRec

--- a/educator/src/Dscp/Educator/Launcher/Resource.hs
+++ b/educator/src/Dscp/Educator/Launcher/Resource.hs
@@ -67,7 +67,7 @@ instance AllocResource Pdf.LatexPath where
 
 instance AllocResource Pdf.ResourcePath where
     type Deps Pdf.ResourcePath = (FilePath, AppDir)
-    allocResource (userPath, appDir) =
+    allocResource (userPath, AppDir appDir) =
         buildComponentR "LaTeX resources path" preparePath (\_ -> pass)
       where
         resPath
@@ -77,7 +77,6 @@ instance AllocResource Pdf.ResourcePath where
             logDebug $ "Certificate PDF resources path will be " +| resPath |+ ""
             unlessM (liftIO $ doesDirectoryExist resPath) $
                 throwM $ DirectoryDoesNotExist "pdf templates" resPath
-            -- TODO: maybe let's also check that "xelatex" can be found?
             return $ Pdf.ResourcePath resPath
 
 instance AllocResource EducatorResources where

--- a/educator/tests/Test/Dscp/Educator/Mode.hs
+++ b/educator/tests/Test/Dscp/Educator/Mode.hs
@@ -32,6 +32,7 @@ import Dscp.Educator.Arbitrary ()
 import Dscp.Educator.Config
 import Dscp.Educator.Launcher
 import Dscp.Educator.TestConfig
+import Dscp.Resource.AppDir
 import Dscp.Resource.Keys
 import Dscp.Rio
 import Dscp.Util
@@ -52,6 +53,7 @@ data TestEducatorCtx = TestEducatorCtx
     , _tecWitnessKeys      :: KeyResources WitnessNode
     , _tecWitnessVariables :: TestWitnessVariables
     , _tecLogging          :: Log.Logging IO
+    , _tecAppDir           :: AppDir
     }
 makeLenses ''TestEducatorCtx
 deriveHasLensDirect ''TestEducatorCtx
@@ -98,6 +100,7 @@ runTestSqlM testDb action =
         let _tecLogging = testLogging
         let _tecPdfLatexPath = testLatexPath
         let _tecPdfResourcePath = testResourcePath
+        let _tecAppDir = error "AppDir is not defined"
         let ctx = TestEducatorCtx{..}
         runRIO ctx $ markWithinWriteSDLockUnsafe applyGenesisBlock
 

--- a/multi-educator/package.yaml
+++ b/multi-educator/package.yaml
@@ -41,12 +41,14 @@ library:
     - reflection
     - safe-exceptions >= 0.1.4
     - serialise
+    - serokell-util
     - servant-auth-server
     - servant-client-core
     - servant-generic
     - servant-server
     - servant-util
     - singleton-bool
+    - stm
     - sqlite-simple
     - template-haskell
     - text

--- a/multi-educator/src/Dscp/MultiEducator/Launcher/Resource.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Launcher/Resource.hs
@@ -13,6 +13,7 @@ module Dscp.MultiEducator.Launcher.Resource
 
 import Control.Lens (makeLenses, Wrapped (..))
 import qualified Pdf.FromLatex as Pdf
+import UnliftIO.Async (Async)
 
 import Dscp.Config
 import Dscp.DB.SQL (SQL)
@@ -29,6 +30,7 @@ data LoadedEducatorContext where
     LoadedEducatorContext
         :: E.HasEducatorConfig
         => { lecCtx :: E.EducatorContext
+           , lecWorkerHandlers :: [Async ()]
            }
         -> LoadedEducatorContext
 

--- a/multi-educator/src/Dscp/MultiEducator/Launcher/Resource.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Launcher/Resource.hs
@@ -4,12 +4,14 @@
 
 module Dscp.MultiEducator.Launcher.Resource
        ( EducatorContexts (..)
-       , EducatorCtxWithCfg (..)
+       , LoadedEducatorContext (..)
+       , MaybeLoadedEducatorContext (..)
        , MultiEducatorResources (..)
        , merWitnessResources
+       , merEducatorData
        ) where
 
-import Control.Lens (makeLenses)
+import Control.Lens (makeLenses, Wrapped (..))
 import qualified Pdf.FromLatex as Pdf
 
 import Dscp.Config
@@ -22,9 +24,25 @@ import Dscp.Resource.Network (NetServResources)
 import Dscp.Util.HasLens
 import qualified Dscp.Witness.Launcher.Resource as Witness
 
-data EducatorCtxWithCfg where
-    EducatorCtxWithCfg :: E.HasEducatorConfig => E.EducatorContext -> EducatorCtxWithCfg
-newtype EducatorContexts = EducatorContexts (Map Text EducatorCtxWithCfg)
+-- | Context and related stuff of a single educator.
+data LoadedEducatorContext where
+    LoadedEducatorContext
+        :: E.HasEducatorConfig
+        => { lecCtx :: E.EducatorContext
+           }
+        -> LoadedEducatorContext
+
+data MaybeLoadedEducatorContext
+      -- | Educator is not yet loaded, please retry later.
+    = YetLoadingEducatorContext
+      -- | Educator context has been loaded.
+    | FullyLoadedEducatorContext LoadedEducatorContext
+
+-- | Contexts of every loaded educator.
+newtype EducatorContexts = EducatorContexts (Map Text MaybeLoadedEducatorContext)
+    deriving (Generic)
+
+instance Wrapped EducatorContexts
 
 -- | Datatype which contains resources required by all Disciplina nodes
 -- to start working.

--- a/witness/src/Dscp/Resource/Keys/Functions.hs
+++ b/witness/src/Dscp/Resource/Keys/Functions.hs
@@ -27,8 +27,8 @@ import Dscp.Core
 import Dscp.Crypto
 import Dscp.Resource.AppDir
 import Dscp.Resource.Keys.Error (KeyInitError (..), rewrapKeyIOErrors)
-import Dscp.Resource.Keys.Types (BaseKeyParamsRec, CommitteeParamsRec,
-                                 KeyJson (..), KeyResources (..), KeyfileContent)
+import Dscp.Resource.Keys.Types (BaseKeyParamsRec, CommitteeParamsRec, KeyJson (..),
+                                 KeyResources (..), KeyfileContent)
 import Dscp.System (checkFileMode, mode600, setMode, whenPosix)
 import Dscp.Util (leftToThrow)
 import Dscp.Util.Aeson (EncodeSerialised (..), Versioned (..))
@@ -63,7 +63,7 @@ fromKeyfileContent pp (Versioned content) = fromSecretJson pp content
 storePath
     :: Buildable (Proxy node)
     => BaseKeyParamsRec -> AppDir -> Proxy node -> FilePath
-storePath baseKeyParams appDir nodeNameP =
+storePath baseKeyParams (AppDir appDir) nodeNameP =
     fromMaybe defPath (baseKeyParams ^. option #path)
   where
     defPath = appDir </> (nodeNameP |+ ".key")

--- a/witness/src/Dscp/Witness/Launcher/Context.hs
+++ b/witness/src/Dscp/Witness/Launcher/Context.hs
@@ -29,6 +29,7 @@ import Loot.Network.ZMQ as Z
 import Dscp.DB.CanProvideDB (Plugin)
 import qualified Dscp.Launcher.Mode as Basic
 import Dscp.Network ()
+import Dscp.Resource.AppDir
 import Dscp.Resource.Keys (KeyResources)
 import Dscp.Resource.Network
 import Dscp.Rio (RIO)
@@ -63,6 +64,7 @@ type WitnessWorkMode ctx m =
         , SDLock
         , Plugin
         , TimeActions
+        , AppDir
         ]
     )
 

--- a/witness/tests/Test/Dscp/Witness/Mode.hs
+++ b/witness/tests/Test/Dscp/Witness/Mode.hs
@@ -11,6 +11,7 @@ import Loot.Log (Logging (..))
 import Dscp.Config
 import Dscp.DB.CanProvideDB as DB
 import Dscp.DB.CanProvideDB.Pure as PureDB
+import Dscp.Resource.AppDir
 import Dscp.Resource.Keys
 import Dscp.Rio
 import Dscp.Util
@@ -27,6 +28,7 @@ data TestWitnessCtx = TestWitnessCtx
     , _twcLogging :: Logging IO
     , _twcKeys    :: KeyResources WitnessNode
     , _twcDb      :: DB.Plugin
+    , _twcAppDir  :: AppDir
     }
 
 makeLenses ''TestWitnessCtx
@@ -54,6 +56,7 @@ runWitnessTestMode action =
         _twcDb   <- PureDB.plugin <$> liftIO PureDB.newCtxVar
         _twcVars <- mkTestWitnessVariables (_twcKeys ^. krPublicKey) _twcDb
         let _twcLogging = testLogging
+        let _twcAppDir = error "AppDir is not defined"
         let ctx = TestWitnessCtx{..}
 
         runRIO ctx $ do


### PR DESCRIPTION
### Description

Adds multi-educator workers and a bit of cleanup.
Review on a per-commit basis is recommended.

Tested with optional authentication and no fees, when I add a certificate a private block is published and gets visible in explorer.

### YT issue

https://issues.serokell.io/issue/DSCP-485

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
