### PR TITLE
[DSCP-488] Public endpoint for PDF downloading

### DIFF
--- a/core/src/Dscp/Util.hs
+++ b/core/src/Dscp/Util.hs
@@ -47,6 +47,8 @@ module Dscp.Util
        , fromBase
        , toBase64
        , fromBase64
+       , toBase64Url
+       , fromBase64Url
        , toHex
        , fromHex
 
@@ -287,13 +289,15 @@ fromBase base =
     fromByteArray @ba @ByteString
 
 -- These are compatible with fmt.
-toBase64, toHex :: ByteArrayAccess ba => ba -> Text
-toBase64 = toBase Base64
-toHex    = toBase Base16
+toBase64, toBase64Url, toHex :: ByteArrayAccess ba => ba -> Text
+toBase64    = toBase Base64
+toBase64Url = toBase Base64URLUnpadded
+toHex       = toBase Base16
 
-fromBase64, fromHex :: FromByteArray ba => Text -> Either String ba
-fromBase64 = fromBase Base64
-fromHex    = fromBase Base16
+fromBase64, fromBase64Url, fromHex :: FromByteArray ba => Text -> Either String ba
+fromBase64    = fromBase Base64
+fromBase64Url = fromBase Base64URLUnpadded
+fromHex       = fromBase Base16
 
 -----------------------------------------------------------
 -- Lens fun

--- a/educator/src/Dscp/Educator/Web/Educator/API.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/API.hs
@@ -7,6 +7,8 @@ module Dscp.Educator.Web.Educator.API
     , rawEducatorAPI
     , protectedEducatorAPI
     , EducatorApiHandlers
+    -- * Re-export for using in packages dependent on `disciplina-educator`
+    , PDFBody (..)
     ) where
 
 import Pdf.Scanner (PDFBody (..))

--- a/multi-educator/package.yaml
+++ b/multi-educator/package.yaml
@@ -59,6 +59,19 @@ library:
     - wai
     - wai-cors
 
+tests:
+  disciplina-multi-educator-test:
+    <<: *test-common
+    
+    build-tools:
+      - tasty-discover
+
+    dependencies:
+      - disciplina-core
+      - disciplina-multi-educator
+      - tasty
+      - tasty-hspec
+
 executables:
   dscp-multi-educator:
     <<: *exec-common

--- a/multi-educator/package.yaml
+++ b/multi-educator/package.yaml
@@ -62,7 +62,7 @@ library:
 tests:
   disciplina-multi-educator-test:
     <<: *test-common
-    
+
     build-tools:
       - tasty-discover
 

--- a/multi-educator/src/Dscp/MultiEducator/Config.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Config.hs
@@ -35,6 +35,7 @@ type MultiEducatorWebConfig =
      , "studentAPINoAuth"       ::: NoAuthContext "student"
      ]
 
+type MultiEducatorWebConfigRecP = ConfigRec 'Partial MultiEducatorWebConfig
 type MultiEducatorWebConfigRec = ConfigRec 'Final MultiEducatorWebConfig
 
 type MultiEducatorConfig = WitnessConfig ++
@@ -61,7 +62,13 @@ type HasMultiEducatorConfig = Given MultiEducatorConfigRec
 defaultMultiEducatorConfig :: MultiEducatorConfigRecP
 defaultMultiEducatorConfig = upcast defaultWitnessConfig
     & sub #educator . sub #db .~ defaultPostgresRealParams
+    & sub #educator . sub #api .~ defaultMultiEducatorWebConfig
     & sub #educator . sub #certificates . option #latex ?~ "xelatex"
+
+defaultMultiEducatorWebConfig :: MultiEducatorWebConfigRecP
+defaultMultiEducatorWebConfig = mempty
+    & option #multiEducatorAPINoAuth ?~ NoAuthOffContext
+    & option #studentAPINoAuth ?~ NoAuthOffContext
 
 -- instance (HasEducatorConfig, cfg ~ WitnessConfigRec) => Given cfg where
 --     given = rcast (given @EducatorConfigRec)

--- a/multi-educator/src/Dscp/MultiEducator/Launcher/Mode.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Launcher/Mode.hs
@@ -18,6 +18,7 @@ module Dscp.MultiEducator.Launcher.Mode
     , mecWitnessVars
     , lookupEducator
     , loadEducator
+    , educatorSchemaName
     , normalToMulti
     ) where
 
