### PR TITLE
[DSCP-495] Remove limit in `checkFairCVPDF`

### DIFF
--- a/witness/src/Dscp/Witness/Web/Logic.hs
+++ b/witness/src/Dscp/Witness/Web/Logic.hs
@@ -246,7 +246,7 @@ checkFairCVPDF
     => Pdf.PDFBody -> m FairCVAndCheckResult
 checkFairCVPDF pdf = do
     let maybeFairCV = do
-            fairCVencoded <- Pdf.project (Pdf.MaxSearchLength (Just 2048)) pdf
+            fairCVencoded <- Pdf.project (Pdf.MaxSearchLength Nothing) pdf
             Aeson.decodeStrict fairCVencoded
 
     fairCV   <- maybe (throwM InvalidFormat) pure maybeFairCV


### PR DESCRIPTION
### Description

With the current one we cannot even verify certificates with just 3 grades.
Sane limits are to be set in DSCP-495 later.

### YT issue

https://issues.serokell.io/issue/DSCP-495

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
