### PR TITLE
[DSCP-473] Swagger UI

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -58,6 +58,8 @@ demo: &demo
         params:
           enabled:
             seed: Bot seed
+    certificates:
+      downloadBaseUrl: "https://example.com/api/certificates/v1/cert"
 
   faucet:
     logging:

--- a/core/src/Dscp/Core/Foundation/Educator.hs
+++ b/core/src/Dscp/Core/Foundation/Educator.hs
@@ -20,7 +20,6 @@ module Dscp.Core.Foundation.Educator
     , mkGrade
     , Language (..)
     , gradeToNum
-    , EducatorId
     , Assignment (..)
     , AssignmentType (..)
     , Submission (..)
@@ -196,9 +195,6 @@ gradeToNum (UnsafeGrade g) = fromIntegral g
 type Student = Address
 
 instance HasId Student
-
--- | Educator is identified by their public adddress.
-type EducatorId = Address
 
 -- | Educator's course ID is simply a number too.
 -- There's a mapping from course ID to a set of associated subject IDs.

--- a/educator/package.yaml
+++ b/educator/package.yaml
@@ -56,6 +56,7 @@ library:
     - servant-util-beam-pg
     - snowdrop-util
     - swagger2
+    - tagged
     - template-haskell
     - text
     - text-format
@@ -109,6 +110,7 @@ tests:
       - servant-util
       - sqlite-simple
       - stm
+      - tagged
       - tasty
       - tasty-hspec
       - text-format