@@ -65,6 +66,10 @@ type MultiEducatorWorkMode ctx m =
 
     , HasMultiEducatorConfig
     , HasLens' ctx (TVar EducatorContexts)
+    , HasLens' ctx SQL
+
+    -- It's easier to just have these two lenses instead of reconstructing
+    -- the full educator context in multiToNormal from other lenses
     , HasLens' ctx MultiEducatorResources
     , HasLens' ctx W.WitnessVariables
 
@@ -153,9 +158,12 @@ loadEducator login mpassphrase = do
     ctx <- ask
     let resources = ctx ^. lensOf @MultiEducatorResources
         (MultiEducatorKeyParams keyDir) = multiEducatorConfig ^. sub #educator . option #keys
-        db = resources ^. lensOf @SQL
+        dbParams = multiEducatorConfig ^. sub #educator . sub #db
+
+    -- open the new DB connection
+    db <- openPostgresDB (PostgresParams $ PostgresReal dbParams)
     -- set the DB schema name and create it if it's not ready
-    setSchemaName db ("educator_" <> login)
+    setSchemaName db $ educatorSchemaName login
     prepareEducatorSchema db
     liftIO $ createDirectoryIfMissing True keyDir
     -- read key from file and creates one if it does not exist yet
@@ -179,7 +187,7 @@ loadEducator login mpassphrase = do
         newCfg = (finaliseDeferredUnsafe mempty) -- not great but it actually works
             & sub #core .~ multiEducatorConfig ^. sub #core
             & sub #witness .~ multiEducatorConfig ^. sub #witness
-            & sub #educator . sub #db .~ multiEducatorConfig ^. sub #educator . sub #db
+            & sub #educator . sub #db .~ dbParams
             & sub #educator . sub #keys . sub #keyParams .~ keyParams
             & sub #educator . sub #api . option #educatorAPINoAuth .~
                 error "Do not touch, multi-educator has already run the server"
@@ -193,6 +201,10 @@ loadEducator login mpassphrase = do
             , lecWorkerHandlers = workerAsyncs
             }
     return loadedEducatorCtx
+
+-- | Returns database schema name for an educator with given ID.
+educatorSchemaName :: Text -> Text
+educatorSchemaName eId = "educator_" <> eId
 
 normalToMulti :: MultiEducatorWorkMode ctx m => LoadedEducatorContext -> E.EducatorRealMode a -> m a
 normalToMulti LoadedEducatorContext{..} = runRIO lecCtx

