### PR TITLE
[DSCP-480] Prepare multi-educator to deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 run/tmp/
+run/multieducator/
 educator-db
 witness-db
 

--- a/docs/config-full-sample.yaml
+++ b/docs/config-full-sample.yaml
@@ -188,7 +188,7 @@ sample:
         params:
           # Type of botConfig.
           # - `enabled` - to use a bot with the specified seed and delay.
-          # - `closed` - to use no bot.
+          # - `disabled` - to use no bot.
           paramsType: "disabled"
           enabled:
             # Random seed which determines bot's actions

--- a/multi-educator/src/Dscp/MultiEducator/Launcher/Mode.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Launcher/Mode.hs
@@ -28,7 +28,7 @@ import Loot.Config (option, sub)
 import Loot.Log (LoggingIO)
 import qualified Pdf.FromLatex as Pdf
 import System.Directory (createDirectoryIfMissing)
-import System.FilePath.Posix ((</>))
+import System.FilePath ((<.>), (</>))
 
 import Dscp.Config
 import Dscp.Crypto
@@ -128,15 +128,15 @@ loadEducator login mpassphrase = do
         sel -> error $ "unknown AppDir type: " <> fromString sel
     ctx <- ask
     let resources = ctx ^. lensOf @MultiEducatorResources
-        (MultiEducatorKeyParams keyFile) = multiEducatorConfig ^. sub #educator . option #keys
+        (MultiEducatorKeyParams keyDir) = multiEducatorConfig ^. sub #educator . option #keys
         db = resources ^. lensOf @SQL
     -- set the DB schema name and create it if it's not ready
     setSchemaName db ("educator_" <> login)
     prepareEducatorSchema db
-    liftIO $ createDirectoryIfMissing True (appDir </> keyFile)
+    liftIO $ createDirectoryIfMissing True keyDir
     -- read key from file and creates one if it does not exist yet
     let keyParams = finaliseDeferredUnsafe $ mempty
-            & option #path       ?~ Just keyFile
+            & option #path       ?~ Just (keyDir </> toString login <.> "key")
             & option #genNew     ?~ True
             & option #passphrase ?~ mpassphrase
     key <- withCoreConfig (rcast multiEducatorConfig) $ linkStore keyParams appDir

--- a/multi-educator/src/Dscp/MultiEducator/Launcher/Params.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Launcher/Params.hs
@@ -14,7 +14,7 @@ import Dscp.MultiEducator.Web.Educator.Auth (MultiEducatorPublicKey)
 -- | Educator key parameters.
 newtype MultiEducatorKeyParams = MultiEducatorKeyParams
     { unMultiEducatorKeyParams :: FilePath
-      -- ^ Educator key folder
+      -- ^ Path to educator key folder.
     } deriving (Eq, Show, FromJSON)
 
 -- | AAA microservice configuration

--- a/multi-educator/src/Dscp/MultiEducator/Web/Educator/API.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Web/Educator/API.hs
@@ -17,7 +17,8 @@ import Dscp.Educator.Web.Educator.API
 import Dscp.Educator.Web.Student.API
 import Dscp.MultiEducator.Web.Educator.Auth
 
-type MultiEducatorAPI = ProtectedMultiEducatorAPI
+type MultiEducatorAPI =
+    "api" :> "educator" :> "v1" :> ProtectedMultiEducatorAPI
 
 type ProtectedMultiEducatorAPI = Auth' '[MultiEducatorAuth] EducatorAuthToken :> RawEducatorAPI
 

--- a/release.nix
+++ b/release.nix
@@ -23,6 +23,7 @@ let
 
   server-packages = with project; [
     disciplina-educator
+    disciplina-multi-educator
     disciplina-faucet
     disciplina-tools
     disciplina-witness

--- a/scripts/launch/node.sh
+++ b/scripts/launch/node.sh
@@ -114,7 +114,7 @@ educator_params="
 --pdf-resource-path ../pdfs/template
 "
 multi_educator_params="
---educator-key-dir $files/educator.key
+--educator-key-dir $files/multieducator
 --sql-conn-str "postgresql:///$sql_db_name"
 --educator-listen 127.0.0.1:8090
 --educator-api-no-auth


### PR DESCRIPTION
### Description

Nothing to see here, just adding an executable to a distribution.

Actually, no, there seems to be a bug in `loadEducator` also!

### YT issue

https://issues.serokell.io/issue/DSCP-480

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [ ] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
