### PR TITLE
[DSCP-481] Forbid catching exceptions in DBT

### DIFF
--- a/core/src/Dscp/Util/Rethrow.hs
+++ b/core/src/Dscp/Util/Rethrow.hs
@@ -1,0 +1,108 @@
+module Dscp.Util.Rethrow
+    ( MonadRethrow (..)
+    , rethrow
+    , rethrowJust
+    , UseMonadRethrow
+
+      -- * Testing
+    , ExpectedException (..)
+    , expectRethrowing
+    , expectAnyRethrowing
+    , expectJustRethrowing
+    , expectPrismRethrowing
+    , throwsOnlyExpected
+    ) where
+
+import Control.Lens (LensLike')
+import GHC.TypeLits (ErrorMessage (..), TypeError)
+import Test.QuickCheck (Property, Testable, property)
+
+-- | Allows to map thrown exceptions.
+-- Suitable when defining `MonadCatch` is undesired.
+class MonadThrow m => MonadRethrow m where
+    -- | A version of 'catch' which cannot completely handle exceptions,
+    -- it has to throw them further.
+    -- Asynchronous exceptions are passed.
+    catchHot :: Exception e => m a -> (e -> m Void) -> m a
+
+    default catchHot :: (MonadCatch m, Exception e) => m a -> (e -> m Void) -> m a
+    catchHot action handler = catch action (vacuous . handler)
+    {-# NOINLINE catchHot #-}
+
+instance MonadRethrow IO
+instance MonadCatch m => MonadRethrow (ReaderT r m)
+
+-- | Catches synchronous errors, maps them and throws further.
+rethrow
+    :: (MonadRethrow m, Exception e1, Exception e2)
+    => (e1 -> e2) -> m a -> m a
+rethrow wrap action = catchHot action (throwM . wrap)
+
+-- | Maps exceptions; those for which mapping fails are passed.
+rethrowJust
+    :: (MonadRethrow m, Exception e1, Exception e2)
+    => (e1 -> Maybe e2) -> m a -> m a
+rethrowJust wrap action =
+    catchHot action (\e -> maybe (throwM e) throwM (wrap e))
+
+-- | Useful for `MonadCatch` implementation.
+type family UseMonadRethrow m :: Constraint where
+    UseMonadRethrow m =
+        ( MonadThrow m
+        , TypeError
+            ('Text "Using MonadCatch instance is not allowed here" ':$$:
+             'Text "Consider using `rethrow` function instead")
+        )
+
+----------------------------------------------------------------------------
+-- Testing
+----------------------------------------------------------------------------
+
+-- | Sometimes in test case you want to check that a proper exception is
+-- thrown but you have only @MonadRethrow m@ context.
+-- In this case you can rethrow 'ExpectedException' and match against it later.
+data ExpectedException = ExpectedException
+    deriving (Show)
+
+instance Exception ExpectedException
+
+-- | When you expect an exception but it does not happen, you can throw this
+-- thing.
+data UnexpectedlyNoException = UnexpectedlyNoException
+    deriving (Show)
+
+instance Exception UnexpectedlyNoException
+
+-- | Expect that only the given exception is thrown.
+expectRethrowing
+    :: forall e m a.
+       (MonadRethrow m, Exception e)
+    => m a -> m Void
+expectRethrowing action =
+    rethrow (\(_ :: e) -> ExpectedException) action
+    *> throwM UnexpectedlyNoException
+
+-- | Expect that any synchronous exception is thrown.
+expectAnyRethrowing
+    :: MonadRethrow m
+    => m a -> m Void
+expectAnyRethrowing = expectRethrowing @SomeException
+
+-- | Expect that an exception returning 'Just' on the given predicate is thrown.
+expectJustRethrowing
+    :: (MonadRethrow m, Exception e)
+    => (e -> Maybe e') -> m a -> m Void
+expectJustRethrowing match action =
+    rethrowJust (\e -> match e $> ExpectedException) action
+    *> throwM UnexpectedlyNoException
+
+-- | Expect that exception matching the given prism is thrown.
+expectPrismRethrowing
+    :: (MonadRethrow m, Exception e)
+    => LensLike' (Const $ First e') e e' -> m a -> m Void
+expectPrismRethrowing pri = expectJustRethrowing (^? pri)
+
+-- | Fail only when an exception is thrown, and that's not 'ExpectedException'.
+throwsOnlyExpected :: (MonadCatch m, Testable prop) => m prop -> m Property
+throwsOnlyExpected action =
+    catch (property <$> action) $ \ExpectedException -> return $ property ()

--- a/core/src/Dscp/Util/Test.hs
+++ b/core/src/Dscp/Util/Test.hs
@@ -209,6 +209,9 @@ withProbability p action = do
 withProbability_ :: Monad m => Rational -> PropertyM m a -> PropertyM m ()
 withProbability_ = void ... withProbability
 
+instance Testable Void where
+    property = absurd
+
 ----------------------------------------------------------------------------
 -- CLI interface testing
 ----------------------------------------------------------------------------

--- a/educator/src/Dscp/Educator/Web/Bot/Setting.hs
+++ b/educator/src/Dscp/Educator/Web/Bot/Setting.hs
@@ -223,8 +223,8 @@ botNoteCompletedAssignments student course completedAssigns =
       \courseAssigns ->
         forM_ courseAssigns $ \(WithDependencies assign deps) ->
             when (deps `S.isSubsetOf` completedAssigns) $
-                transact $
                 maybePresent $
+                transact $
                 setStudentAssignment student (getId assign)
 
 -- | Helper to invoke 'botNoteCompletedAssignments', accepts

--- a/educator/tests/Test/Dscp/DB/SQL/Queries.hs
+++ b/educator/tests/Test/Dscp/DB/SQL/Queries.hs
@@ -12,6 +12,7 @@ import Dscp.Core.Arbitrary
 -- import qualified Dscp.Crypto.MerkleTree as MerkleTree
 import Dscp.Educator.DB as DB
 import Dscp.Util
+import Dscp.Util.Rethrow
 
 import Test.Dscp.DB.SQL.Mode
 import Test.Dscp.Educator.Mode
@@ -62,14 +63,14 @@ spec_Instances = specWithTempPostgresServer $ do
 
             it "Assignment is not created if course does not exist" $
                 sqlProperty $ \(assignment) -> do
-                    throws @DomainError $ do
+                    expectRethrowing @DomainError $ do
                         _ <- DB.createAssignment assignment
                         return ()
 
         describe "Submissions" $ do
             it "Submission is not created unless Assignment exist" $
                 sqlProperty $ \submission -> do
-                    throws @DomainError $ do
+                    expectRethrowing @DomainError $ do
                         _ <- DB.createSignedSubmission submission
                         return ()
 
@@ -85,7 +86,7 @@ spec_Instances = specWithTempPostgresServer $ do
                     _ <- DB.createCourse           (simpleCourse course)
                     _ <- DB.createAssignment       assignment
 
-                    throws @DomainError $ do
+                    expectRethrowing @DomainError $ do
                         _ <- DB.createSignedSubmission sigSubmission
                         return ()
 
@@ -96,7 +97,7 @@ spec_Instances = specWithTempPostgresServer $ do
                     let assignment    = tiOne $ cteAssignments env
                         sigSubmission = tiOne $ cteSignedSubmissions env
 
-                    throws @DomainError $ do
+                    expectRethrowing @DomainError $ do
                         let submission = sigSubmission^.ssSubmission
                             course     = assignment^.aCourseId
                             student    = submission^.sStudentId

--- a/educator/tests/Test/Dscp/Educator/Mode.hs
+++ b/educator/tests/Test/Dscp/Educator/Mode.hs
@@ -38,6 +38,7 @@ import Dscp.Resource.Keys
 import Dscp.Rio
 import Dscp.Util
 import Dscp.Util.HasLens
+import Dscp.Util.Rethrow
 import Dscp.Util.Test
 import Dscp.Witness
 
@@ -146,13 +147,14 @@ sqlProperty
     :: (Testable prop, Show a, Arbitrary a)
     => (a -> DBT t TestEducatorM prop) -> PostgresTestServer -> Property
 sqlProperty action =
-    educatorProperty (invokeUnsafe . action)
+    educatorProperty (throwsOnlyExpected . invokeUnsafe . action)
 
 sqlPropertyM
     :: Testable prop
     => PropertyM (DBT t TestEducatorM) prop -> PostgresTestServer -> Property
 sqlPropertyM action testDb =
-    monadic (ioProperty . runTestSqlM testDb . invokeUnsafe) (void $ action >>= stop)
+    monadic (ioProperty . runTestSqlM testDb . throwsOnlyExpected . invokeUnsafe)
+            (void $ action >>= stop)
 
 orIfItFails :: MonadCatch m => m a -> a -> m a
 orIfItFails action instead = do

--- a/educator/tests/Test/Dscp/Educator/Web/Educator/Queries.hs
+++ b/educator/tests/Test/Dscp/Educator/Web/Educator/Queries.hs
@@ -11,6 +11,7 @@ import Dscp.Educator.Web.Educator
 import Dscp.Educator.Web.Logic
 import Dscp.Educator.Web.Types
 import Dscp.Util
+import Dscp.Util.Rethrow
 import Dscp.Util.Test
 
 import Test.Dscp.DB.SQL.Mode
@@ -88,7 +89,7 @@ spec_Educator_API_queries = specWithTempPostgresServer $ do
             env <- pickSmall $ genCoreTestEnv simpleCoreTestParams
             let course = tiOne $ cteCourses env
 
-            lift . throwsPrism (_AbsentError . _CourseDomain) $
+            lift . expectPrismRethrowing (_AbsentError . _CourseDomain) $
                 educatorGetCourse (getId course)
 
         it "Returns existing course properly" $ sqlPropertyM $ do
@@ -135,7 +136,7 @@ spec_Educator_API_queries = specWithTempPostgresServer $ do
 
             _ <- lift $ createStudent student
 
-            lift . throwsPrism (_AbsentError . _SubmissionDomain) $
+            lift . expectPrismRethrowing (_AbsentError . _SubmissionDomain) $
                 educatorGetSubmission (getId submission)
 
         it "Returns existing submission properly" $ sqlPropertyM $ do

--- a/educator/tests/Test/Dscp/Educator/Web/Student/Queries.hs
+++ b/educator/tests/Test/Dscp/Educator/Web/Student/Queries.hs
@@ -16,6 +16,7 @@ import Dscp.Educator.Web.Queries
 import Dscp.Educator.Web.Student
 import Dscp.Educator.Web.Types
 import Dscp.Util
+import Dscp.Util.Rethrow
 import Dscp.Util.Test
 
 import Test.Dscp.DB.SQL.Mode
@@ -270,7 +271,7 @@ spec_Student_API_queries = specWithTempPostgresServer $ do
     describe "getAssignment" $ do
         it "Fails on request of non-existent assignment" $
             sqlProperty $ \() ->
-                throwsPrism (_AbsentError . _AssignmentDomain) $ do
+                expectPrismRethrowing (_AbsentError . _AssignmentDomain) $ do
                     _ <- createStudent student1
                     studentGetAssignment student1 (hash assignment1)
 
@@ -282,7 +283,7 @@ spec_Student_API_queries = specWithTempPostgresServer $ do
                 _ <- createStudent student1
                 _ <- createCourse $ simpleCourse course
                 _ <- createAssignment assignment
-                throwsPrism (_AbsentError . _AssignmentDomain) $
+                expectPrismRethrowing (_AbsentError . _AssignmentDomain) $
                     studentGetAssignment student1 (hash assignment1)
 
         it "Returns existing assignment properly" $
@@ -315,7 +316,7 @@ spec_Student_API_queries = specWithTempPostgresServer $ do
                 _ <- createAssignment assignment
                 _ <- enrollStudentToCourse student1 course
                 _ <- setStudentAssignment student1 (hash assignment)
-                throwsPrism (_AbsentError . _AssignmentDomain) $
+                expectPrismRethrowing (_AbsentError . _AssignmentDomain) $
                     studentGetAssignment student1 (getId needlessAssignment)
 
     describe "getAssignments" $ do
@@ -454,7 +455,7 @@ spec_Student_API_queries = specWithTempPostgresServer $ do
                     _ <- setStudentAssignment owner (hash assignment)
                     _ <- submitAssignment sigSub
                     return ()
-                lift . fmap property $ throwsPrism (_AbsentError . _SubmissionDomain) $
+                lift . fmap property $ expectPrismRethrowing (_AbsentError . _SubmissionDomain) $
                     studentGetSubmission user (getId submission)
 
     describe "getSubmissions" $ do
@@ -482,7 +483,7 @@ spec_Student_API_queries = specWithTempPostgresServer $ do
         it "Deletion of non-existing submission throws" $
             sqlProperty $ \submission -> do
                 _ <- createStudent student1
-                throwsPrism (_AbsentError . _SubmissionDomain) $
+                expectPrismRethrowing (_AbsentError . _SubmissionDomain) $
                     commonDeleteSubmission (hash submission) (Just student1)
 
         it "Delete works" $
@@ -515,7 +516,7 @@ spec_Student_API_queries = specWithTempPostgresServer $ do
                 _ <- createTransaction $
                      PrivateTx sigSub gA someTime
 
-                throwsPrism (_SemanticError . _DeletingGradedSubmission) $
+                expectPrismRethrowing (_SemanticError . _DeletingGradedSubmission) $
                      commonDeleteSubmission (hash sub) (Just student)
 
         it "Can not delete other student's submission" $
@@ -532,7 +533,7 @@ spec_Student_API_queries = specWithTempPostgresServer $ do
                 else do
                     prepareAndCreateSubmission env
 
-                    fmap property . throwsPrism (_AbsentError . _SubmissionDomain) $
+                    fmap property . expectPrismRethrowing (_AbsentError . _SubmissionDomain) $
                         commonDeleteSubmission (hash sub) (Just otherStudent)
 
     describe "makeSubmission" $ do
@@ -544,7 +545,7 @@ spec_Student_API_queries = specWithTempPostgresServer $ do
 
                 prepareForSubmissions env
                 void $ submitAssignment sigSub
-                throwsPrism (_AlreadyPresentError . _SubmissionDomain) $
+                expectPrismRethrowing (_AlreadyPresentError . _SubmissionDomain) $
                     void $ submitAssignment sigSub
 
         it "Making submission works" $


### PR DESCRIPTION
### Description

Otherwise one can accidentially continue doing SQL operations, but when
an error comes from SQL engine further operations are prohibited until the end
of transaction.

I forbidded using `MonadCatch` instance in `DBT` monad and added `MonadRethrow`
typeclass instead which allows only mapping thrown exceptions.

Also, caught one my bug :)

### YT issue

https://issues.serokell.io/issue/DSCP-481

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