--- a/educator/src/Dscp/Educator/Web/Educator/API.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/API.hs
@@ -4,8 +4,10 @@ module Dscp.Educator.Web.Educator.API
     ( EducatorApiEndpoints (..)
     , RawEducatorAPI
     , ProtectedEducatorAPI
+    , FullEducatorAPI
     , rawEducatorAPI
     , protectedEducatorAPI
+    , fullEducatorAPI
     , EducatorApiHandlers
     -- * Re-export for using in packages dependent on `disciplina-educator`
     , PDFBody (..)
@@ -53,8 +55,11 @@ data EducatorApiEndpoints route = EducatorApiEndpoints
 type RawEducatorAPI = ToServant (EducatorApiEndpoints AsApi)
 
 type ProtectedEducatorAPI =
-    "api" :> "educator" :> "v1" :>
     Auth' [EducatorAuth, NoAuth "educator"] () :> RawEducatorAPI
+
+type FullEducatorAPI =
+    "api" :> "educator" :> "v1" :>
+    (WithSwaggerUI ProtectedEducatorAPI)
 
 type EducatorApiHandlers m = EducatorApiEndpoints (AsServerT m)
 
@@ -63,6 +68,9 @@ rawEducatorAPI = Proxy
 
 protectedEducatorAPI :: Proxy ProtectedEducatorAPI
 protectedEducatorAPI = Proxy
+
+fullEducatorAPI :: Proxy FullEducatorAPI
+fullEducatorAPI = Proxy
 
 ---------------------------------------------------------------------------
 -- General

--- a/educator/src/Dscp/Educator/Web/Educator/Queries.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Queries.hs
@@ -34,7 +34,7 @@ import Pdf.Scanner (PDFBody)
 import Servant (err501)
 import Servant.Client.Core.Internal.BaseUrl (showBaseUrl)
 import Servant.Util (PaginationSpec, SortingSpecOf, HList (HNil), (.*.))
-import Servant.Util.Beam.Postgres (bySpec_, fieldSort_, paginate_)
+import Servant.Util.Beam.Postgres (fieldSort, paginate_, sortBy_)
 
 import Dscp.Core
 import Dscp.Crypto
@@ -331,11 +331,11 @@ educatorGetCertificates sorting pagination =
     runSelectMap certificateFromRow . select $
     paginate_ pagination $ do
         certificate <-
-            orderBy_ (bySpec_ sorting . sortingSpecApp) $ do
+            sortBy_ sorting sortingSpecApp $ do
             all_ (esCertificates es)
         return (crHash certificate, crMeta certificate)
   where
     sortingSpecApp CertificateRow{..} =
-        fieldSort_ @"createdAt" (crMeta ->>$. #cmIssueDate) .*.
-        fieldSort_ @"studentName" (crMeta ->>$. #cmStudentName) .*.
+        fieldSort @"createdAt" (crMeta ->>$. #cmIssueDate) .*.
+        fieldSort @"studentName" (crMeta ->>$. #cmStudentName) .*.
         HNil

--- a/educator/src/Dscp/Educator/Web/Educator/Swagger.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Swagger.hs
@@ -12,21 +12,24 @@ import qualified Data.Swagger as S
 import Dscp.Educator.Web.Educator.API
 import Dscp.Util
 import Dscp.Web.Swagger
+import Dscp.Web.Types
 
 -- | Swagger documentation for Educator API.
-educatorAPISwagger :: Swagger
-educatorAPISwagger = toAwesomeSwagger protectedEducatorAPI &: do
+educatorAPISwagger :: Maybe NetworkAddress -> Swagger
+educatorAPISwagger mhost = toAwesomeSwagger protectedEducatorAPI &: do
     setSerokellDocMeta
 
     zoom S.info $ do
         S.title .= "Disciplina Educator API"
         S.version .= "1.0.0"
 
-    S.host ?= "localhost:8090"
+    S.host .= fmap networkAddressToSwaggerHost mhost
     S.schemes ?= [Http, Https]
 
 -- | Write documentation to file, for testing purposes.
 -- Normally you can use "dscp-swagger" executable to build documentation.
 writeEducatorAPISwagger :: FilePath -> IO ()
 writeEducatorAPISwagger file =
-    liftIO $ LBS.writeFile file (encodeSwagger educatorAPISwagger)
+    liftIO $ LBS.writeFile file (encodeSwagger $ educatorAPISwagger demoAddr)
+  where
+    demoAddr = Just $ NetworkAddress "localhost" 8090

--- a/educator/src/Dscp/Educator/Web/Educator/Swagger.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Swagger.hs
@@ -16,7 +16,7 @@ import Dscp.Web.Types
 
 -- | Swagger documentation for Educator API.
 educatorAPISwagger :: Maybe NetworkAddress -> Swagger
-educatorAPISwagger mhost = toAwesomeSwagger protectedEducatorAPI &: do
+educatorAPISwagger mhost = toAwesomeSwagger fullEducatorAPI &: do
     setSerokellDocMeta
 
     zoom S.info $ do

--- a/educator/src/Dscp/Educator/Web/Educator/Swagger.hs
+++ b/educator/src/Dscp/Educator/Web/Educator/Swagger.hs
@@ -8,6 +8,7 @@ import Control.Lens (zoom, (.=), (?=))
 import qualified Data.ByteString.Lazy as LBS
 import Data.Swagger (Scheme (..), Swagger)
 import qualified Data.Swagger as S
+import Data.Tagged (Tagged (..), untag)
 
 import Dscp.Educator.Web.Educator.API
 import Dscp.Util
@@ -15,8 +16,8 @@ import Dscp.Web.Swagger
 import Dscp.Web.Types
 
 -- | Swagger documentation for Educator API.
-educatorAPISwagger :: Maybe NetworkAddress -> Swagger
-educatorAPISwagger mhost = toAwesomeSwagger fullEducatorAPI &: do
+educatorAPISwagger :: Maybe NetworkAddress -> Tagged ProtectedEducatorAPI Swagger
+educatorAPISwagger mhost = Tagged $ toAwesomeSwagger fullEducatorAPI &: do
     setSerokellDocMeta
 
     zoom S.info $ do
@@ -30,6 +31,6 @@ educatorAPISwagger mhost = toAwesomeSwagger fullEducatorAPI &: do
 -- Normally you can use "dscp-swagger" executable to build documentation.
 writeEducatorAPISwagger :: FilePath -> IO ()
 writeEducatorAPISwagger file =
-    liftIO $ LBS.writeFile file (encodeSwagger $ educatorAPISwagger demoAddr)
+    liftIO $ LBS.writeFile file (encodeSwagger . untag $ educatorAPISwagger demoAddr)
   where
     demoAddr = Just $ NetworkAddress "localhost" 8090

--- a/educator/src/Dscp/Educator/Web/Server.hs
+++ b/educator/src/Dscp/Educator/Web/Server.hs
@@ -29,34 +29,40 @@ import Dscp.Educator.DB (existsStudent)
 import Dscp.Educator.Launcher.Mode (EducatorNode, EducatorWorkMode)
 import Dscp.Educator.Web.Auth
 import Dscp.Educator.Web.Bot
-import Dscp.Educator.Web.Educator (EducatorPublicKey (..), ProtectedEducatorAPI,
+import Dscp.Educator.Web.Educator (EducatorPublicKey (..), FullEducatorAPI,
                                    convertEducatorApiHandler, educatorApiHandlers,
                                    protectedEducatorAPI)
-import Dscp.Educator.Web.Student (ProtectedStudentAPI, StudentCheckAction (..),
-                                  convertStudentApiHandler, rawStudentAPI, studentApiHandlers)
+import Dscp.Educator.Web.Educator.Swagger
+import Dscp.Educator.Web.Student (FullStudentAPI, StudentCheckAction (..), convertStudentApiHandler,
+                                  protectedStudentAPI, studentApiHandlers)
 import Dscp.Educator.Web.Student.Auth (mkStudentActionM)
+import Dscp.Educator.Web.Student.Swagger
 import Dscp.Resource.Keys (KeyResources, krPublicKey)
 import Dscp.Web (buildServantLogConfig, serveWeb)
 import Dscp.Web.Metrics (responseTimeMetric)
+import Dscp.Web.Swagger.UI
+import Dscp.Web.Types
 import Dscp.Witness.Web
 
 type EducatorWebAPI =
-    ProtectedEducatorAPI
+    FullEducatorAPI
     :<|>
-    ProtectedStudentAPI
+    FullStudentAPI
     :<|>
     WitnessAPI
 
 mkEducatorApiServer
     :: forall ctx m. EducatorWorkMode ctx m
     => (forall x. m x -> Handler x)
-    -> Server ProtectedEducatorAPI
-mkEducatorApiServer nat =
-    hoistServerWithContext
-        protectedEducatorAPI
-        (Proxy :: Proxy '[EducatorPublicKey, NoAuthContext "educator"])
-        nat
-        (\() -> toServant educatorApiHandlers)
+    -> NetworkAddress
+    -> Server FullEducatorAPI
+mkEducatorApiServer nat host =
+    withSwaggerUI (educatorAPISwagger (Just host)) protectedEducatorAPI $
+        hoistServerWithContext
+            protectedEducatorAPI
+            (Proxy :: Proxy '[EducatorPublicKey, NoAuthContext "educator"])
+            nat
+            (\() -> toServant educatorApiHandlers)
 
 -- | Create these two:
 -- 1. An action which checks whether or not the
@@ -67,32 +73,34 @@ mkEducatorApiServer nat =
 mkStudentApiServer
     :: forall ctx m. EducatorWorkMode ctx m
     => (forall x. m x -> Handler x)
+    -> NetworkAddress
     -> EducatorBotConfigRec
-    -> m (StudentCheckAction, Server ProtectedStudentAPI)
-mkStudentApiServer nat botConfig = case botConfig ^. tree #params . selection of
+    -> m (StudentCheckAction, Server FullStudentAPI)
+mkStudentApiServer nat host botConfig = case botConfig ^. tree #params . selection of
     "enabled" ->
         initializeBot (botConfig ^. tree #params . peekBranch #enabled) $ do
-            let server student =
-                    getServer . addBotHandlers student $
-                    studentApiHandlers student
+            let server = getServer $
+                    \student -> addBotHandlers student $ studentApiHandlers student
             checkAction <- mkStudentActionM $ \pk -> do
                 let student = mkAddr pk
                 botProvideInitSetting student
                 return True
             return (checkAction, server)
     "disabled" -> do
-        let server = getServer . studentApiHandlers
+        let server = getServer studentApiHandlers
         checkAction <- mkStudentActionM $ \pk ->
               let addr = mkAddr pk
               in invoke $ existsStudent addr
         return (checkAction, server)
     other -> error $ "unknown EducatorBotConfig type: " <> fromString other
   where
-    getServer handlers = hoistServerWithContext
-        rawStudentAPI
-        (Proxy :: Proxy '[StudentCheckAction])
-        nat
-        (toServant handlers)
+    getServer handlers =
+        withSwaggerUI (studentAPISwagger (Just host)) protectedStudentAPI $
+            hoistServerWithContext
+                protectedStudentAPI
+                (Proxy :: Proxy '[StudentCheckAction, NoAuthContext "student"])
+                nat
+                (\student -> toServant $ handlers student)
 
 -- | CORS is enabled to ease development for frontend team.
 educatorCors :: Middleware
@@ -116,7 +124,7 @@ serveEducatorAPIsReal withWitnessApi = do
 
     educatorKeyResources <- view (lensOf @(KeyResources EducatorNode))
     (studentCheckAction, studentApiServer) <-
-          mkStudentApiServer (convertStudentApiHandler unliftIO) botConfig
+          mkStudentApiServer (convertStudentApiHandler unliftIO) serverAddress botConfig
 
     let educatorPublicKey = EducatorPublicKey $ educatorKeyResources ^. krPublicKey
     let srvCtx = educatorPublicKey :. educatorAPINoAuth :.
@@ -125,7 +133,8 @@ serveEducatorAPIsReal withWitnessApi = do
 
     logInfo $ "Serving Student API on "+|serverAddress|+""
     lc <- buildServantLogConfig (<> "web")
-    let educatorApiServer = mkEducatorApiServer (convertEducatorApiHandler unliftIO)
+    let educatorApiServer =
+          mkEducatorApiServer (convertEducatorApiHandler unliftIO) serverAddress
     let witnessApiServer = if withWitnessApi
           then mkWitnessAPIServer (convertWitnessHandler unliftIO)
           else throwAll err405{ errBody = "Witness API disabled at this port" }

--- a/educator/src/Dscp/Educator/Web/Server.hs
+++ b/educator/src/Dscp/Educator/Web/Server.hs
@@ -57,7 +57,7 @@ mkEducatorApiServer
     -> NetworkAddress
     -> Server FullEducatorAPI
 mkEducatorApiServer nat host =
-    withSwaggerUI (educatorAPISwagger (Just host)) protectedEducatorAPI $
+    withSwaggerUI protectedEducatorAPI (educatorAPISwagger (Just host)) $
         hoistServerWithContext
             protectedEducatorAPI
             (Proxy :: Proxy '[EducatorPublicKey, NoAuthContext "educator"])
@@ -95,7 +95,7 @@ mkStudentApiServer nat host botConfig = case botConfig ^. tree #params . selecti
     other -> error $ "unknown EducatorBotConfig type: " <> fromString other
   where
     getServer handlers =
-        withSwaggerUI (studentAPISwagger (Just host)) protectedStudentAPI $
+        withSwaggerUI Proxy (studentAPISwagger (Just host)) $
             hoistServerWithContext
                 protectedStudentAPI
                 (Proxy :: Proxy '[StudentCheckAction, NoAuthContext "student"])

--- a/educator/src/Dscp/Educator/Web/Student/API.hs
+++ b/educator/src/Dscp/Educator/Web/Student/API.hs
@@ -4,7 +4,9 @@
 module Dscp.Educator.Web.Student.API
        ( StudentApiEndpoints (..)
        , ProtectedStudentAPI
+       , FullStudentAPI
        , protectedStudentAPI
+       , fullStudentAPI
        , RawStudentAPI
        , rawStudentAPI
        , StudentApiHandlers
@@ -38,8 +40,11 @@ data StudentApiEndpoints route = StudentApiEndpoints
 type RawStudentAPI = ToServant (StudentApiEndpoints AsApi)
 
 type ProtectedStudentAPI =
-    "api" :> "student" :> "v1" :>
     Auth' [StudentAuth, NoAuth "student"] Core.Student :> RawStudentAPI
+
+type FullStudentAPI =
+    "api" :> "student" :> "v1" :>
+    (WithSwaggerUI ProtectedStudentAPI)
 
 type StudentApiHandlers m = StudentApiEndpoints (AsServerT m)
 
@@ -48,6 +53,9 @@ rawStudentAPI = Proxy
 
 protectedStudentAPI :: Proxy ProtectedStudentAPI
 protectedStudentAPI = Proxy
+
+fullStudentAPI :: Proxy FullStudentAPI
+fullStudentAPI = Proxy
 
 ---------------------------------------------------------------------------
 -- Courses

--- a/educator/src/Dscp/Educator/Web/Student/Swagger.hs
+++ b/educator/src/Dscp/Educator/Web/Student/Swagger.hs
@@ -12,21 +12,24 @@ import qualified Data.Swagger as S
 import Dscp.Educator.Web.Student.API
 import Dscp.Util
 import Dscp.Web.Swagger
+import Dscp.Web.Types
 
 -- | Swagger documentation for Student API.
-studentAPISwagger :: Swagger
-studentAPISwagger = toAwesomeSwagger protectedStudentAPI &: do
+studentAPISwagger :: Maybe NetworkAddress -> Swagger
+studentAPISwagger mhost = toAwesomeSwagger protectedStudentAPI &: do
     setSerokellDocMeta
 
     zoom S.info $ do
         S.title .= "Disciplina Student API"
         S.version .= "1.0.0"
 
-    S.host ?= "localhost:8090"
+    S.host .= fmap networkAddressToSwaggerHost mhost
     S.schemes ?= [Http, Https]
 
 -- | Write documentation to file, for testing purposes.
 -- Normally you can use "dscp-swagger" executable to build documentation.
 writeStudentAPISwagger :: FilePath -> IO ()
 writeStudentAPISwagger file =
-    liftIO $ LBS.writeFile file (encodeSwagger studentAPISwagger)
+    liftIO $ LBS.writeFile file (encodeSwagger $ studentAPISwagger demoAddr)
+  where
+    demoAddr = Just $ NetworkAddress "localhost" 8090

--- a/educator/src/Dscp/Educator/Web/Student/Swagger.hs
+++ b/educator/src/Dscp/Educator/Web/Student/Swagger.hs
@@ -8,6 +8,7 @@ import Control.Lens (zoom, (.=), (?=))
 import qualified Data.ByteString.Lazy as LBS
 import Data.Swagger (Scheme (..), Swagger)
 import qualified Data.Swagger as S
+import Data.Tagged (Tagged (..), untag)
 
 import Dscp.Educator.Web.Student.API
 import Dscp.Util
@@ -15,8 +16,8 @@ import Dscp.Web.Swagger
 import Dscp.Web.Types
 
 -- | Swagger documentation for Student API.
-studentAPISwagger :: Maybe NetworkAddress -> Swagger
-studentAPISwagger mhost = toAwesomeSwagger fullStudentAPI &: do
+studentAPISwagger :: Maybe NetworkAddress -> Tagged ProtectedStudentAPI Swagger
+studentAPISwagger mhost = Tagged $ toAwesomeSwagger fullStudentAPI &: do
     setSerokellDocMeta
 
     zoom S.info $ do
@@ -30,6 +31,6 @@ studentAPISwagger mhost = toAwesomeSwagger fullStudentAPI &: do
 -- Normally you can use "dscp-swagger" executable to build documentation.
 writeStudentAPISwagger :: FilePath -> IO ()
 writeStudentAPISwagger file =
-    liftIO $ LBS.writeFile file (encodeSwagger $ studentAPISwagger demoAddr)
+    liftIO $ LBS.writeFile file (encodeSwagger . untag $ studentAPISwagger demoAddr)
   where
     demoAddr = Just $ NetworkAddress "localhost" 8090

--- a/educator/src/Dscp/Educator/Web/Student/Swagger.hs
+++ b/educator/src/Dscp/Educator/Web/Student/Swagger.hs
@@ -16,7 +16,7 @@ import Dscp.Web.Types
 
 -- | Swagger documentation for Student API.
 studentAPISwagger :: Maybe NetworkAddress -> Swagger
-studentAPISwagger mhost = toAwesomeSwagger protectedStudentAPI &: do
+studentAPISwagger mhost = toAwesomeSwagger fullStudentAPI &: do
     setSerokellDocMeta
 
     zoom S.info $ do

--- a/educator/tests/Test/Dscp/Educator/Web/Educator/Swagger.hs
+++ b/educator/tests/Test/Dscp/Educator/Web/Educator/Swagger.hs
@@ -8,5 +8,5 @@ import Dscp.Web.Swagger
 
 spec_Educator_API_swagger :: Spec
 spec_Educator_API_swagger = do
-    it "Builds without errors" . once $ do
-        total $ encodeSwagger educatorAPISwagger
+    it "Builds without errors" . once $ \addr -> do
+        total $ encodeSwagger (educatorAPISwagger addr)

--- a/educator/tests/Test/Dscp/Educator/Web/Educator/Swagger.hs
+++ b/educator/tests/Test/Dscp/Educator/Web/Educator/Swagger.hs
@@ -1,5 +1,6 @@
 module Test.Dscp.Educator.Web.Educator.Swagger where
 
+import Data.Tagged (untag)
 import Test.QuickCheck (once, total)
 
 import Dscp.Educator.Web.Educator
@@ -9,4 +10,4 @@ import Dscp.Web.Swagger
 spec_Educator_API_swagger :: Spec
 spec_Educator_API_swagger = do
     it "Builds without errors" . once $ \addr -> do
-        total $ encodeSwagger (educatorAPISwagger addr)
+        total $ encodeSwagger $ untag (educatorAPISwagger addr)

--- a/educator/tests/Test/Dscp/Educator/Web/Student/Swagger.hs
+++ b/educator/tests/Test/Dscp/Educator/Web/Student/Swagger.hs
@@ -1,5 +1,6 @@
 module Test.Dscp.Educator.Web.Student.Swagger where
 
+import Data.Tagged (untag)
 import Test.QuickCheck (once, total)
 
 import Dscp.Educator.Web.Student
@@ -9,4 +10,4 @@ import Dscp.Web.Swagger
 spec_Student_API_swagger :: Spec
 spec_Student_API_swagger = do
     it "Builds without errors" . once $ \addr -> do
-        total $ encodeSwagger (studentAPISwagger addr)
+        total $ encodeSwagger $ untag (studentAPISwagger addr)

--- a/educator/tests/Test/Dscp/Educator/Web/Student/Swagger.hs
+++ b/educator/tests/Test/Dscp/Educator/Web/Student/Swagger.hs
@@ -8,5 +8,5 @@ import Dscp.Web.Swagger
 
 spec_Student_API_swagger :: Spec
 spec_Student_API_swagger = do
-    it "Builds without errors" . once $ do
-        total $ encodeSwagger studentAPISwagger
+    it "Builds without errors" . once $ \addr -> do
+        total $ encodeSwagger (studentAPISwagger addr)

--- a/multi-educator/package.yaml
+++ b/multi-educator/package.yaml
@@ -50,6 +50,8 @@ library:
     - singleton-bool
     - stm
     - sqlite-simple
+    - swagger2
+    - tagged
     - template-haskell
     - text
     - text-format

--- a/multi-educator/src/Dscp/MultiEducator/Launcher/Resource.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Launcher/Resource.hs
@@ -24,6 +24,7 @@ import qualified Dscp.Educator.Config as E
 import qualified Dscp.Educator.Launcher.Mode as E
 import Dscp.MultiEducator.Config
 import Dscp.Resource.Class (AllocResource (..), buildComponentR)
+import Dscp.MultiEducator.Types
 import Dscp.Resource.Network (NetServResources)
 import Dscp.Util.TimeLimit
 import Dscp.Util.HasLens
@@ -44,7 +45,7 @@ data MaybeLoadedEducatorContext
       -- | Educator context has been loaded.
     | FullyLoadedEducatorContext LoadedEducatorContext
 
-type EducatorContexts = Map Text MaybeLoadedEducatorContext
+type EducatorContexts = Map EducatorId MaybeLoadedEducatorContext
 
 -- | Contexts of every loaded educator.
 newtype EducatorContextsVar = EducatorContextsVar (TVar EducatorContexts)

--- a/multi-educator/src/Dscp/MultiEducator/Types.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Types.hs
@@ -1,0 +1,34 @@
+module Dscp.MultiEducator.Types
+    ( EducatorId (..)
+    ) where
+
+import Control.Lens ((.=))
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import qualified Data.Swagger as S
+import Fmt (build)
+import Servant (FromHttpApiData (..), ToHttpApiData (..))
+
+import Dscp.Util
+import Dscp.Web.Swagger
+
+-- | Educator id we receive from AAA service.
+newtype EducatorId = EducatorId Text
+    deriving (Show, Eq, Ord, IsString)
+
+instance Buildable EducatorId where
+    build (EducatorId eId) = "\"" <> build eId <> "\""
+
+deriving instance ToJSON EducatorId
+deriving instance FromJSON EducatorId
+
+instance ToHttpApiData EducatorId where
+    toUrlPiece (EducatorId eid) = eid
+
+instance FromHttpApiData EducatorId where
+    parseUrlPiece = pure . EducatorId
+
+type instance ParamDescription EducatorId = "Educator identifier."
+
+instance S.ToParamSchema EducatorId where
+    toParamSchema _ = mempty &: do
+        S.type_ .= S.SwaggerString

--- a/multi-educator/src/Dscp/MultiEducator/Web/Educator/API.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Web/Educator/API.hs
@@ -7,21 +7,31 @@ module Dscp.MultiEducator.Web.Educator.API
     ( CertificatesApiEndpoints (..)
     , CertificatesApiHandlers
     , CertificatesAPI
+    , FullCertificatesAPI
     , certificatesAPI
+    , fullCertificatesAPI
+    , ProtectedMultiEducatorAPI
     , MultiEducatorAPI
+    , protectedMultiEducatorAPI
     , multiEducatorAPI
     , MultiStudentAPI
+    , ProtectedMultiStudentAPI
+    , protectedMultiStudentAPI
     , multiStudentAPI
     ) where
 
 import Servant
 import Servant.Generic
+import Servant.Util (type ( #: ), ExceptionalResponses)
 
 import Dscp.Core.Foundation.Educator
 import Dscp.Educator.Web.Auth
 import Dscp.Educator.Web.Educator.API
+import Dscp.Educator.Web.Educator.Error
 import Dscp.Educator.Web.Student.API
+import Dscp.MultiEducator.Types
 import Dscp.MultiEducator.Web.Educator.Auth
+import Dscp.Web.Swagger.UI
 import Dscp.Witness.Web.ContentTypes
 
 ---------------------------------------------------------------------------
@@ -36,7 +46,11 @@ data CertificatesApiEndpoints route = CertificatesApiEndpoints
 type CertificatesApiHandlers m = CertificatesApiEndpoints (AsServerT m)
 
 type CertificatesAPI =
-    "api" :> "certificates" :> "v1" :> ToServant (CertificatesApiEndpoints AsApi)
+    ToServant (CertificatesApiEndpoints AsApi)
+
+type FullCertificatesAPI =
+    "api" :> "certificates" :> "v1" :>
+    WithSwaggerUI CertificatesAPI
 
 -- | Endpoint for getting a certificate by full ID.
 type GetCertificatePublic
@@ -46,17 +60,24 @@ type GetCertificatePublic
         \CertificateID is obtained as `base64url(\"<educator-UUID>:<certificate-hash>\")`, \
         \where `<educator-UUID>` is the UUID assigned by AAA microservice to Educator, \
         \and `<certificate-hash>` is a hash of certificate meta."
+    :> ExceptionalResponses EducatorAPIError
+       '[ 404 #: "Certificate with given ID not found."
+        ]
     :> Get '[PDF] PDFBody
 
 certificatesAPI :: Proxy CertificatesAPI
 certificatesAPI = Proxy
+
+fullCertificatesAPI :: Proxy FullCertificatesAPI
+fullCertificatesAPI = Proxy
 
 ---------------------------------------------------------------------------
 -- Educator API
 ---------------------------------------------------------------------------
 
 type MultiEducatorAPI =
-    "api" :> "educator" :> "v1" :> ProtectedMultiEducatorAPI
+    "api" :> "educator" :> "v1" :>
+    (WithSwaggerUI ProtectedMultiEducatorAPI)
 
 type ProtectedMultiEducatorAPI =
     Auth' '[MultiEducatorAuth, NoAuth "multi-educator"] EducatorAuthLogin :> RawEducatorAPI
@@ -64,11 +85,22 @@ type ProtectedMultiEducatorAPI =
 multiEducatorAPI :: Proxy MultiEducatorAPI
 multiEducatorAPI = Proxy
 
+protectedMultiEducatorAPI :: Proxy ProtectedMultiEducatorAPI
+protectedMultiEducatorAPI = Proxy
+
 ---------------------------------------------------------------------------
 -- Student API
 ---------------------------------------------------------------------------
 
-type MultiStudentAPI = Capture "educator" Text :> ProtectedStudentAPI
+type MultiStudentAPI =
+    "api" :> "student" :> "v1" :>
+    (WithSwaggerUI ProtectedMultiStudentAPI)
+
+type ProtectedMultiStudentAPI =
+    Capture "educator" EducatorId :> ProtectedStudentAPI
 
 multiStudentAPI :: Proxy MultiStudentAPI
 multiStudentAPI = Proxy
+
+protectedMultiStudentAPI :: Proxy ProtectedMultiStudentAPI
+protectedMultiStudentAPI = Proxy

--- a/multi-educator/src/Dscp/MultiEducator/Web/Educator/Auth.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Web/Educator/Auth.hs
@@ -26,6 +26,7 @@ import System.FilePath.Posix ((</>))
 
 import Dscp.Crypto
 import Dscp.Educator.Web.Auth
+import Dscp.MultiEducator.Types
 import Dscp.Util.FileEmbed
 
 import qualified Data.ByteArray as BA
@@ -35,7 +36,7 @@ import qualified Data.ByteArray as BA
 ---------------------------------------------------------------------------
 
 newtype EducatorAuthData = EducatorAuthData
-    { eadId :: Text
+    { eadId :: EducatorId
     } deriving (Show, Eq)
 
 deriveJSON defaultOptions ''EducatorAuthData
@@ -44,7 +45,7 @@ instance FromJWT EducatorAuthData
 instance ToJWT EducatorAuthData
 
 instance Buildable EducatorAuthData where
-    build (EducatorAuthData eId) = "\"" <> build eId <> "\""
+    build (EducatorAuthData eId) = build eId
 
 data EducatorAuthToken = EducatorAuthToken
     { eatData :: EducatorAuthData
@@ -121,7 +122,7 @@ multiEducatorAuthCheck (MultiEducatorPublicKey mpk) = do
     let ealData = eatData educatorAuthToken
     return $ EducatorAuthLogin {..}
 
-educatorAuthLoginSimple :: Text -> EducatorAuthLogin
+educatorAuthLoginSimple :: EducatorId -> EducatorAuthLogin
 educatorAuthLoginSimple eadId = EducatorAuthLogin {..}
   where
     ealData = EducatorAuthData {..}

--- a/multi-educator/src/Dscp/MultiEducator/Web/Educator/Handlers.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Web/Educator/Handlers.hs
@@ -8,6 +8,7 @@ import Dscp.Core.Foundation.Educator
 import Dscp.DB.SQL
 import Dscp.Educator.Web.Educator
 import Dscp.MultiEducator.Launcher.Mode
+import Dscp.MultiEducator.Types
 import Dscp.MultiEducator.Web.Educator.API
 
 certificatesApiHandlers
@@ -15,6 +16,6 @@ certificatesApiHandlers
     => CertificatesApiHandlers m
 certificatesApiHandlers = CertificatesApiEndpoints
     { cGetCertificate = \(CertificateName eId cId) -> invoke $ do
-            setConnSchemaName $ educatorSchemaName eId
+            setConnSchemaName $ educatorSchemaName (EducatorId eId)
             educatorGetCertificate cId
     }

--- a/multi-educator/src/Dscp/MultiEducator/Web/Swagger.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Web/Swagger.hs
@@ -1,0 +1,58 @@
+-- | Swagger documentation of multi-educator APIs.
+module Dscp.MultiEducator.Web.Swagger
+    ( multiStudentAPISwagger
+    , multiEducatorAPISwagger
+    , certificatesAPISwagger
+    ) where
+
+import Control.Lens (zoom, (.=), (?=))
+import Data.Swagger (Scheme (..), Swagger)
+import qualified Data.Swagger as S
+import Data.Tagged (Tagged (..))
+
+import Dscp.MultiEducator.Web.Educator.API
+import Dscp.Util
+import Dscp.Web.Swagger
+import Dscp.Web.Types
+
+-- | Swagger documentation for Student API of multi-educator.
+multiEducatorAPISwagger
+    :: Maybe NetworkAddress
+    -> Tagged ProtectedMultiEducatorAPI Swagger
+multiEducatorAPISwagger mhost = Tagged $ toAwesomeSwagger multiEducatorAPI &: do
+    setSerokellDocMeta
+
+    zoom S.info $ do
+        S.title .= "Disciplina Multi-educator API"
+        S.version .= "1.0.0"
+
+    S.host .= fmap networkAddressToSwaggerHost mhost
+    S.schemes ?= [Http, Https]
+
+-- | Swagger documentation for Student API of multi-educator.
+multiStudentAPISwagger
+    :: Maybe NetworkAddress
+    -> Tagged ProtectedMultiStudentAPI Swagger
+multiStudentAPISwagger mhost = Tagged $ toAwesomeSwagger multiStudentAPI &: do
+    setSerokellDocMeta
+
+    zoom S.info $ do
+        S.title .= "Disciplina Multi-educator Student API"
+        S.version .= "1.0.0"
+
+    S.host .= fmap networkAddressToSwaggerHost mhost
+    S.schemes ?= [Http, Https]
+
+-- | Swagger documentation for Student API of multi-educator.
+certificatesAPISwagger
+    :: Maybe NetworkAddress
+    -> Tagged CertificatesAPI Swagger
+certificatesAPISwagger mhost = Tagged $ toAwesomeSwagger fullCertificatesAPI &: do
+    setSerokellDocMeta
+
+    zoom S.info $ do
+        S.title .= "Disciplina Certificates API"
+        S.version .= "1.0.0"
+
+    S.host .= fmap networkAddressToSwaggerHost mhost
+    S.schemes ?= [Http, Https]

--- a/stack.yaml
+++ b/stack.yaml
@@ -39,7 +39,7 @@ extra-deps:
 
 
 - git: https://github.com/serokell/servant-util.git
-  commit: cad493edb135adf10c76945ad61a74c42c40c883
+  commit: 54a8af9f82055a4cc45ad85eb4094ecbe77d249e
   subdirs:
     - servant-util
     - servant-util-beam-pg

--- a/tools/package.yaml
+++ b/tools/package.yaml
@@ -71,9 +71,13 @@ executables:
     source-dirs: src/swagger
     dependencies:
       - bytestring
+      - containers
+      - data-default
       - disciplina-core
       - disciplina-witness
       - disciplina-educator
+      - disciplina-multi-educator
       - optparse-applicative
       - swagger2
+      - tagged
       - text

--- a/tools/src/swagger/Main.hs
+++ b/tools/src/swagger/Main.hs
@@ -1,7 +1,6 @@
 import SwaggerOptions
 
 import qualified Data.ByteString.Lazy as LBS
-import qualified Data.Swagger as S
 import Options.Applicative (execParser, fullDesc, helper, info, progDesc)
 
 import Dscp.CommonCLI
@@ -12,17 +11,13 @@ import Dscp.Web.Swagger
 main :: IO ()
 main = do
     options <- getSwaggerOptions
+    let mhost = soHost options
 
     let swagger = case soSwaggerAPI options of
-            StudentAPI  -> studentAPISwagger
-            EducatorAPI -> educatorAPISwagger
+            StudentAPI  -> studentAPISwagger mhost
+            EducatorAPI -> educatorAPISwagger mhost
 
-    let modSwagger = case soHost options of
-            Nothing   -> id
-            Just host -> S.host .~ Just (fromString host)
-
-    let swagger' = modSwagger swagger
-    let encoded = encodeSwagger swagger'
+    let encoded = encodeSwagger swagger
 
     case soOutput options of
         Nothing     -> LBS.hPut stdout encoded

--- a/tools/src/swagger/Main.hs
+++ b/tools/src/swagger/Main.hs
@@ -1,11 +1,13 @@
 import SwaggerOptions
 
 import qualified Data.ByteString.Lazy as LBS
+import Data.Tagged (untag)
 import Options.Applicative (execParser, fullDesc, helper, info, progDesc)
 
 import Dscp.CommonCLI
 import Dscp.Educator.Web.Educator.Swagger
 import Dscp.Educator.Web.Student.Swagger
+import Dscp.MultiEducator.Web.Swagger
 import Dscp.Web.Swagger
 
 main :: IO ()
@@ -14,8 +16,11 @@ main = do
     let mhost = soHost options
 
     let swagger = case soSwaggerAPI options of
-            StudentAPI  -> studentAPISwagger mhost
-            EducatorAPI -> educatorAPISwagger mhost
+            EducatorAPI      -> untag $ educatorAPISwagger mhost
+            StudentAPI       -> untag $ studentAPISwagger mhost
+            MultiEducatorAPI -> untag $ multiEducatorAPISwagger mhost
+            MultiStudentAPI  -> untag $ multiStudentAPISwagger mhost
+            CertificatesAPI  -> untag $ certificatesAPISwagger mhost
 
     let encoded = encodeSwagger swagger
 

--- a/tools/src/swagger/SwaggerOptions.hs
+++ b/tools/src/swagger/SwaggerOptions.hs
@@ -6,10 +6,13 @@ module SwaggerOptions
        , swaggerOptionsParser
        ) where
 
+import Data.Default (Default)
+import qualified Data.Map as M
 import qualified Data.Text as T
 import Options.Applicative (Parser, ReadM, eitherReader, help, long, metavar, option, short,
                             strOption)
 
+import Dscp.Util
 import Dscp.Util.Constructors
 import Dscp.Web.Types
 
@@ -17,22 +20,31 @@ import Dscp.Web.Types
 data SwaggerAPI
     = StudentAPI
     | EducatorAPI
+    | MultiEducatorAPI
+    | MultiStudentAPI
+    | CertificatesAPI
     deriving (Generic)
+
+allSwaggerAPIs :: Map Text SwaggerAPI
+allSwaggerAPIs =
+    M.fromList . map (apiName &&& id) $ enlistConstructors @Default
+  where
+    apiName = \case
+        StudentAPI -> "student"
+        EducatorAPI -> "educator"
+        MultiEducatorAPI -> "multi-educator"
+        MultiStudentAPI -> "multi-student"
+        CertificatesAPI -> "certificates"
 
 -- | APIs names, should correspond to 'swaggerAPIReadM'.
 swaggerAPINames :: Text
-swaggerAPINames =
-    T.intercalate ", " $ map show $
-    enlistConstructors @UnsafeFiller <&> \case
-        StudentAPI -> "student" :: Text
-        EducatorAPI -> "educator"
+swaggerAPINames = T.intercalate ", " . map show $ M.keys allSwaggerAPIs
 
 swaggerAPIReadM :: ReadM SwaggerAPI
-swaggerAPIReadM = eitherReader $ \case
-    "student" -> Right StudentAPI
-    "educator" -> Right EducatorAPI
-    other -> Left $ "Unknown API name " <> show other <> ", " <>
-                    "allowed values: " <> toString swaggerAPINames
+swaggerAPIReadM = eitherReader $ \name ->
+    M.lookup (toText name) allSwaggerAPIs
+        & nothingToFail ("Unknown API name " <> show name <> ", " <>
+                         "allowed values: " <> swaggerAPINames)
 
 data SwaggerOptions = SwaggerOptions
     { soSwaggerAPI :: SwaggerAPI

--- a/tools/src/swagger/SwaggerOptions.hs
+++ b/tools/src/swagger/SwaggerOptions.hs
@@ -11,6 +11,7 @@ import Options.Applicative (Parser, ReadM, eitherReader, help, long, metavar, op
                             strOption)
 
 import Dscp.Util.Constructors
+import Dscp.Web.Types
 
 -- | All our APIs.
 data SwaggerAPI
@@ -36,7 +37,7 @@ swaggerAPIReadM = eitherReader $ \case
 data SwaggerOptions = SwaggerOptions
     { soSwaggerAPI :: SwaggerAPI
     , soOutput     :: Maybe FilePath
-    , soHost       :: Maybe String
+    , soHost       :: Maybe NetworkAddress
     }
 
 swaggerOptionsParser :: Parser SwaggerOptions
@@ -54,9 +55,9 @@ swaggerOptionsParser = do
         , help "Print the swagger specification to the given file. \
                \If not specified, the specification will be printed to stdout"
         ]
-    soHost <- optional . strOption $ mconcat
+    soHost <- optional . option (eitherReader parseNetAddr) $ mconcat
         [ long "host"
-        , metavar "ADDR:PORT"
+        , metavar "HOST:PORT"
         , help "Override the default value for 'host' field. \
                \Useful when documenation is going to be served in Swagger UI \
                \and requests via it should refer to a given server."

--- a/witness/package.yaml
+++ b/witness/package.yaml
@@ -66,6 +66,7 @@ library:
     - snowdrop-execution
     - snowdrop-util
     - stm
+    - tagged
     - template-haskell
     - text
     - text-format

--- a/witness/package.yaml
+++ b/witness/package.yaml
@@ -57,6 +57,7 @@ library:
     - servant-server
     - servant-generic
     - servant-swagger
+    - servant-swagger-ui
     - servant-util
     - swagger2
     - serokell-util

--- a/witness/src/Dscp/Web/Swagger/Generation/Global.hs
+++ b/witness/src/Dscp/Web/Swagger/Generation/Global.hs
@@ -12,8 +12,8 @@ import Data.Aeson.Encoding (encodingToLazyByteString)
 import Data.Swagger (Swagger, URL (..))
 import qualified Data.Swagger as S
 import GHC.TypeLits (AppendSymbol, KnownSymbol, Symbol)
-import Servant ((:<|>), (:>), Capture', Description, NoContent, QueryFlag, QueryParam', StdMethod,
-                Verb)
+import Servant ((:<|>), (:>), Capture', Description, NoContent, QueryFlag, QueryParam', Raw,
+                StdMethod, Verb)
 import Servant.Swagger (HasSwagger (..))
 
 import Dscp.Util
@@ -93,6 +93,8 @@ type family SwaggerrizeApi api where
 
     SwaggerrizeApi (Verb (method :: StdMethod) (code :: Nat) ctx a) =
         Verb method code ctx a
+
+    SwaggerrizeApi Raw = Raw
 
 -- | Apply some beautiness to automatically generated spec.
 swaggerPostfixes :: Swagger -> Swagger

--- a/witness/src/Dscp/Web/Swagger/Generation/Global.hs
+++ b/witness/src/Dscp/Web/Swagger/Generation/Global.hs
@@ -1,6 +1,7 @@
 -- | Top-level swagger entries and global transformations.
 module Dscp.Web.Swagger.Generation.Global
-    ( toAwesomeSwagger
+    ( networkAddressToSwaggerHost
+    , toAwesomeSwagger
     , setSerokellDocMeta
     , encodeSwagger
     ) where
@@ -17,8 +18,16 @@ import Servant.Swagger (HasSwagger (..))
 
 import Dscp.Util
 import Dscp.Web.Swagger.Generation.Class
+import Dscp.Web.Types
 
 makePrisms ''S.Referenced
+
+networkAddressToSwaggerHost :: NetworkAddress -> S.Host
+networkAddressToSwaggerHost addr =
+    S.Host
+    { S._hostName = toString $ naHost addr
+    , S._hostPort = Just . fromIntegral $ naPort addr
+    }
 
 -- | Apply all meta info which is fixed for this project.
 setSerokellDocMeta :: State Swagger ()

--- a/witness/src/Dscp/Web/Swagger/Instances/Core.hs
+++ b/witness/src/Dscp/Web/Swagger/Instances/Core.hs
@@ -50,6 +50,8 @@ type instance ParamDescription (DocumentType Submission) =
 type instance ParamDescription SubmissionWitness =
     "Concatenated student public key and submission hash signed with \
     \student secret key."
+type instance ParamDescription CertificateName =
+    "Full certificate ID"
 
 ----------------------------------------------------------------------------
 -- ToParamSchema instances
@@ -142,6 +144,12 @@ instance ToSchema (EmptyMerkleProof PrivateTx) where
 
 instance ToSchema PrivateTx where
     declareNamedSchema _ = declareNamedSchema (Proxy @Text)
+
+instance S.ToParamSchema CertificateName where
+    toParamSchema _ = mempty &: do
+        S.type_ .= S.SwaggerString
+        S.format ?= "base64url"
+        S.pattern ?= ".pdf$"
 
 ----------------------------------------------------------------------------
 -- Error description

--- a/witness/src/Dscp/Web/Swagger/UI.hs
+++ b/witness/src/Dscp/Web/Swagger/UI.hs
@@ -8,6 +8,7 @@ module Dscp.Web.Swagger.UI
 import Control.Lens ((.=), (?=))
 import qualified Data.Swagger as S
 import qualified Data.Swagger.Internal.Schema as S
+import Data.Tagged (Tagged (..))
 import Servant ((:<|>) (..), (:>), Server)
 import Servant.Swagger.UI (SwaggerSchemaUI, SwaggerUiHtml, swaggerSchemaUIServer)
 import Servant.Util (Tag)
@@ -23,8 +24,13 @@ type SwaggerUI =
 type WithSwaggerUI api = api :<|> SwaggerUI
 
 -- | Attach a UI serving given documentation to the given server.
-withSwaggerUI :: S.Swagger -> Proxy api -> Server api -> Server (WithSwaggerUI api)
-withSwaggerUI swagger _ server = server :<|> swaggerSchemaUIServer swagger
+withSwaggerUI
+    :: Proxy api
+    -> Tagged api S.Swagger
+    -> Server api
+    -> Server (WithSwaggerUI api)
+withSwaggerUI _ (Tagged swagger) server =
+    server :<|> swaggerSchemaUIServer swagger
 
 ----------------------------------------------------------------------------
 -- Instances

--- a/witness/src/Dscp/Web/Swagger/UI.hs
+++ b/witness/src/Dscp/Web/Swagger/UI.hs
@@ -1,0 +1,44 @@
+-- | Serving swagger UI.
+module Dscp.Web.Swagger.UI
+    ( SwaggerUI
+    , WithSwaggerUI
+    , withSwaggerUI
+    ) where
+
+import Control.Lens ((.=), (?=))
+import qualified Data.Swagger as S
+import qualified Data.Swagger.Internal.Schema as S
+import Servant ((:<|>) (..), (:>), Server)
+import Servant.Swagger.UI (SwaggerSchemaUI, SwaggerUiHtml, swaggerSchemaUIServer)
+import Servant.Util (Tag)
+
+import Dscp.Util
+
+-- | Swagger UI we use across the project.
+type SwaggerUI =
+    Tag "Documentation" :>
+    SwaggerSchemaUI "docs" "swagger.json"
+
+-- | Attach a swagger UI to the given API.
+type WithSwaggerUI api = api :<|> SwaggerUI
+
+-- | Attach a UI serving given documentation to the given server.
+withSwaggerUI :: S.Swagger -> Proxy api -> Server api -> Server (WithSwaggerUI api)
+withSwaggerUI swagger _ server = server :<|> swaggerSchemaUIServer swagger
+
+----------------------------------------------------------------------------
+-- Instances
+----------------------------------------------------------------------------
+
+instance S.ToSchema (SwaggerUiHtml dir api) where
+    declareNamedSchema _ =
+        S.plain $ mempty &: do
+            S.type_ .= S.SwaggerNull
+            S.title ?= "Swagger UI page"
+
+instance S.ToSchema S.Swagger where
+    declareNamedSchema _ =
+        S.plain $ mempty &: do
+            S.type_ .= S.SwaggerObject
+            S.title ?= "Swagger specification"
+            S.description ?= "The specification you are currently reading."

--- a/witness/src/Dscp/Web/Types.hs
+++ b/witness/src/Dscp/Web/Types.hs
@@ -35,6 +35,9 @@ instance Buildable NetworkAddress where
 instance Show NetworkAddress where
     show = toString . pretty
 
+instance Arbitrary NetworkAddress where
+    arbitrary = NetworkAddress <$> arbitrary <*> arbitrary
+
 ---------------------------------------------------------------------------
 -- Util functions for working with web types
 ---------------------------------------------------------------------------


### PR DESCRIPTION
### Description

Serve swagger UI next to our main endpoints.
I also had to add swagger generation to multi-educator and slightly rearrange API types and server implementations.
Finally, I bumped the version of `servant-util` so sorting has to be updated.

### YT issue

https://issues.serokell.io/issue/DSCP-473

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