--- a/multi-educator/src/Dscp/MultiEducator/Launcher/Mode.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Launcher/Mode.hs
@@ -27,7 +27,7 @@ import Control.Lens (at, makeLenses, zoom, (?~), _Wrapped')
 import Fmt ((+|), (|+))
 import Loot.Base.HasLens (HasLens', lensOf)
 import Loot.Config (option, sub)
-import Loot.Log (logDebug)
+import Loot.Log (logDebug, logInfo)
 import Loot.Network.Class (NetworkingCli, NetworkingServ)
 import Loot.Network.ZMQ (ZmqTcp)
 import qualified Pdf.FromLatex as Pdf
@@ -163,7 +163,9 @@ loadEducator login mpassphrase = do
     -- open the new DB connection
     db <- openPostgresDB (PostgresParams $ PostgresReal dbParams)
     -- set the DB schema name and create it if it's not ready
-    setSchemaName db $ educatorSchemaName login
+    let schema = educatorSchemaName login
+    logInfo $ "Creating a schema with name `"+|schema|+"`"
+    setSchemaName db schema
     prepareEducatorSchema db
     liftIO $ createDirectoryIfMissing True keyDir
     -- read key from file and creates one if it does not exist yet

--- a/multi-educator/src/Dscp/MultiEducator/Web/Educator/API.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Web/Educator/API.hs
@@ -4,26 +4,51 @@
 -- | Educator HTTP API definition.
 
 module Dscp.MultiEducator.Web.Educator.API
-    ( MultiEducatorAPI
+    ( CertificatesApiEndpoints (..)
+    , CertificatesApiHandlers
+    , MultiEducatorAPI
     , multiEducatorAPI
     , MultiStudentAPI
     , multiStudentAPI
     ) where
 
 import Servant
+import Servant.Generic
 
 import Dscp.Educator.Web.Auth
 import Dscp.Educator.Web.Educator.API
 import Dscp.Educator.Web.Student.API
 import Dscp.MultiEducator.Web.Educator.Auth
+import Dscp.MultiEducator.Web.Educator.Types
+import Dscp.Witness.Web.ContentTypes
+
+-- | Endpoints of public certificate API.
+data CertificatesApiEndpoints route = CertificatesApiEndpoints
+    { cGetCertificate :: route :- GetCertificatePublic
+    } deriving (Generic)
+
+type CertificatesAPI = ToServant (CertificatesApiEndpoints AsApi)
+type CertificatesApiHandlers m = CertificatesApiEndpoints (AsServerT m)
 
 type MultiEducatorAPI =
     "api" :> "educator" :> "v1" :> ProtectedMultiEducatorAPI
+    :<|>
+    "api" :> "certificates" :> "v1" :> CertificatesAPI
 
 type ProtectedMultiEducatorAPI =
     Auth' '[MultiEducatorAuth, NoAuth "multi-educator"] EducatorAuthData :> RawEducatorAPI
 
 type MultiStudentAPI = Capture "educator" Text :> ProtectedStudentAPI
+
+-- | Endpoint for getting a certificate by full ID.
+type GetCertificatePublic
+    = "cert" :> Capture "certificate" CertificateName
+    :> Summary "Get the certificate by ID"
+    :> Description "Gets the PDF certificate with FairCV JSON included as metadata by ID. \
+        \CertificateID is obtained as `base64url(\"<educator-UUID>:<certificate-hash>\")`, \
+        \where `<educator-UUID>` is the UUID assigned by AAA microservice to Educator, \
+        \and `<certificate-hash>` is a hash of certificate meta."
+    :> Get '[PDF] PDFBody
 
 multiEducatorAPI :: Proxy MultiEducatorAPI
 multiEducatorAPI = Proxy

--- a/multi-educator/src/Dscp/MultiEducator/Web/Educator/API.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Web/Educator/API.hs
@@ -6,6 +6,8 @@
 module Dscp.MultiEducator.Web.Educator.API
     ( CertificatesApiEndpoints (..)
     , CertificatesApiHandlers
+    , CertificatesAPI
+    , certificatesAPI
     , MultiEducatorAPI
     , multiEducatorAPI
     , MultiStudentAPI
@@ -22,23 +24,19 @@ import Dscp.MultiEducator.Web.Educator.Auth
 import Dscp.MultiEducator.Web.Educator.Types
 import Dscp.Witness.Web.ContentTypes
 
+---------------------------------------------------------------------------
+-- Certificates API
+---------------------------------------------------------------------------
+
 -- | Endpoints of public certificate API.
 data CertificatesApiEndpoints route = CertificatesApiEndpoints
     { cGetCertificate :: route :- GetCertificatePublic
     } deriving (Generic)
 
-type CertificatesAPI = ToServant (CertificatesApiEndpoints AsApi)
 type CertificatesApiHandlers m = CertificatesApiEndpoints (AsServerT m)
 
-type MultiEducatorAPI =
-    "api" :> "educator" :> "v1" :> ProtectedMultiEducatorAPI
-    :<|>
-    "api" :> "certificates" :> "v1" :> CertificatesAPI
-
-type ProtectedMultiEducatorAPI =
-    Auth' '[MultiEducatorAuth, NoAuth "multi-educator"] EducatorAuthData :> RawEducatorAPI
-
-type MultiStudentAPI = Capture "educator" Text :> ProtectedStudentAPI
+type CertificatesAPI =
+    "api" :> "certificates" :> "v1" :> ToServant (CertificatesApiEndpoints AsApi)
 
 -- | Endpoint for getting a certificate by full ID.
 type GetCertificatePublic
@@ -50,8 +48,27 @@ type GetCertificatePublic
         \and `<certificate-hash>` is a hash of certificate meta."
     :> Get '[PDF] PDFBody
 
+certificatesAPI :: Proxy CertificatesAPI
+certificatesAPI = Proxy
+
+---------------------------------------------------------------------------
+-- Educator API
+---------------------------------------------------------------------------
+
+type MultiEducatorAPI =
+    "api" :> "educator" :> "v1" :> ProtectedMultiEducatorAPI
+
+type ProtectedMultiEducatorAPI =
+    Auth' '[MultiEducatorAuth, NoAuth "multi-educator"] EducatorAuthData :> RawEducatorAPI
+
 multiEducatorAPI :: Proxy MultiEducatorAPI
 multiEducatorAPI = Proxy
+
+---------------------------------------------------------------------------
+-- Student API
+---------------------------------------------------------------------------
+
+type MultiStudentAPI = Capture "educator" Text :> ProtectedStudentAPI
 
 multiStudentAPI :: Proxy MultiStudentAPI
 multiStudentAPI = Proxy

--- a/multi-educator/src/Dscp/MultiEducator/Web/Educator/Auth.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Web/Educator/Auth.hs
@@ -32,7 +32,7 @@ import qualified Data.ByteArray as BA
 
 newtype EducatorAuthData = EducatorAuthData
     { eadId :: Text
-    }
+    } deriving (Show, Eq)
 
 deriveJSON defaultOptions ''EducatorAuthData
 
@@ -60,7 +60,8 @@ instance ToJWT EducatorAuthToken
 data MultiEducatorAuth
 
 -- | Type that holds MultiEducator's public key
-newtype MultiEducatorPublicKey = MultiEducatorPublicKey PublicKey deriving Show
+newtype MultiEducatorPublicKey = MultiEducatorPublicKey PublicKey
+    deriving (Show, Eq)
 
 instance IsAuth MultiEducatorAuth EducatorAuthData where
     type AuthArgs MultiEducatorAuth = '[MultiEducatorPublicKey]

--- a/multi-educator/src/Dscp/MultiEducator/Web/Educator/Handlers.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Web/Educator/Handlers.hs
@@ -1,0 +1,23 @@
+-- | API handlers specific for multi educator.
+
+module Dscp.MultiEducator.Web.Educator.Handlers
+       ( certificatesApiHandlers
+       ) where
+
+import Loot.Base.HasLens (lensOf)
+
+import Dscp.DB.SQL
+import Dscp.Educator.Web.Educator
+import Dscp.MultiEducator.Launcher.Mode
+import Dscp.MultiEducator.Web.Educator.API
+import Dscp.MultiEducator.Web.Educator.Types
+
+certificatesApiHandlers
+    :: forall m ctx. MultiEducatorWorkMode ctx m
+    => CertificatesApiHandlers m
+certificatesApiHandlers = CertificatesApiEndpoints
+    { cGetCertificate = \(CertificateName eId cId) -> do
+            db <- view (lensOf @SQL)
+            setSchemaName db $ educatorSchemaName eId
+            invoke $ educatorGetCertificate cId
+    }

--- a/multi-educator/src/Dscp/MultiEducator/Web/Educator/Handlers.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Web/Educator/Handlers.hs
@@ -4,8 +4,6 @@ module Dscp.MultiEducator.Web.Educator.Handlers
        ( certificatesApiHandlers
        ) where
 
-import Loot.Base.HasLens (lensOf)
-
 import Dscp.DB.SQL
 import Dscp.Educator.Web.Educator
 import Dscp.MultiEducator.Launcher.Mode
@@ -16,8 +14,7 @@ certificatesApiHandlers
     :: forall m ctx. MultiEducatorWorkMode ctx m
     => CertificatesApiHandlers m
 certificatesApiHandlers = CertificatesApiEndpoints
-    { cGetCertificate = \(CertificateName eId cId) -> do
-            db <- view (lensOf @SQL)
-            setSchemaName db $ educatorSchemaName eId
-            invoke $ educatorGetCertificate cId
+    { cGetCertificate = \(CertificateName eId cId) -> invoke $ do
+            setConnSchemaName $ educatorSchemaName eId
+            educatorGetCertificate cId
     }

--- a/multi-educator/src/Dscp/MultiEducator/Web/Educator/Types.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Web/Educator/Types.hs
@@ -1,0 +1,31 @@
+-- | API handlers specific for multi educator.
+
+module Dscp.MultiEducator.Web.Educator.Types
+       ( CertificateName (..)
+       ) where
+
+import Data.List (span)
+import Servant (FromHttpApiData (..), ToHttpApiData (..))
+import System.FilePath (splitExtension)
+
+import Dscp.Core.Foundation
+import Dscp.Util
+
+data CertificateName = CertificateName
+    { cnEducatorId    :: Text
+    , cnCertificateId :: Id CertificateMeta
+    } deriving (Show, Eq, Generic)
+
+instance ToHttpApiData CertificateName where
+    toUrlPiece (CertificateName eId cId) =
+        toBase64Url @ByteString (encodeUtf8 $ eId <> ":" <> toHex cId) <> ".pdf"
+
+instance FromHttpApiData CertificateName where
+    parseUrlPiece txt = do
+        let (name, ext) = splitExtension $ toString txt
+        when (ext /= ".pdf") $
+            fail "Wrong extension, `.pdf` is expected"
+        let (eId, cId'') = span (/= ':') name
+            cId' = drop 1 cId''
+        cId <- parseUrlPiece $ toText cId'
+        return (CertificateName (toText eId) cId)

--- a/multi-educator/src/Dscp/MultiEducator/Web/Educator/Types.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Web/Educator/Types.hs
@@ -5,16 +5,28 @@ module Dscp.MultiEducator.Web.Educator.Types
        ) where
 
 import Data.List (span)
+import Fmt (build, (+|), (|+))
 import Servant (FromHttpApiData (..), ToHttpApiData (..))
 import System.FilePath (splitExtension)
 
 import Dscp.Core.Foundation
 import Dscp.Util
+import Dscp.Util.Test
 
 data CertificateName = CertificateName
     { cnEducatorId    :: Text
     , cnCertificateId :: Id CertificateMeta
     } deriving (Show, Eq, Generic)
+
+instance Buildable CertificateName where
+    build (CertificateName eId cId) =
+        "certificate { educator-id = "+|eId|+", hash = "+|build cId|+"}"
+
+instance Arbitrary CertificateName where
+    arbitrary = CertificateName
+        <$> (toBase64Url @ByteString <$> arbitrary)
+            -- avoiding having ':' in educator ID
+        <*> arbitrary
 
 instance ToHttpApiData CertificateName where
     toUrlPiece (CertificateName eId cId) =
@@ -22,9 +34,10 @@ instance ToHttpApiData CertificateName where
 
 instance FromHttpApiData CertificateName where
     parseUrlPiece txt = do
-        let (name, ext) = splitExtension $ toString txt
+        let (name', ext) = splitExtension $ toString txt
         when (ext /= ".pdf") $
             fail "Wrong extension, `.pdf` is expected"
+        name <- decodeUtf8 <$> leftToFail (fromBase64Url @ByteString $ toText name')
         let (eId, cId'') = span (/= ':') name
             cId' = drop 1 cId''
         cId <- parseUrlPiece $ toText cId'

--- a/multi-educator/src/Dscp/MultiEducator/Web/Server.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Web/Server.hs
@@ -30,7 +30,7 @@ import Dscp.MultiEducator.Config
 import Dscp.MultiEducator.Launcher.Mode (MultiCombinedWorkMode, MultiEducatorWorkMode,
                                          lookupEducator, normalToMulti)
 import Dscp.MultiEducator.Launcher.Params (MultiEducatorAAAConfigRec)
-import Dscp.MultiEducator.Web.Educator (MultiEducatorAPI, MultiStudentAPI, multiEducatorAPI)
+import Dscp.MultiEducator.Web.Educator
 import Dscp.MultiEducator.Web.Educator.Auth
 import Dscp.Web (buildServantLogConfig, serveWeb)
 import Dscp.Web.Metrics (responseTimeMetric)
@@ -64,7 +64,10 @@ mkMultiEducatorApiServer _aaaConfig nat =
         multiEducatorAPI
         (Proxy :: Proxy '[MultiEducatorPublicKey, NoAuthContext "multi-educator"])
         nat
-        (\eData -> mkEducatorApiServer' $ eadId eData)
+        (protected :<|> public)
+  where
+    protected = mkEducatorApiServer' . eadId
+    public = toServant certificatesApiHandlers
 
 mkStudentApiServer
     :: forall ctx m. MultiEducatorWorkMode ctx m

--- a/multi-educator/src/Dscp/MultiEducator/Web/Server.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Web/Server.hs
@@ -14,7 +14,7 @@ import Network.HTTP.Types.Header (hAuthorization, hContentType)
 import Network.Wai (Middleware)
 import Network.Wai.Middleware.Cors (CorsResourcePolicy (..), cors, simpleCorsResourcePolicy)
 import Servant ((:<|>) (..), Context (..), Handler, ServantErr (..), Server, ServerT,
-                StdMethod (..), err405, hoistServerWithContext, serveWithContext)
+                StdMethod (..), err405, hoistServer, hoistServerWithContext, serveWithContext)
 import Servant.Auth.Server.Internal.ThrowAll (throwAll)
 import Servant.Generic (toServant)
 import Servant.Util (methodsCoveringAPI, serverWithLogging)
@@ -31,15 +31,16 @@ import Dscp.MultiEducator.Launcher.Mode (MultiCombinedWorkMode, MultiEducatorWor
                                          lookupEducator, normalToMulti)
 import Dscp.MultiEducator.Launcher.Params (MultiEducatorAAAConfigRec)
 import Dscp.MultiEducator.Web.Educator
-import Dscp.MultiEducator.Web.Educator.Auth
 import Dscp.Web (buildServantLogConfig, serveWeb)
 import Dscp.Web.Metrics (responseTimeMetric)
 import Dscp.Witness.Web
 
-type EducatorWebAPI =
+type MultiEducatorWebAPI =
     MultiEducatorAPI
     :<|>
     MultiStudentAPI
+    :<|>
+    CertificatesAPI
     :<|>
     WitnessAPI
 
@@ -64,10 +65,7 @@ mkMultiEducatorApiServer _aaaConfig nat =
         multiEducatorAPI
         (Proxy :: Proxy '[MultiEducatorPublicKey, NoAuthContext "multi-educator"])
         nat
-        (protected :<|> public)
-  where
-    protected = mkEducatorApiServer' . eadId
-    public = toServant certificatesApiHandlers
+        (mkEducatorApiServer' . eadId)
 
 mkStudentApiServer
     :: forall ctx m. MultiEducatorWorkMode ctx m
@@ -80,6 +78,13 @@ mkStudentApiServer nat =
             (Proxy :: Proxy '[StudentCheckAction])
             (\x -> nat $ lookupEducator login >>= \c -> normalToMulti c x)
             (toServant $ studentApiHandlers student)
+
+mkCertificatesApiServer
+    :: forall ctx m. MultiEducatorWorkMode ctx m
+    => (forall x. m x -> Handler x)
+    -> Server CertificatesAPI
+mkCertificatesApiServer nat =
+    hoistServer certificatesAPI nat $ toServant certificatesApiHandlers
 
 -- | Create an action which checks whether or not the
 -- student is a valid API user.
@@ -105,7 +110,7 @@ educatorCors = cors $ const $ Just $
       -- authentication prevents CSRF attacks, and API is public anyway.
       corsOrigins = Nothing
     , corsRequestHeaders = [hContentType, hAuthorization]
-    , corsMethods = methodsCoveringAPI @['GET, 'POST, 'PUT, 'DELETE] @EducatorWebAPI
+    , corsMethods = methodsCoveringAPI @['GET, 'POST, 'PUT, 'DELETE] @MultiEducatorWebAPI
     }
 
 serveEducatorAPIsReal :: MultiCombinedWorkMode ctx m => Bool -> m ()
@@ -120,14 +125,15 @@ serveEducatorAPIsReal withWitnessApi = do
     let educatorPublicKey = aaaSettings ^. option #publicKey
         srvCtx =
             educatorPublicKey :.
+            educatorAPINoAuth :.
             studentCheckAction :.
             studentAPINoAuth :.
-            educatorAPINoAuth :.
             EmptyContext
 
     logInfo $ "Serving Student API on "+|serverAddress|+""
     unliftIO <- askUnliftIO
     let educatorApiServer = mkMultiEducatorApiServer aaaSettings (convertEducatorApiHandler unliftIO)
+        certificatesApiServer = mkCertificatesApiServer (convertEducatorApiHandler unliftIO)
     studentApiServer <- mkStudentApiServer (convertStudentApiHandler unliftIO)
     let witnessApiServer = if withWitnessApi
           then mkWitnessAPIServer (convertWitnessHandler unliftIO)
@@ -135,12 +141,14 @@ serveEducatorAPIsReal withWitnessApi = do
     let metricsEndpoint = witnessConfig ^. sub #witness . option #metricsEndpoint
     lc <- buildServantLogConfig (<> "web")
     serveWeb serverAddress $
-      responseTimeMetric metricsEndpoint $
-      educatorCors $
-      serverWithLogging lc (Proxy @EducatorWebAPI) $ \api ->
-      serveWithContext api srvCtx $
-         educatorApiServer
-         :<|>
-         studentApiServer
-         :<|>
-         witnessApiServer
+        responseTimeMetric metricsEndpoint $
+        educatorCors $
+        serverWithLogging lc (Proxy @MultiEducatorWebAPI) $ \api ->
+        serveWithContext api srvCtx $
+            educatorApiServer
+            :<|>
+            studentApiServer
+            :<|>
+            certificatesApiServer
+            :<|>
+            witnessApiServer

--- a/multi-educator/tests/Test/Dscp/MultiEducator/Web/Educator/Types.hs
+++ b/multi-educator/tests/Test/Dscp/MultiEducator/Web/Educator/Types.hs
@@ -1,0 +1,8 @@
+module Test.Dscp.MultiEducator.Web.Educator.Types where
+
+import Dscp.MultiEducator.Web.Educator.Types
+import Dscp.Util.Test
+
+spec_HttpDataSerialisation :: Spec
+spec_HttpDataSerialisation = describe "MultiEducator types URL serialisation" $
+    httpApiRoundtripProp @CertificateName

--- a/specs/disciplina/educator/api/certificates.yaml
+++ b/specs/disciplina/educator/api/certificates.yaml
@@ -1,0 +1,70 @@
+openapi: 3.0.0
+info:
+  description: >-
+    This is a public HTTP API served by Disciplina Multi-Educator node
+    and it covers public access to Disciplina certificates.
+  version: 1.0.0
+  title: Disciplina Certificates API
+  termsOfService: 'https://disciplina.io/tnc.pdf'
+  contact:
+    email: hi@serokell.io
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+externalDocs:
+  description: Find out more about Swagger
+  url: 'http://swagger.io'
+servers:
+  - url: 'https://localhost:8090/api/certificates/v1'
+  - url: 'http://localhost:8090/api/certificates/v1'
+paths:
+  /cert/{certificateId}.pdf:
+    get:
+      summary: Get the certificate by ID
+      description: >-
+        Gets the PDF certificate with FairCV JSON included as metadata by ID.
+        CertificateID is obtained as `base64url("<educator-UUID>:<certificate-hash>")`,
+        where `<educator-UUID>` is the UUID assigned by AAA microservice to Educator,
+        and `<certificate-hash>` is a hash of certificate meta.
+      operationId: getCertificate
+      parameters:
+        - $ref: '#/components/parameters/CertificateId'
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+        404:
+          description: Certificate with given ID not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrResponse'
+
+components:
+  parameters:
+    CertificateId:
+      in: path
+      name: certificateId
+      description: Full certificate ID
+      required: true
+      schema:
+        type: string
+        format: base64url
+
+  schemas:
+    ErrResponse:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          enum:
+            - CertificateNotFound
+          description: |-
+            Error type:
+              * `CertificateNotFound` - Specified certificate does not exist.

--- a/specs/disciplina/educator/api/educator.yaml
+++ b/specs/disciplina/educator/api/educator.yaml
@@ -1195,12 +1195,17 @@ components:
             - StudentNotFound
             - CourseNotFound
             - AssignmentNotFound
+            - CertificateNotFound
             - StudentAlreadyExists
             - CourseAlreadyExists
             - AssignmentAlreadyExists
+            - CertificateAlreadyExists
             - StudentDoesNotAttendCourse
-            - StudentIsActive
+            - StudentAlreadyAttendsCourse
+            - StudentAlreadyHasAssignment
             - StudentHasNoAssignment
+            - StudentIsActive
+            - DeletingGradedSubmission
           description: |-
             Error type:
               * `InvalidFormat` - Failed to deserialise one of parameters.


### PR DESCRIPTION
### Description

Adds an endpoint to multi-educator which is not protected by authentication and allows to download any certificate issued by any educator on this multi-educator.

Also fixes a potential (but apparent) bug with destructive editing of connections which are shared across multiple educators. Before `loadEducator` used `setSchemaName` on the whole existing connection pool, which is shared across multiple Educators. This would lead to the following scenario:
- Educator 1 queries the API for the first time, DB connections are redirected to Educator 1 schema, the context is added to a context map.
- Educator 2 queries the API for the first time, DB connections are redirected to Educator 2 schema, the context is added to a context map.
- Educator 1 queries the API for the second time and the query goes _to the database of Educator 2_.

It is fixed by creating a new connection pool for each new educator.

### YT issue

https://issues.serokell.io/issue/DSCP-488

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
