### PR TITLE
[DSCP-487] use name and website of authenticated educator in the PDF certificate

### DIFF
--- a/core/src/Dscp/Core/Aeson.hs
+++ b/core/src/Dscp/Core/Aeson.hs
@@ -28,7 +28,8 @@ import Dscp.Util.Aeson (dscpAesonOptions, parseJSONSerialise, toJSONSerialise)
 ---------------------------------------------------------------------------
 
 -- TODO [DSCP-416]: Move
-deriving instance ToJSON ItemDesc
+instance ToJSON ItemDesc where
+    toJSON = toJSON . unItemDesc
 instance FromJSON ItemDesc where
     parseJSON v = leftToFail . toItemDesc =<< parseJSON @Text v
 
@@ -175,6 +176,7 @@ deriveJSON defaultOptions ''Submission
 deriveJSON defaultOptions ''SignedSubmission
 deriveJSON dscpAesonOptions ''DocumentType  -- TODO: apply everywhere
 deriveJSON dscpAesonOptions ''AssignmentType
+deriveJSON defaultOptions ''CertificateIssuerInfo
 deriveJSON defaultOptions ''CertificateMeta
 deriveJSON defaultOptions ''PrivateTx
 deriveJSON defaultOptions ''PrivateBlockHeader

--- a/core/src/Dscp/Core/Arbitrary.hs
+++ b/core/src/Dscp/Core/Arbitrary.hs
@@ -504,8 +504,8 @@ submissionWitnessEx = _ssWitness signedSubmissionEx
 certificateIssuerInfoEx :: CertificateIssuerInfo
 certificateIssuerInfoEx =
     CertificateIssuerInfo
-    { ciiName = "Grimpy Cat University"
-    , ciiUrl = "example@gmail.com"
+    { ciiName    = "Grimpy Cat University"
+    , ciiWebsite = "example@gmail.com"
     }
 
 ----------------------------------------------------------------------------

--- a/core/src/Dscp/Core/Foundation/Educator.hs
+++ b/core/src/Dscp/Core/Foundation/Educator.hs
@@ -396,8 +396,8 @@ data GradeInfo = GradeInfo
 -- | Datatype containing information about Educator which issued
 -- the certificate, required in order to render a certificate.
 data CertificateIssuerInfo = CertificateIssuerInfo
-    { ciiName :: ItemDesc
-    , ciiUrl  :: ItemDesc
+    { ciiName    :: ItemDesc
+    , ciiWebsite :: ItemDesc
     } deriving (Show, Eq, Generic)
 
 instance Buildable (StudentInfo) where

--- a/docs/config-full-sample.yaml
+++ b/docs/config-full-sample.yaml
@@ -222,6 +222,10 @@ sample:
       latex: "xelatex"
       # Path to the directory with LaTeX templates
       resources: "/var/lib/disciplina/certificate-templates"
+      # Info about the certificates issuer, to be used in Pdf generation
+      issuer:
+        name: Grimpy Cat University
+        website: example.grimpy.cat.com
     # These are options for the AAA microservice, only used by the multi-educator
     aaa:
       # URL of the AAA microservice

--- a/educator/package.yaml
+++ b/educator/package.yaml
@@ -28,6 +28,8 @@ library:
     - fmt
     - interpolatedstring-perl6
     - jose
+    - http-client
+    - http-client-tls
     - http-types
     - lens
     - loot-base

--- a/educator/src/Dscp/Educator/Config.hs
+++ b/educator/src/Dscp/Educator/Config.hs
@@ -22,6 +22,7 @@ import Loot.Config ((:::), (::<), ConfigKind (Final, Partial), ConfigRec, upcast
 import Time (Second, Time)
 
 import Dscp.Config
+import Dscp.Core.Foundation.Educator (ItemDesc (..))
 import Dscp.DB.SQL
 import Dscp.Educator.Launcher.Params
 import Dscp.Educator.Web.Config
@@ -39,6 +40,10 @@ type EducatorConfig = WitnessConfig ++
         , "certificates" ::<
            '[ "latex" ::: FilePath
             , "resources" ::: FilePath
+            , "issuer" ::<
+               '[ "name" ::: ItemDesc
+                , "website" ::: ItemDesc
+                ]
             ]
         ]
      ]

