### PR TITLE
[DSCP-474] Optional multi auth

### DIFF
--- a/docs/config-full-sample.yaml
+++ b/docs/config-full-sample.yaml
@@ -176,7 +176,7 @@ sample:
         genNew: false
         passphrase: "qwerty123"
 
-    # Student API params
+    # Student & Educator API params
     api:
       # HTTP server params
       serverParams:
@@ -206,6 +206,11 @@ sample:
       educatorAPINoAuth:
         enabled: true
         data: []
+      # For multi-educator case, whether authentication in Educator API should be optional.
+      multiEducatorAPINoAuth:
+        enabled: true
+        # Id of educator pretending to be the requests author.
+        data: The principal
 
     # Private blocks publishing params
     publishing:

--- a/educator/src/Dscp/Educator/CLI.hs
+++ b/educator/src/Dscp/Educator/CLI.hs
@@ -5,6 +5,10 @@
 
 module Dscp.Educator.CLI
     ( postgresParamsParser
+    , educatorBotConfigParser
+    , noAuthContextParser
+    , educatorApiNoAuthParser
+    , studentApiNoAuthParser
     , educatorWebConfigParser
     , educatorConfigParser
     , publishingPeriodParser

--- a/multi-educator/src/Dscp/MultiEducator/CLI.hs
+++ b/multi-educator/src/Dscp/MultiEducator/CLI.hs
@@ -10,13 +10,15 @@ module Dscp.MultiEducator.CLI
 
 import Data.Aeson (eitherDecodeStrict')
 import Loot.Config (OptModParser, uplift, (.::), (.:<), (<*<))
-import Options.Applicative (Parser, help, long, metavar, strOption, option, eitherReader)
+import Options.Applicative (Parser, eitherReader, help, long, metavar, option, strOption)
 import Servant.Client.Core (BaseUrl, parseBaseUrl)
 
+import Dscp.CommonCLI
 import Dscp.Educator.CLI
-import Dscp.MultiEducator.Config (MultiEducatorConfig)
-import Dscp.MultiEducator.Launcher.Params (MultiEducatorKeyParams (..), MultiEducatorAAAConfig)
-import Dscp.MultiEducator.Web.Educator.Auth (MultiEducatorPublicKey)
+import Dscp.Educator.Web.Auth
+import Dscp.MultiEducator.Config
+import Dscp.MultiEducator.Launcher.Params (MultiEducatorAAAConfig, MultiEducatorKeyParams (..))
+import Dscp.MultiEducator.Web.Educator.Auth (EducatorAuthData (..), MultiEducatorPublicKey)
 import Dscp.Witness.CLI (witnessConfigParser)
 
 import qualified Data.ByteString as BS
@@ -46,6 +48,19 @@ multiEducatorAAAConfigParser =
       where
         addQuotationMarks bs = BS.intercalate bs ["\"", "\""]
 
+multiEducatorApiNoAuthParser :: Parser (NoAuthContext "multi-educator")
+multiEducatorApiNoAuthParser = noAuthContextParser . fmap EducatorAuthData . strOption $
+    long "educator-api-no-auth" <>
+    help "Make authentication into Educator API of multi-educator optional. \
+         \Accepts educator id used when request is unauthenticated."
+
+multiEducatorWebConfigParser :: OptModParser MultiEducatorWebConfig
+multiEducatorWebConfigParser =
+    #serverParams .:< serverParamsParser "Educator" <*<
+    #botConfig .:< educatorBotConfigParser <*<
+    #multiEducatorAPINoAuth .:: multiEducatorApiNoAuthParser <*<
+    #studentAPINoAuth .:: studentApiNoAuthParser
+
 multiEducatorConfigParser :: OptModParser MultiEducatorConfig
 multiEducatorConfigParser =
     uplift witnessConfigParser <*<
@@ -53,7 +68,7 @@ multiEducatorConfigParser =
         (#db .:< postgresParamsParser <*<
          #keys .:: multiEducatorKeyParamsParser <*<
          #aaa .:< multiEducatorAAAConfigParser <*<
-         #api .:< educatorWebConfigParser <*<
+         #api .:< multiEducatorWebConfigParser <*<
          #publishing .:<
              (#period .:: publishingPeriodParser
              ) <*<

--- a/multi-educator/src/Dscp/MultiEducator/CLI.hs
+++ b/multi-educator/src/Dscp/MultiEducator/CLI.hs
@@ -57,7 +57,6 @@ multiEducatorApiNoAuthParser = noAuthContextParser . fmap EducatorAuthData . str
 multiEducatorWebConfigParser :: OptModParser MultiEducatorWebConfig
 multiEducatorWebConfigParser =
     #serverParams .:< serverParamsParser "Educator" <*<
-    #botConfig .:< educatorBotConfigParser <*<
     #multiEducatorAPINoAuth .:: multiEducatorApiNoAuthParser <*<
     #studentAPINoAuth .:: studentApiNoAuthParser
 

--- a/multi-educator/src/Dscp/MultiEducator/Config.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Config.hs
@@ -4,7 +4,9 @@
 -- | All educator's configurations.
 
 module Dscp.MultiEducator.Config
-    ( MultiEducatorConfig
+    ( MultiEducatorWebConfig
+    , MultiEducatorWebConfigRec
+    , MultiEducatorConfig
     , MultiEducatorConfigRec
     , HasMultiEducatorConfig
     , defaultMultiEducatorConfig
@@ -22,16 +24,27 @@ import Time (Second, Time)
 
 import Dscp.Config
 import Dscp.DB.SQL
-import Dscp.Educator.Web.Config
+import Dscp.Educator.Web.Auth
+import Dscp.Educator.Web.Bot.Params
 import Dscp.MultiEducator.Launcher.Params
+import Dscp.Web
 import Dscp.Witness.Config
+
+type MultiEducatorWebConfig =
+    '[ "serverParams"           ::< ServerParams
+     , "botConfig"              ::< EducatorBotConfig
+     , "multiEducatorAPINoAuth" ::: NoAuthContext "multi-educator"
+     , "studentAPINoAuth"       ::: NoAuthContext "student"
+     ]
+
+type MultiEducatorWebConfigRec = ConfigRec 'Final MultiEducatorWebConfig
 
 type MultiEducatorConfig = WitnessConfig ++
     '[ "educator" ::<
        '[ "db" ::< PostgresRealParams
         , "keys" ::: MultiEducatorKeyParams
         , "aaa" ::< MultiEducatorAAAConfig
-        , "api" ::< EducatorWebConfig
+        , "api" ::< MultiEducatorWebConfig
         , "publishing" ::<
            '[ "period" ::: Time Second
             ]

--- a/multi-educator/src/Dscp/MultiEducator/Config.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Config.hs
@@ -25,14 +25,12 @@ import Time (Second, Time)
 import Dscp.Config
 import Dscp.DB.SQL
 import Dscp.Educator.Web.Auth
-import Dscp.Educator.Web.Bot.Params
 import Dscp.MultiEducator.Launcher.Params
 import Dscp.Web
 import Dscp.Witness.Config
 
 type MultiEducatorWebConfig =
     '[ "serverParams"           ::< ServerParams
-     , "botConfig"              ::< EducatorBotConfig
      , "multiEducatorAPINoAuth" ::: NoAuthContext "multi-educator"
      , "studentAPINoAuth"       ::: NoAuthContext "student"
      ]
@@ -63,7 +61,6 @@ type HasMultiEducatorConfig = Given MultiEducatorConfigRec
 defaultMultiEducatorConfig :: MultiEducatorConfigRecP
 defaultMultiEducatorConfig = upcast defaultWitnessConfig
     & sub #educator . sub #db .~ defaultPostgresRealParams
-    & sub #educator . sub #api . sub #botConfig . tree #params . selection ?~ "disabled"
     & sub #educator . sub #certificates . option #latex ?~ "xelatex"
 
 -- instance (HasEducatorConfig, cfg ~ WitnessConfigRec) => Given cfg where

--- a/multi-educator/src/Dscp/MultiEducator/Launcher/Mode.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Launcher/Mode.hs
@@ -157,7 +157,8 @@ loadEducator login mpassphrase = do
             & sub #witness .~ multiEducatorConfig ^. sub #witness
             & sub #educator . sub #db .~ multiEducatorConfig ^. sub #educator . sub #db
             & sub #educator . sub #keys . sub #keyParams .~ keyParams
-            & sub #educator . sub #api .~ multiEducatorConfig ^. sub #educator . sub #api
+            & sub #educator . sub #api . option #educatorAPINoAuth .~
+                error "Do not touch, multi-educator has already run the server"
             & sub #educator . sub #publishing .~ multiEducatorConfig ^. sub #educator . sub #publishing
         educatorCtxWithCfg = E.withEducatorConfig newCfg $ EducatorCtxWithCfg educatorContext
     -- add to/update the educator context map with the newly made one

--- a/multi-educator/src/Dscp/MultiEducator/Web/Educator/API.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Web/Educator/API.hs
@@ -20,7 +20,8 @@ import Dscp.MultiEducator.Web.Educator.Auth
 type MultiEducatorAPI =
     "api" :> "educator" :> "v1" :> ProtectedMultiEducatorAPI
 
-type ProtectedMultiEducatorAPI = Auth' '[MultiEducatorAuth] EducatorAuthToken :> RawEducatorAPI
+type ProtectedMultiEducatorAPI =
+    Auth' '[MultiEducatorAuth, NoAuth "multi-educator"] EducatorAuthData :> RawEducatorAPI
 
 type MultiStudentAPI = Capture "educator" Text :> ProtectedStudentAPI
 

--- a/multi-educator/src/Dscp/MultiEducator/Web/Educator/Auth.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Web/Educator/Auth.hs
@@ -17,6 +17,7 @@ import Data.Aeson (FromJSON (..), ToJSON (..), decodeStrict)
 import Data.Aeson.Options (defaultOptions)
 import Data.Aeson.TH (deriveJSON)
 import Data.Time.Clock (addUTCTime, getCurrentTime)
+import Fmt (build)
 import Servant.Auth.Server (AuthCheck, FromJWT, ToJWT)
 import Servant.Auth.Server.Internal.Class (IsAuth (..))
 
@@ -37,6 +38,9 @@ deriveJSON defaultOptions ''EducatorAuthData
 
 instance FromJWT EducatorAuthData
 instance ToJWT EducatorAuthData
+
+instance Buildable EducatorAuthData where
+    build (EducatorAuthData eId) = "\"" <> build eId <> "\""
 
 data EducatorAuthToken = EducatorAuthToken
     { eatData :: EducatorAuthData

--- a/multi-educator/src/Dscp/MultiEducator/Web/Server.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Web/Server.hs
@@ -22,17 +22,15 @@ import UnliftIO (askUnliftIO)
 
 import Dscp.Config
 import Dscp.Educator.Web.Auth
-import Dscp.Educator.Web.Bot
 import Dscp.Educator.Web.Educator (RawEducatorAPI, convertEducatorApiHandler, educatorApiHandlers,
                                    rawEducatorAPI)
-import Dscp.Educator.Web.Student (ProtectedStudentAPI, StudentCheckAction (..),
-                                  convertStudentApiHandler, rawStudentAPI, studentApiHandlers)
+import Dscp.Educator.Web.Student (StudentCheckAction (..), convertStudentApiHandler, rawStudentAPI,
+                                  studentApiHandlers)
 import Dscp.MultiEducator.Config
 import Dscp.MultiEducator.Launcher.Mode (MultiCombinedWorkMode, MultiEducatorWorkMode,
                                          lookupEducator, normalToMulti)
 import Dscp.MultiEducator.Launcher.Params (MultiEducatorAAAConfigRec)
-import Dscp.MultiEducator.Web.Educator (MultiEducatorAPI, MultiStudentAPI, multiEducatorAPI,
-                                        multiStudentAPI)
+import Dscp.MultiEducator.Web.Educator (MultiEducatorAPI, MultiStudentAPI, multiEducatorAPI)
 import Dscp.MultiEducator.Web.Educator.Auth
 import Dscp.Web (buildServantLogConfig, serveWeb)
 import Dscp.Web.Metrics (responseTimeMetric)
@@ -68,48 +66,28 @@ mkMultiEducatorApiServer _aaaConfig nat =
         nat
         (\eData -> mkEducatorApiServer' $ eadId eData)
 
-mkStudentApiServer'
-    :: forall ctx m. MultiEducatorWorkMode ctx m
-    => (forall x. m x -> Handler x)
-    -> EducatorBotConfigRec
-    -> m (Text -> Server ProtectedStudentAPI)
-mkStudentApiServer' nat botConfig = do
-    case botConfig ^. tree #params . selection of
-      _ {-EducatorBotOff-} -> return $ \login -> getServer login . studentApiHandlers
-      -- To initilialize the bot we need a database, how do we choose a database?
-      {-EducatorBotOn params -> initializeBot params $ do
-        return $ (\student -> getServer . addBotHandlers student . studentApiHandlers $ student)-}
-  where
-    getServer login handlers = hoistServerWithContext
-        rawStudentAPI
-        (Proxy :: Proxy '[StudentCheckAction])
-        (\x -> nat $ lookupEducator login >>= \c -> normalToMulti c x)
-        (toServant handlers)
-
 mkStudentApiServer
     :: forall ctx m. MultiEducatorWorkMode ctx m
     => (forall x. m x -> Handler x)
-    -> EducatorBotConfigRec
     -> m (Server MultiStudentAPI)
-mkStudentApiServer nat botParams = do
-    studApi <- mkStudentApiServer' nat botParams
-    return $ hoistServerWithContext
-        multiStudentAPI
-        (Proxy :: Proxy '[StudentCheckAction, NoAuthContext "student"])
-        id
-        studApi
+mkStudentApiServer nat =
+    return $ \login student ->
+        hoistServerWithContext
+            rawStudentAPI
+            (Proxy :: Proxy '[StudentCheckAction])
+            (\x -> nat $ lookupEducator login >>= \c -> normalToMulti c x)
+            (toServant $ studentApiHandlers student)
 
 -- | Create an action which checks whether or not the
 -- student is a valid API user.
 -- If bot is enabled, all students are allowed to use API.
 createStudentCheckAction
     :: forall ctx m. MultiEducatorWorkMode ctx m
-    => EducatorBotConfigRec
-    -> m StudentCheckAction
-createStudentCheckAction _ =
+    => m StudentCheckAction
+createStudentCheckAction =
     return . StudentCheckAction . const $ pure True
 {-
-createStudentCheckAction EducatorBotOff = do
+createStudentCheckAction = do
     db <- view (lensOf @SQL)
     return . StudentCheckAction $ \pk ->
         let addr = mkAddr pk
@@ -131,12 +109,11 @@ serveEducatorAPIsReal :: MultiCombinedWorkMode ctx m => Bool -> m ()
 serveEducatorAPIsReal withWitnessApi = do
     let webCfg = multiEducatorConfig ^. sub #educator . sub #api
         serverAddress     = webCfg ^. sub #serverParams . option #addr
-        botConfig         = webCfg ^. sub #botConfig
         studentAPINoAuth  = webCfg ^. option #studentAPINoAuth
         educatorAPINoAuth = webCfg ^. option #multiEducatorAPINoAuth
         aaaSettings       = multiEducatorConfig ^. sub #educator . sub #aaa
 
-    studentCheckAction <- createStudentCheckAction botConfig
+    studentCheckAction <- createStudentCheckAction
     let educatorPublicKey = aaaSettings ^. option #publicKey
         srvCtx =
             educatorPublicKey :.
@@ -148,7 +125,7 @@ serveEducatorAPIsReal withWitnessApi = do
     logInfo $ "Serving Student API on "+|serverAddress|+""
     unliftIO <- askUnliftIO
     let educatorApiServer = mkMultiEducatorApiServer aaaSettings (convertEducatorApiHandler unliftIO)
-    studentApiServer <- mkStudentApiServer (convertStudentApiHandler unliftIO) botConfig
+    studentApiServer <- mkStudentApiServer (convertStudentApiHandler unliftIO)
     let witnessApiServer = if withWitnessApi
           then mkWitnessAPIServer (convertWitnessHandler unliftIO)
           else throwAll err405{ errBody = "Witness API disabled at this port" }

--- a/scripts/launch/node.sh
+++ b/scripts/launch/node.sh
@@ -117,7 +117,7 @@ multi_educator_params="
 --educator-key-dir $files/multieducator
 --sql-conn-str "postgresql:///$sql_db_name"
 --educator-listen 127.0.0.1:8090
---educator-api-no-auth
+--educator-api-no-auth Principal
 --student-api-no-auth 3BAyX5pNpoFrLJcP5bZ2kXihBfmBVLprSyP1RhcPPddm6Dw42jzEPXZz22
 --publication-period 15s
 --pdf-resource-path ../pdfs/template


### PR DESCRIPTION
### Description

Allows optional authentication AND enables logging (sorre, otherwise that would take too long). Only 2 commits.

I made multi-educator authentication return `EducatorAuthData` instead of `EducatorAuthToken` because the latter mainly contains (aside from `EducatorAuthData` itself) auth implementation details unneeded for endpoints implementation.

### YT issue

https://issues.serokell.io/issue/DSCP-474

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
