### PR TITLE
[DSCP-423] Remove opportinity to specify id in `POST course` endpoint

### DIFF
--- a/educator/src/Dscp/Educator/Web/Educator/Handlers.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Handlers.hs
@@ -54,9 +54,9 @@ educatorApiHandlers =
     , eGetCourses = \mStudent onlyCount pagination ->
         fmap (mkCountedList onlyCount) $ invoke $ educatorGetCourses mStudent pagination
 
-    , eAddCourse = \(NewCourse mcid desc subjects) ->
+    , eAddCourse = \(NewCourse desc subjects) ->
         transact $ createCourse CourseDetails
-            { cdCourseId = mcid
+            { cdCourseId = Nothing
             , cdDesc = desc
             , cdSubjects = subjects
             }

--- a/educator/src/Dscp/Educator/Web/Educator/Types.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Types.hs
@@ -62,8 +62,7 @@ data NewStudent = NewStudent
     } deriving (Show, Eq, Generic)
 
 data NewCourse = NewCourse
-    { ncId       :: Maybe Course
-    , ncDesc     :: ItemDesc
+    { ncDesc     :: ItemDesc
     , ncSubjects :: [Subject]
     } deriving (Show, Eq, Generic)
 
@@ -206,8 +205,7 @@ instance Buildable (NewStudent) where
 
 instance Buildable (NewCourse) where
     build (NewCourse{..}) =
-      "{ course id = " +| ncId |+
-      ", description = " +| ncDesc |+
+      "{ description = " +| ncDesc |+
       ", subjects = " +| listF ncSubjects |+
       " }"
 


### PR DESCRIPTION
### Description

I guess no one at frontend wants to specify their own course ids, and that would potentially allow for bugs.
Probably we still want to create courses with specific ids internally, otherwise life gets too difficult (can't know ids in advance => can't generate assignments, submissions and transactions in advance as well).

Swagger doc is already proper.

### YT issue

https://issues.serokell.io/issue/DSCP-423

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