--- a/educator/src/Dscp/Educator/Launcher/Mode.hs
+++ b/educator/src/Dscp/Educator/Launcher/Mode.hs
@@ -13,6 +13,8 @@ module Dscp.Educator.Launcher.Mode
 
       -- * Implementations
     , EducatorContext (..)
+    , ecResources
+    , ecWitnessVars
     , EducatorRealMode
     ) where
 
@@ -24,7 +26,7 @@ import Dscp.DB.CanProvideDB as DB
 import Dscp.DB.SQL (SQL)
 import Dscp.Educator.Config (HasEducatorConfig, withEducatorConfig)
 import Dscp.Educator.Launcher.Marker (EducatorNode)
-import Dscp.Educator.Launcher.Resource (EducatorResources)
+import Dscp.Educator.Launcher.Resource (CertificateIssuerResource, EducatorResources)
 import qualified Dscp.Launcher.Mode as Basic
 import Dscp.Resource.Keys (KeyResources)
 import Dscp.Resource.Network
@@ -48,6 +50,7 @@ type EducatorOnlyWorkMode ctx m =
         , KeyResources EducatorNode
         , Pdf.LatexPath
         , Pdf.ResourcePath
+        , CertificateIssuerResource
         ]
     )
 
@@ -70,7 +73,7 @@ data EducatorContext = EducatorContext
     { _ecResources   :: !EducatorResources
       -- ^ Resources, allocated from params.
     , _ecWitnessVars :: !W.WitnessVariables
-      -- ^ Wintess variables (non-resources).
+      -- ^ Witness variables (non-resources).
     }
 
 makeLenses ''EducatorContext

--- a/educator/src/Dscp/Educator/Web/Auth.hs
+++ b/educator/src/Dscp/Educator/Web/Auth.hs
@@ -18,6 +18,7 @@ module Dscp.Educator.Web.Auth
        , NoAuthData
        , NoAuthContext (..)
 
+       , authBearerToken
        , authTimeout
        , requestEndpoint
        , createAuthToken

--- a/educator/src/Dscp/Educator/Web/Types.hs
+++ b/educator/src/Dscp/Educator/Web/Types.hs
@@ -44,6 +44,7 @@ import Dscp.Crypto
 import Dscp.DB.SQL
 import Dscp.Educator.DB
 import Dscp.Educator.Launcher.Marker
+import Dscp.Educator.Launcher.Resource (CertificateIssuerResource)
 import Dscp.Resource.Keys
 import Dscp.Util.Aeson
 import Dscp.Web.Swagger
@@ -58,7 +59,13 @@ type MonadEducatorWebQuery m =
 
 type MonadEducatorWeb ctx m =
     ( WitnessWorkMode ctx m
-    , HasCtx ctx m '[SQL, KeyResources EducatorNode, Pdf.LatexPath, Pdf.ResourcePath]
+    , HasCtx ctx m
+       '[ SQL
+        , KeyResources EducatorNode
+        , Pdf.LatexPath
+        , Pdf.ResourcePath
+        , CertificateIssuerResource
+        ]
     )
 
 ---------------------------------------------------------------------------

--- a/educator/tests/Test/Dscp/Educator/Mode.hs
+++ b/educator/tests/Test/Dscp/Educator/Mode.hs
@@ -54,6 +54,7 @@ data TestEducatorCtx = TestEducatorCtx
     , _tecWitnessVariables :: TestWitnessVariables
     , _tecLogging          :: Log.Logging IO
     , _tecAppDir           :: AppDir
+    , _tecIssuerInfo       :: CertificateIssuerResource
     }
 makeLenses ''TestEducatorCtx
 deriveHasLensDirect ''TestEducatorCtx
@@ -101,6 +102,7 @@ runTestSqlM testDb action =
         let _tecPdfLatexPath = testLatexPath
         let _tecPdfResourcePath = testResourcePath
         let _tecAppDir = error "AppDir is not defined"
+        let _tecIssuerInfo = KnownIssuerInfo certificateIssuerInfoEx
         let ctx = TestEducatorCtx{..}
         runRIO ctx $ markWithinWriteSDLockUnsafe applyGenesisBlock
 

--- a/multi-educator/src/Dscp/MultiEducator/CLI.hs
+++ b/multi-educator/src/Dscp/MultiEducator/CLI.hs
@@ -18,7 +18,7 @@ import Dscp.Educator.CLI
 import Dscp.Educator.Web.Auth
 import Dscp.MultiEducator.Config
 import Dscp.MultiEducator.Launcher.Params (MultiEducatorAAAConfig, MultiEducatorKeyParams (..))
