### PR TITLE
[DSCP-451] Add grading scale parameter to `CertificateGrade`

### DIFF
--- a/core/src/Dscp/Core/Aeson.hs
+++ b/core/src/Dscp/Core/Aeson.hs
@@ -191,6 +191,7 @@ deriveJSON defaultOptions ''PublicationTxWitnessed
 deriveJSON defaultOptions ''PublicationTx
 deriveJSON defaultOptions ''FeeCoefficients
 deriveJSON dscpAesonOptions ''EducationForm
+deriveJSON dscpAesonOptions ''GradingScale
 
 deriveFromJSON defaultOptions ''Committee
 deriveJSON defaultOptions ''GenesisDistributionElem

--- a/core/src/Dscp/Core/Arbitrary.hs
+++ b/core/src/Dscp/Core/Arbitrary.hs
@@ -121,6 +121,9 @@ genCommonDocumentType = frequency [(5, pure Offline), (1, pure Online)]
 instance Arbitrary EducationForm where
     arbitrary = arbitraryBoundedEnum
 
+instance Arbitrary GradingScale where
+    arbitrary = arbitraryBoundedEnum
+
 instance Arbitrary CertificateMeta where
     arbitrary = do
         cmStudentName <- arbitrary

--- a/core/src/Dscp/Core/Foundation/Educator.hs
+++ b/core/src/Dscp/Core/Foundation/Educator.hs
@@ -37,6 +37,7 @@ module Dscp.Core.Foundation.Educator
     , StudentInfo (..)
     , GradeInfo (..)
     , EducationForm (..)
+    , GradingScale (..)
     , documentType
     , _aDocumentType
     , aDocumentType
@@ -351,6 +352,9 @@ data CertificateMeta = CertificateMeta
 data EducationForm = Fulltime | Parttime | Fullpart
     deriving (Show, Eq, Generic, Enum, Bounded)
 
+data GradingScale = RusDiff | RusNonDiff
+    deriving (Show, Eq, Generic, Enum, Bounded)
+
 -- | Datatype which combines certificate meta with its ID.
 data Certificate = Certificate
     { cId   :: Hash CertificateMeta
@@ -364,6 +368,7 @@ data CertificateGrade = CertificateGrade
     , cgLang    :: Language
     , cgHours   :: Word32
     , cgCredits :: Maybe Word32
+    , cgScale   :: GradingScale
     , cgGrade   :: Grade
     } deriving (Show, Eq, Generic)
 

--- a/educator/src/Dscp/Educator/Web/Educator/Types.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Types.hs
@@ -403,6 +403,9 @@ instance ToSchema Certificate where
 instance ToSchema EducationForm where
     declareNamedSchema = gDeclareNamedSchema
 
+instance ToSchema GradingScale where
+    declareNamedSchema = gDeclareNamedSchema
+
 instance ToSchema CertificateGrade where
     declareNamedSchema = gDeclareNamedSchema
 

--- a/pdfs/src/Pdf/FromLatex.hs
+++ b/pdfs/src/Pdf/FromLatex.hs
@@ -96,12 +96,25 @@ fullInfo
       where
         course
             = custom
-            $ \CertificateGrade { cgSubject, cgLang, cgHours, cgCredits, cgGrade = UnsafeGrade grade} -> ""
+            $ \CertificateGrade { cgSubject, cgLang, cgHours, cgCredits, cgScale, cgGrade = UnsafeGrade grade} -> ""
                 <> shownDesc cgSubject <> " & "
                 <> shown     cgLang    <> " & "
                 <> shown     cgHours   <> " & "
                 <> maybe "---" shown cgCredits <> " & "
-                <> shown     grade
+                <> renderGrade cgLang cgScale grade
+
+        renderGrade _ RusDiff grade
+            | grade >= 100 = "5"
+            | grade >= 80 = "4"
+            | grade >= 60 = "3"
+            | grade >= 40 = "2"
+            | otherwise = "1"
+        renderGrade RU RusNonDiff grade
+            | grade >= 100 = "зачёт"
+            | otherwise = "незачёт"
+        renderGrade EN RusNonDiff grade
+            | grade >= 100 = "passed"
+            | otherwise = "not passed"
 
     formatDate day = [shown d, shown m, shown y]
       where
@@ -190,6 +203,7 @@ testData = CertificateFullInfo
             , cgCredits = Just 132
             , cgHours = 123
             , cgLang = RU
+            , cgScale = RusNonDiff
             , cgSubject = "Следование за обозом"
             }
         , CertificateGrade
@@ -197,6 +211,7 @@ testData = CertificateFullInfo
             , cgCredits = Nothing
             , cgHours = 13
             , cgLang = RU
+            , cgScale = RusDiff
             , cgSubject = "Черпание"
             }
         , CertificateGrade
@@ -204,6 +219,7 @@ testData = CertificateFullInfo
             , cgCredits = Just 34
             , cgHours = 1
             , cgLang = EN
+            , cgScale = RusNonDiff
             , cgSubject = "Сопротивление холере"
             }
         ]

--- a/specs/disciplina/educator/api/educator.yaml
+++ b/specs/disciplina/educator/api/educator.yaml
@@ -1165,6 +1165,7 @@ components:
       type: object
       required:
         - subject
+        - scale
         - grade
       properties:
         subject:
@@ -1178,6 +1179,14 @@ components:
         credits:
           type: integer
           format: int32
+        scale:
+          type: string
+          enum: [rusDiff, rusNonDiff]
+          description: >-
+            Grading scale sets up how the integer grades are interpreted.
+            Scales are the following:
+              * Russian differentiated (`rusDiff`): 5 = 100, 4 = 80, 3 = 60, 2 = 40
+              * Russian non-differentiated (`rusNonDiff`): "zachot" = 100, "nezachot" = 0
         grade:
           type: integer
           format: int32


### PR DESCRIPTION
### Description

Adds a grading scheme parameter to `CertificateGrade` which governs how the grade (which is represented internally as an integer from 1 to 100) is displayed in the certificate.

### YT issue

https://issues.serokell.io/issue/DSCP-451

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