-import Dscp.MultiEducator.Web.Educator.Auth (EducatorAuthData (..), MultiEducatorPublicKey)
+import Dscp.MultiEducator.Web.Educator.Auth (MultiEducatorPublicKey, educatorAuthLoginSimple)
 import Dscp.Witness.CLI (witnessConfigParser)
 
 import qualified Data.ByteString as BS
@@ -49,7 +49,7 @@ multiEducatorAAAConfigParser =
         addQuotationMarks bs = BS.intercalate bs ["\"", "\""]
 
 multiEducatorApiNoAuthParser :: Parser (NoAuthContext "multi-educator")
-multiEducatorApiNoAuthParser = noAuthContextParser . fmap EducatorAuthData . strOption $
+multiEducatorApiNoAuthParser = noAuthContextParser . fmap educatorAuthLoginSimple . strOption $
     long "educator-api-no-auth" <>
     help "Make authentication into Educator API of multi-educator optional. \
          \Accepts educator id used when request is unauthenticated."

--- a/multi-educator/src/Dscp/MultiEducator/Launcher/Mode.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Launcher/Mode.hs
@@ -32,6 +32,7 @@ import Loot.Network.Class (NetworkingCli, NetworkingServ)
 import Loot.Network.ZMQ (ZmqTcp)
 import qualified Pdf.FromLatex as Pdf
 import Serokell.Util (modifyTVarS)
+import Servant.Client.Core.Internal.BaseUrl
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath ((<.>), (</>))
 import UnliftIO (async)
@@ -42,12 +43,14 @@ import Dscp.DB.SQL
 import qualified Dscp.Educator.Config as E
 import Dscp.Educator.DB (prepareEducatorSchema)
 import Dscp.Educator.Launcher.Marker (EducatorNode)
+import Dscp.Educator.Launcher.Resource (CertificateIssuerResource (..))
 import qualified Dscp.Educator.Launcher.Mode as E
 import qualified Dscp.Educator.Launcher.Resource as E
 import Dscp.Educator.Workers
 import Dscp.MultiEducator.Config
 import Dscp.MultiEducator.Launcher.Params (MultiEducatorKeyParams (..))
 import Dscp.MultiEducator.Launcher.Resource
+import Dscp.MultiEducator.Web.Educator.Auth (EducatorAuthData (..), EducatorAuthLogin (..))
 import Dscp.Network
 import Dscp.Resource.AppDir (AppDir)
 import Dscp.Resource.Keys (linkStore)
@@ -112,16 +115,20 @@ deriveHasLens 'mecWitnessVars ''MultiEducatorContext ''W.WitnessVariables
 ----------------------------------------------------------------------------
 
 -- | This function transforms normal workmode into multi-workmode using login.
--- It returns Nothing is login was not found
-lookupEducator :: MultiEducatorWorkMode ctx m => Text -> m LoadedEducatorContext
-lookupEducator login = do
+-- It create a new Educator context if login was not found
+lookupEducator
+    :: MultiEducatorWorkMode ctx m
+    => EducatorAuthLogin
+    -> m LoadedEducatorContext
+lookupEducator educatorAuthLogin = do
     educatorContexts <- view $ lensOf @MultiEducatorResources . merEducatorData
 
-    let withEducatorContextAtomically
+    let educatorId = eadId $ ealData educatorAuthLogin
+        withEducatorContextAtomically
             :: MonadIO m
             => StateT (Maybe MaybeLoadedEducatorContext) STM a -> m a
         withEducatorContextAtomically =
-            atomically . modifyTVarS educatorContexts . zoom (_Wrapped' . at login)
+            atomically . modifyTVarS educatorContexts . zoom (_Wrapped' . at educatorId)
 
     mask_ $ do
         mctx <- withEducatorContextAtomically $ do
@@ -138,49 +145,64 @@ lookupEducator login = do
                     -- already prepared
                     return (Just ctx)
 
-        whenNothing mctx $
-            let rollback = withEducatorContextAtomically $ put Nothing
-            in (`onException` rollback) $ do
-                    ctx <- loadEducator login Nothing
-                    withEducatorContextAtomically $
-                        put $ Just (FullyLoadedEducatorContext ctx)
-                    return ctx
-
+        case mctx of
+            Nothing -> let rollback = withEducatorContextAtomically $ put Nothing
+                in (`onException` rollback) $ do
+                        ctx <- loadEducator educatorAuthLogin Nothing
+                        withEducatorContextAtomically $
+                            put $ Just (FullyLoadedEducatorContext ctx)
+                        return ctx
+            -- Note: we need this because even if we already have the 'EducatorCtxWithCfg'
+            -- in the map it may need to be updated with a new token
+            Just ctx -> do
+                certIssuerInfoRes <- makeCertIssuerRes educatorAuthLogin
+                let newEdCtx = lecCtx ctx & E.ecResources.E.erPdfCertIssuerRes .~ certIssuerInfoRes
+                    newCtxWithCfg = ctx {lecCtx = newEdCtx}
+                withEducatorContextAtomically $
+                    put $ Just (FullyLoadedEducatorContext newCtxWithCfg)
+                return newCtxWithCfg
     -- TODO lookupEducator should probably take a Maybe PassPhrase
     -- to pass it to 'loadEducator'
-    -- or the relationship with loadEducator should be different/removed
 
-loadEducator :: (MultiEducatorWorkMode ctx m) => Text -> Maybe PassPhrase -> m LoadedEducatorContext
-loadEducator login mpassphrase = do
-    logDebug $ "Loading educator " +| login |+ ""
+loadEducator
+    :: (MultiEducatorWorkMode ctx m)
+    => EducatorAuthLogin
+    -> Maybe PassPhrase
+    -> m LoadedEducatorContext
+loadEducator educatorAuthLogin mpassphrase = do
+    let educatorId = eadId $ ealData educatorAuthLogin
+    logDebug $ "Loading educator " +| educatorId |+ ""
     -- TODO: add hashing
     appDir <- view $ lensOf @AppDir
     ctx <- ask
-    let resources = ctx ^. lensOf @MultiEducatorResources
+    let multiEducatorSub = multiEducatorConfig ^. sub #educator
+        resources = ctx ^. lensOf @MultiEducatorResources
         (MultiEducatorKeyParams keyDir) = multiEducatorConfig ^. sub #educator . option #keys
         dbParams = multiEducatorConfig ^. sub #educator . sub #db
 
     -- open the new DB connection
     db <- openPostgresDB (PostgresParams $ PostgresReal dbParams)
     -- set the DB schema name and create it if it's not ready
-    let schema = educatorSchemaName login
+    let schema = educatorSchemaName educatorId
     logInfo $ "Creating a schema with name `"+|schema|+"`"
     setSchemaName db schema
     prepareEducatorSchema db
     liftIO $ createDirectoryIfMissing True keyDir
     -- read key from file and creates one if it does not exist yet
     let keyParams = finaliseDeferredUnsafe $ mempty
-            & option #path       ?~ Just (keyDir </> toString login <.> "key")
+            & option #path       ?~ Just (keyDir </> toString educatorId <.> "key")
             & option #genNew     ?~ True
             & option #passphrase ?~ mpassphrase
     key <- withCoreConfig (rcast multiEducatorConfig) $ linkStore keyParams appDir
     -- build up a new educator context with config
+    certIssuerInfoRes <- makeCertIssuerRes educatorAuthLogin
     let educatorResources = E.EducatorResources
             { _erWitnessResources = resources ^. lensOf @W.WitnessResources
             , _erKeys = key
             , _erDB = db
             , _erPdfLatexPath = ctx ^. lensOf @MultiEducatorResources . lensOf @Pdf.LatexPath
             , _erPdfResourcePath = ctx ^. lensOf @MultiEducatorResources . lensOf @Pdf.ResourcePath
+            , _erPdfCertIssuerRes = certIssuerInfoRes
             }
         educatorContext = E.EducatorContext
             { _ecResources = educatorResources
@@ -193,7 +215,15 @@ loadEducator login mpassphrase = do
             & sub #educator . sub #keys . sub #keyParams .~ keyParams
             & sub #educator . sub #api . option #educatorAPINoAuth .~
                 error "Do not touch, multi-educator has already run the server"
-            & sub #educator . sub #publishing .~ multiEducatorConfig ^. sub #educator . sub #publishing
+            & sub #educator . sub #publishing .~ multiEducatorSub ^. sub #publishing
+            & sub #educator . sub #certificates . option #latex .~
+                multiEducatorSub ^. sub #certificates . option #latex
+            & sub #educator . sub #certificates . option #resources .~
+                multiEducatorSub ^. sub #certificates . option #resources
+            & sub #educator . sub #certificates . sub #issuer . option #name .~
+                error "Should not use certificate config, resource is made by multi-educator"
+            & sub #educator . sub #certificates . sub #issuer . option #website .~
+                error "Should not use certificate config, resource is made by multi-educator"
 
     workerAsyncs <- E.withEducatorConfig newCfg $ runRIO educatorContext $
         mapM (async . runWorker identity) $ educatorWorkers
@@ -207,6 +237,16 @@ loadEducator login mpassphrase = do
 -- | Returns database schema name for an educator with given ID.
 educatorSchemaName :: Text -> Text
 educatorSchemaName eId = "educator_" <> eId
+
+makeCertIssuerRes
+    :: MultiEducatorWorkMode ctx m
+    => EducatorAuthLogin
+    -> m CertificateIssuerResource
+makeCertIssuerRes educatorAuthLogin = do
+    let aaaUrl = multiEducatorConfig ^. sub #educator . sub #aaa . option #serviceUrl
+    return $ FromServiceIssuerInfo
+        (aaaUrl { baseUrlPath = "educators" </> "current"})
+        (ealToken educatorAuthLogin)
 
 normalToMulti :: MultiEducatorWorkMode ctx m => LoadedEducatorContext -> E.EducatorRealMode a -> m a
 normalToMulti LoadedEducatorContext{..} = runRIO lecCtx

--- a/multi-educator/src/Dscp/MultiEducator/Web/Educator/API.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Web/Educator/API.hs
@@ -59,7 +59,7 @@ type MultiEducatorAPI =
     "api" :> "educator" :> "v1" :> ProtectedMultiEducatorAPI
 
 type ProtectedMultiEducatorAPI =
-    Auth' '[MultiEducatorAuth, NoAuth "multi-educator"] EducatorAuthData :> RawEducatorAPI
+    Auth' '[MultiEducatorAuth, NoAuth "multi-educator"] EducatorAuthLogin :> RawEducatorAPI
 
 multiEducatorAPI :: Proxy MultiEducatorAPI
 multiEducatorAPI = Proxy

--- a/multi-educator/src/Dscp/MultiEducator/Web/Educator/Auth.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Web/Educator/Auth.hs
@@ -57,7 +57,7 @@ instance ToJWT EducatorAuthToken
 data EducatorAuthLogin = EducatorAuthLogin
     { ealData  :: EducatorAuthData
     , ealToken :: ByteString
-    }
+    } deriving (Show, Eq)
 
 instance ToJSON EducatorAuthLogin where
     toJSON (EducatorAuthLogin {..}) = toJSON ealData

--- a/pdfs/src/Pdf/FromLatex.hs
+++ b/pdfs/src/Pdf/FromLatex.hs
@@ -70,8 +70,8 @@ fullInfo
 
     meta
         = split (const ())                  (command "MakeHeader"  $ const [])
-        $ split (ciiName . fst)              (command "section"     $ pure . shownDesc)
-        $ split (ciiUrl . fst)               (command "EducatorUrl" $ pure . shownDesc)
+        $ split (ciiName . fst)             (command "section"     $ pure . shownDesc)
+        $ split (ciiWebsite . fst)          (command "EducatorUrl" $ pure . shownDesc)
         $ split (cfiMeta . snd)             (inBlock "Diploma"       diploma)
         $ ignore
 

--- a/scripts/launch/node.sh
+++ b/scripts/launch/node.sh
@@ -112,6 +112,8 @@ educator_params="
 --student-api-no-auth 3BAyX5pNpoFrLJcP5bZ2kXihBfmBVLprSyP1RhcPPddm6Dw42jzEPXZz22
 --publication-period 15s
 --pdf-resource-path ../pdfs/template
+--cert-issuer-name "Grimpy Cat University"
+--cert-issuer-url example@gmail.com
 "
 multi_educator_params="
 --educator-key-dir $files/multieducator


### PR DESCRIPTION
### Description

The scope of this PR is to make it so that `educatorAddCertificate` will use a real name and website for the `CertificateFullInfo` required to make a certificate PDF.

The chosen method to achieve this was to add a new resource to the Educator node (see discussion on info).

### YT issue

https://issues.serokell.io/issue/DSCP-487

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [ ] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [X] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
