### PR TITLE
[DSCP-494] Educator unload on timeout

### DIFF
--- a/core/src/Dscp/Rio.hs
+++ b/core/src/Dscp/Rio.hs
@@ -6,6 +6,7 @@ module Dscp.Rio
     ) where
 
 import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
+import Control.Monad.Fix (MonadFix)
 import Loot.Base.HasLens (HasLens (..))
 import Loot.Log (ModifyLogName (..), MonadLogging (..))
 import Loot.Log.Rio (LoggingIO)
@@ -24,7 +25,7 @@ This also allows us to remorselessly define one global
 -}
 newtype RIO ctx a = RIO { unRIO :: ReaderT ctx IO a }
     deriving (Functor, Applicative, Monad, MonadIO, MonadReader ctx,
-              MonadThrow, MonadCatch, MonadMask, MonadUnliftIO)
+              MonadThrow, MonadCatch, MonadMask, MonadUnliftIO, MonadFix)
 
 runRIO :: MonadIO m => ctx -> RIO ctx a -> m a
 runRIO ctx (RIO act) = liftIO $ runReaderT act ctx

--- a/core/src/Dscp/Util/Time.hs
+++ b/core/src/Dscp/Util/Time.hs
@@ -1,8 +1,11 @@
 -- | Time primitives with emulation support.
 
 module Dscp.Util.Time
-    ( -- * Cababilities
-      TimeActions
+    ( infiniteFuture
+    , timeDiffNonNegative
+
+      -- * Cababilities
+    , TimeActions
     , TestTimeActions
     , HasTime
     , HasTestTime
@@ -21,7 +24,27 @@ import Control.Exception (BlockedIndefinitelyOnSTM (..))
 import Control.Exception.Safe (handle)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Loot.Base.HasLens (HasCtx, HasLens', lensOf)
-import Time (KnownRat, Second, Time, Timestamp (..), fromUnixTime, threadDelay, timeAdd, toUnit)
+import Time (KnownRat, Second, Time, Timestamp (..), fromUnixTime, threadDelay, timeAdd, timeDiff,
+             toUnit)
+
+----------------------------------------------------------------------------
+-- Helpers
+----------------------------------------------------------------------------
+
+-- | Moment of time which will never happen, in theory.
+infiniteFuture :: Timestamp
+infiniteFuture = fromUnixTime @Int 4260211200  -- 1 Jan 2105
+
+-- | Substruct timestamps, returning 0 if result is negative.
+timeDiffNonNegative :: Timestamp -> Timestamp -> Time Second
+timeDiffNonNegative t1 t2 =
+    case timeDiff t1 t2 of
+        (GT, d) -> d
+        _       -> 0
+
+----------------------------------------------------------------------------
+-- Capabilities
+----------------------------------------------------------------------------
 
 -- | Basic timing actions.
 data TimeActions = TimeActions

--- a/docs/config-full-sample.yaml
+++ b/docs/config-full-sample.yaml
@@ -235,6 +235,9 @@ sample:
       # Public key of the microservice, used for JWT validation
       publicKey: "Rdx2rUYesuu6EOBSt27Po85W5k-S4EU6uoSQxrDYUXc"
 
+    # How soon unused educator contexts get automatically unloaded.
+    contextExpiry: 1m
+
   # Faucet config
   faucet:
     # Logging config for faucet node. See option `witness.logging`.

--- a/multi-educator/src/Dscp/MultiEducator/CLI.hs
+++ b/multi-educator/src/Dscp/MultiEducator/CLI.hs
@@ -12,6 +12,7 @@ import Data.Aeson (eitherDecodeStrict')
 import Loot.Config (OptModParser, uplift, (.::), (.:<), (<*<))
 import Options.Applicative (Parser, eitherReader, help, long, metavar, option, strOption)
 import Servant.Client.Core (BaseUrl, parseBaseUrl)
+import Time (KnownRatName, Time)
 
 import Dscp.CommonCLI
 import Dscp.Educator.CLI
@@ -60,6 +61,12 @@ multiEducatorWebConfigParser =
     #multiEducatorAPINoAuth .:: multiEducatorApiNoAuthParser <*<
     #studentAPINoAuth .:: studentApiNoAuthParser
 
+educatorContextExpiryParser :: KnownRatName unit => Parser (Time unit)
+educatorContextExpiryParser = option timeReadM $
+    long "educator-context-expiry" <>
+    metavar "TIME" <>
+    help "How soon unused educator contexts should be unloaded."
+
 multiEducatorConfigParser :: OptModParser MultiEducatorConfig
 multiEducatorConfigParser =
     uplift witnessConfigParser <*<
@@ -72,5 +79,6 @@ multiEducatorConfigParser =
              (#period .:: publishingPeriodParser
              ) <*<
          #certificates .:<
-            (#resources .:: pdfResourcesPathParser)
+            (#resources .:: pdfResourcesPathParser) <*<
+         #contextExpiry .:: educatorContextExpiryParser
         )

--- a/multi-educator/src/Dscp/MultiEducator/Config.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Config.hs
@@ -53,6 +53,7 @@ type MultiEducatorConfig = WitnessConfig ++
             , "resources" ::: FilePath
             , "downloadBaseUrl" ::: BaseUrl
             ]
+        , "contextExpiry" ::: Time Second
         ]
      ]
 

--- a/multi-educator/src/Dscp/MultiEducator/Launcher/Context.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Launcher/Context.hs
@@ -1,6 +1,7 @@
 -- | Context of multi-educator node.
 module Dscp.MultiEducator.Launcher.Context
-       ( EducatorContextsMap
+       ( EducatorContextVar
+       , EducatorContextsMap
        , EducatorContexts (..)
        , EducatorContextsVar
        , MultiEducatorResources (..)
@@ -19,8 +20,12 @@ import Dscp.Resource.Network (NetServResources)
 import Dscp.Util.HasLens
 import qualified Dscp.Witness.Launcher.Resource as Witness
 
+-- | We keep each educator's context in a separate @TVar@ to reduce
+-- contention.
+type EducatorContextVar = TVar MaybeLoadedEducatorContext
+
 -- | For each educator - its context state.
-type EducatorContextsMap = Map EducatorUUID MaybeLoadedEducatorContext
+type EducatorContextsMap = Map EducatorUUID EducatorContextVar
 
 -- | State of active educator contexts.
 data EducatorContexts

--- a/multi-educator/src/Dscp/MultiEducator/Launcher/Context.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Launcher/Context.hs
@@ -1,13 +1,15 @@
 -- | Context of multi-educator node.
 module Dscp.MultiEducator.Launcher.Context
-       ( EducatorContexts
+       ( EducatorContextsMap
+       , EducatorContexts (..)
        , EducatorContextsVar
        , MultiEducatorResources (..)
+       , _ActiveEducatorContexts
        , merWitnessResources
        , merEducatorData
        ) where
 
-import Control.Lens (makeLenses)
+import Control.Lens (makeLenses, makePrisms)
 import qualified Pdf.FromLatex as Pdf
 
 import Dscp.DB.SQL
@@ -17,8 +19,18 @@ import Dscp.Resource.Network (NetServResources)
 import Dscp.Util.HasLens
 import qualified Dscp.Witness.Launcher.Resource as Witness
 
+-- | For each educator - its context state.
+type EducatorContextsMap = Map EducatorUUID MaybeLoadedEducatorContext
+
 -- | State of active educator contexts.
-type EducatorContexts = Map EducatorUUID MaybeLoadedEducatorContext
+data EducatorContexts
+    = -- | Some contexts are in use.
+      ActiveEducatorContexts EducatorContextsMap
+      -- | Multi-educator is terminating and does not accept further
+      -- contexts.
+    | TerminatedEducatorContexts
+
+makePrisms ''EducatorContexts
 
 -- | Contexts of every loaded educator.
 type EducatorContextsVar = TVar EducatorContexts

--- a/multi-educator/src/Dscp/MultiEducator/Launcher/Educator/Context.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Launcher/Educator/Context.hs
@@ -2,6 +2,7 @@
 
 module Dscp.MultiEducator.Launcher.Educator.Context
     ( EducatorContextUsers
+    , EducatorContextKeeper (..)
     , LoadedEducatorContext (..)
     , MaybeLoadedEducatorContext (..)
     , _FullyLoadedEducatorContext
@@ -17,13 +18,15 @@ import qualified Dscp.Educator.Launcher.Mode as E
 
 type EducatorContextUsers = Set (Async ())
 
+newtype EducatorContextKeeper = EducatorContextKeeper (Async Void)
+
 -- | Context and related stuff of a single educator.
 data LoadedEducatorContext where
     LoadedEducatorContext
         :: E.HasEducatorConfig
         => { lecCtx :: E.EducatorContext
              -- ^ The context itself.
-           , lecContextKeeper :: Async Void
+           , lecContextKeeper :: EducatorContextKeeper
              -- ^ Handler to context and resources keeping thread.
            , lecLastActivity :: Timestamp
              -- ^ Last user request time.
@@ -40,9 +43,11 @@ lecUsersL :: Lens' LoadedEducatorContext EducatorContextUsers
 lecUsersL = lens lecUsers (\ctx usrs -> ctx{ lecUsers = usrs })
 
 data MaybeLoadedEducatorContext
-      -- | Educator context is in transient state (loading or unloading).
-    = LockedEducatorContext
+      -- | Educator context is getting prepared.
+    = YetLoadingEducatorContext
       -- | Educator context has been loaded.
     | FullyLoadedEducatorContext LoadedEducatorContext
+      -- | Educator context is currently being unloaded.
+    | TerminatingEducatorContext EducatorContextKeeper
 
 makePrisms ''MaybeLoadedEducatorContext

--- a/multi-educator/src/Dscp/MultiEducator/Launcher/Educator/Context.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Launcher/Educator/Context.hs
@@ -29,6 +29,10 @@ data LoadedEducatorContext where
              -- ^ Last user request time.
            , lecUsers :: EducatorContextUsers
              -- ^ Threads which take use of the context currently.
+           , lecNoFurtherUsers :: Bool
+             -- ^ Whether new context users are allowed.
+             -- You may set this to @True@ upon context termination if
+             -- only STM context is yet available.
            }
         -> LoadedEducatorContext
 

--- a/multi-educator/src/Dscp/MultiEducator/Launcher/Educator/Context.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Launcher/Educator/Context.hs
@@ -5,9 +5,11 @@ module Dscp.MultiEducator.Launcher.Educator.Context
     , LoadedEducatorContext (..)
     , MaybeLoadedEducatorContext (..)
     , _FullyLoadedEducatorContext
+    , lecUsersL
     ) where
 
-import Control.Lens (makePrisms)
+import Control.Lens (makePrisms, lens)
+import Time (Timestamp)
 import UnliftIO.Async (Async)
 
 import qualified Dscp.Educator.Config as E
@@ -21,12 +23,21 @@ data LoadedEducatorContext where
         :: E.HasEducatorConfig
         => { lecCtx :: E.EducatorContext
              -- ^ The context itself.
+           , lecContextKeeper :: Async Void
+             -- ^ Handler to context and resources keeping thread.
+           , lecLastActivity :: Timestamp
+             -- ^ Last user request time.
+           , lecUsers :: EducatorContextUsers
+             -- ^ Threads which take use of the context currently.
            }
         -> LoadedEducatorContext
 
+lecUsersL :: Lens' LoadedEducatorContext EducatorContextUsers
+lecUsersL = lens lecUsers (\ctx usrs -> ctx{ lecUsers = usrs })
+
 data MaybeLoadedEducatorContext
-      -- | Educator context is yet being loaded.
-    = YetLoadingEducatorContext
+      -- | Educator context is in transient state (loading or unloading).
+    = LockedEducatorContext
       -- | Educator context has been loaded.
     | FullyLoadedEducatorContext LoadedEducatorContext
 

--- a/multi-educator/src/Dscp/MultiEducator/Launcher/Educator/Context.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Launcher/Educator/Context.hs
@@ -16,8 +16,10 @@ import UnliftIO.Async (Async)
 import qualified Dscp.Educator.Config as E
 import qualified Dscp.Educator.Launcher.Mode as E
 
+-- | Set of handlers to threads which currently use the context.
 type EducatorContextUsers = Set (Async ())
 
+-- | Handler to resources keeping thread.
 newtype EducatorContextKeeper = EducatorContextKeeper (Async Void)
 
 -- | Context and related stuff of a single educator.
@@ -27,15 +29,15 @@ data LoadedEducatorContext where
         => { lecCtx :: E.EducatorContext
              -- ^ The context itself.
            , lecContextKeeper :: EducatorContextKeeper
-             -- ^ Handler to context and resources keeping thread.
+             -- ^ Handler to resources keeping thread.
            , lecLastActivity :: Timestamp
              -- ^ Last user request time.
            , lecUsers :: EducatorContextUsers
              -- ^ Threads which take use of the context currently.
            , lecNoFurtherUsers :: Bool
-             -- ^ Whether new context users are allowed.
-             -- You may set this to @True@ upon context termination if
-             -- only STM context is yet available.
+             -- ^ Whether new context users are prohibited.
+             -- You may set this to @True@ upon context termination
+             -- within STM to provide some atomicity guarantees.
            }
         -> LoadedEducatorContext
 
@@ -43,7 +45,7 @@ lecUsersL :: Lens' LoadedEducatorContext EducatorContextUsers
 lecUsersL = lens lecUsers (\ctx usrs -> ctx{ lecUsers = usrs })
 
 data MaybeLoadedEducatorContext
-      -- | Educator context is getting prepared.
+      -- | Educator context is yet being loaded.
     = YetLoadingEducatorContext
       -- | Educator context has been loaded.
     | FullyLoadedEducatorContext LoadedEducatorContext

--- a/multi-educator/src/Dscp/MultiEducator/Launcher/Educator/Load.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Launcher/Educator/Load.hs
@@ -1,19 +1,58 @@
--- | Educator context load.
+{- | Thread-safe educator context load.
+
+This module is assumed to contain all the code which manipulates with contexts
+state.
+
+
+# Implementation notes:
+
+For each educator context we have a thread which keeps resources, workers and
+other stuff associated with the context; once this thread is killed,
+corresponding context is destroyed.
+
+
+Prepared context is put into `EducatorContextUsersVar` state.
+In total, this state is updated 4 times during lifecycle of the context:
+
+1. @Nothing -> Just LockedEducatorContext@ - happens when the first request
+to the corresponding educator occurs. This lock is taken until the context
+is ready to use.
+
+2. @Just LockedEducatorContext -> Just FullyLoadedEducatorContext@ - the context
+is ready and can be used by whoever needs it.
+
+3. @Just FullyLoadedEducatorContext -> Just LockedEducatorContext@ - context
+termination initiated. Further we kill all context users, release resources,
+stop workers.
+
+4. @Just LockedEducatorContext -> Nothing@ - context is fully removed, now
+one another context can be created for this educator.
+
+
+We account all context users (e.g. a thread corresponding to request to server)
+so that when the context is terminated we perform an attempt to kill those users
+gently (compare to suddenly getting error about closed database connection).
+
+-}
 module Dscp.MultiEducator.Launcher.Educator.Load
-    ( lookupEducator
-    , loadEducator
-    , normalToMulti
+    ( MultiEducatorIsTerminating (..)
+    , onTerminatedThrow
+    , withSingleEducator
+    , unloadEducator
     ) where
 
 import qualified Control.Concurrent.STM as STM
-import Control.Lens (at, traversed, zoom)
+import Control.Lens (at, traversed, zoom, (%=), _Just)
+import Control.Monad.Fix (mfix)
+import qualified Data.Set as S
 import Fmt ((+|), (|+))
 import Loot.Base.HasLens (lensOf)
-import Loot.Log (logDebug)
+import Loot.Log (MonadLogging, logDebug)
 import Serokell.Util (modifyTVarS)
-import Time (hour, threadDelay)
-import UnliftIO (async)
+import Time (Timestamp, hour, sec, threadDelay)
+import UnliftIO (Async, MonadUnliftIO, async, cancel, forConcurrently_, pollSTM, wait)
 
+import qualified Dscp.Educator.Config as E
 import qualified Dscp.Educator.Launcher.Mode as E
 import qualified Dscp.Educator.Launcher.Resource as E
 import Dscp.Educator.Workers
@@ -26,83 +65,226 @@ import Dscp.MultiEducator.Types
 import Dscp.MultiEducator.Web.Educator.Auth
 import Dscp.Network
 import Dscp.Rio (runRIO)
+import Dscp.Util.Time
+import Dscp.Util.TimeLimit
 
------------------------------------------------------------------------------
---- (Almost) Natural Transformation
------------------------------------------------------------------------------
+-- | Action which saves provided educator context while the provided action
+-- lasts; once it completes, the context is unloaded.
+type FillingEducatorContext m =
+    forall a. E.HasEducatorConfig => E.EducatorContext -> m a -> m a
 
--- | This function transforms normal workmode into multi-workmode using login.
--- It create a new Educator context if login was not found
-lookupEducator
-    :: MultiEducatorWorkMode ctx m
-    => EducatorAuthLogin
-    -> m LoadedEducatorContext
-lookupEducator educatorAuthLogin = do
+-- | Exception indicating that multi-educator is about to stop and does not
+-- accept further requests.
+-- TODO: consider it not as 500 internal on server?
+data MultiEducatorIsTerminating = MultiEducatorIsTerminating
+    deriving (Show)
+
+instance Exception MultiEducatorIsTerminating
+
+-- | Zoom into 'EducatorContext' expecting that multi-educator is active;
+-- if it is terminating, a corresponding exception is thrown.
+onTerminatedThrow :: StateT EducatorContextsMap STM a -> StateT EducatorContexts STM a
+onTerminatedThrow action = StateT $ \case
+    TerminatedEducatorContexts -> throwM MultiEducatorIsTerminating
+    ActiveEducatorContexts ctxs -> second ActiveEducatorContexts <$> runStateT action ctxs
+
+-- | Remember a thread using this context.
+rememberUser :: Async a -> LoadedEducatorContext -> LoadedEducatorContext
+rememberUser (void -> userAsync) = lecUsersL %~ S.insert userAsync
+
+-- | Forget about a completed thread which used this context.
+forgetUser :: MultiEducatorWorkMode ctx m => EducatorUUID -> Async a -> m ()
+forgetUser educatorId (void -> actionAsync) = do
     educatorContexts <- view $ lensOf @MultiEducatorResources . merEducatorData
 
-    let educatorId = eadId $ ealData educatorAuthLogin
-        withEducatorContextAtomically
-            :: MonadIO m
-            => StateT (Maybe MaybeLoadedEducatorContext) STM a -> m a
-        withEducatorContextAtomically =
-            atomically . modifyTVarS educatorContexts . zoom (at educatorId)
+    atomically . modifyTVarS educatorContexts $
+        -- if the context has been terminated, then we do not care about deleting,
+        -- it is being done for us.
+        zoom (_ActiveEducatorContexts . at educatorId) $
+            -- for the same reasons we do nothing when the context is not loaded.
+            _Just . _FullyLoadedEducatorContext . lecUsersL %=
+                S.delete actionAsync
 
-    mask_ $ do
-        mctx <- withEducatorContextAtomically $ do
-            get >>= \case
-                Nothing ->
-                    -- will load the context oursevles, taking a lock
-                    Nothing <$ put (Just YetLoadingEducatorContext)
+-- | Do our best to kill all user threads to perform resources cleanup
+-- safely later.
+disperseUsers
+    :: (MonadUnliftIO m, MonadLogging m)
+    => EducatorContextUsers -> m ()
+disperseUsers users = do
+    forConcurrently_ users $ \user -> do
+        res <- boundExecution (sec 3) "Educator context user waiting" $ wait user
+        whenNothing res $
+            boundExecution_ (sec 1) "Educator context user termination" $ cancel user
 
-                Just YetLoadingEducatorContext ->
-                    -- someone else has taken a lock
-                    lift STM.retry
+-- | Reads a ready context from state or takes a lock if it does not exist yet.
+-- If a context was present, we also update it in-place to reduce number of
+-- state touches.
+getContextOrLock
+    :: MultiEducatorWorkMode ctx m
+    => EducatorAuthLogin -> Timestamp -> Async a -> m (Maybe LoadedEducatorContext)
+getContextOrLock educatorAuthLogin curTime userAsync = do
+    educatorContexts <- view $ lensOf @MultiEducatorResources . merEducatorData
+    let educatorId = ealId educatorAuthLogin
 
-                Just (FullyLoadedEducatorContext ctx) ->
-                    -- already prepared
-                    return (Just ctx)
+    atomically . modifyTVarS educatorContexts . onTerminatedThrow . zoom (at educatorId) $
+        get >>= \case
+            Nothing ->
+                -- will load the context oursevles, taking a lock
+                Nothing <$ put (Just LockedEducatorContext)
 
-        case mctx of
-            Nothing -> let rollback = withEducatorContextAtomically $ put Nothing
-                in (`onException` rollback) $ do
-                        ctx <- loadEducator educatorAuthLogin
-                        withEducatorContextAtomically $
-                            put $ Just (FullyLoadedEducatorContext ctx)
-                        return ctx
-            -- Note: we need this because even if we already have the 'EducatorCtxWithCfg'
-            -- in the map it may need to be updated with a new token
-            Just ctx -> do
-                let certIssuerInfoRes = makeCertIssuerRes educatorAuthLogin
-                let newEdCtx = lecCtx ctx & E.ecResources.E.erPdfCertIssuerRes .~ certIssuerInfoRes
-                    newCtxWithCfg = ctx {lecCtx = newEdCtx}
-                withEducatorContextAtomically $
-                    put $ Just (FullyLoadedEducatorContext newCtxWithCfg)
-                return newCtxWithCfg
+            Just LockedEducatorContext ->
+                -- someone else has taken a lock
+                lift STM.retry
 
-loadEducator
-    :: (MultiEducatorWorkMode ctx m)
-    => EducatorAuthLogin
-    -> m LoadedEducatorContext
-loadEducator educatorAuthLogin  = do
+            Just (FullyLoadedEducatorContext ctx) -> do
+                -- already prepared
+                ctx' <- updateOldCtx ctx
+                put . Just $ FullyLoadedEducatorContext ctx'
+                return (Just ctx')
+  where
+    -- Note: we need this because even if we already have the 'EducatorCtxWithCfg'
+    -- in the map it may need to be updated with a new token
+    updateOldCtx ctx = do
+        let certIssuerInfoRes = makeCertIssuerRes educatorAuthLogin
+            newEdCtx = lecCtx ctx & E.ecResources.E.erPdfCertIssuerRes .~ certIssuerInfoRes
+        return $ ctx
+            { lecCtx = newEdCtx
+            , lecLastActivity = curTime
+            } & rememberUser userAsync
+
+-- | A couple for 'getContextOrLock', releases a previously taken lock leaving
+-- no context in state for the given educator.
+cleanLockedContext :: MultiEducatorWorkMode ctx m => EducatorUUID -> m ()
+cleanLockedContext educatorId = do
+    educatorContexts <- view $ lensOf @MultiEducatorResources . merEducatorData
+
+    atomically . modifyTVarS educatorContexts $
+        zoom (_ActiveEducatorContexts . at educatorId) $
+            put Nothing
+
+-- | Replace a lock with the prepared context, execute given action and replace
+-- the context with the lock back cleaning resources kept in this context.
+--
+-- Generally this function does not guarantee that the action will be executed,
+-- we may abort at context preparation stage.
+fillingEducatorContext
+    :: (MonadUnliftIO m, MonadMask m, MonadLogging m, E.HasEducatorConfig)
+    => EducatorContextsVar
+    -> EducatorUUID
+    -> LoadedEducatorContext
+    -> m a
+    -> m a
+fillingEducatorContext educatorContexts educatorId loadedCtx action = do
+    bracket_ fillContext releaseContext action
+  where
+    fillContext =
+        atomically . modifyTVarS educatorContexts $
+            onTerminatedThrow . zoom (at educatorId) $
+                put $ Just (FullyLoadedEducatorContext loadedCtx)
+
+    releaseContext = do
+        mctx <- atomically . modifyTVarS educatorContexts $
+            zoom (_ActiveEducatorContexts . at educatorId) $
+                get >>= \case
+                    Just (FullyLoadedEducatorContext ctx) -> do
+                        put $ Just LockedEducatorContext
+                        return (Alt $ Just ctx)
+                    _ -> error "Weird state"
+
+        whenJust (getAlt mctx) $ \ctx ->
+            disperseUsers (lecUsers ctx)
+
+-- | Once a thread serving the context is forked, wait for that context to load
+-- and return it once ready.
+waitForContextLoad
+    :: MultiEducatorWorkMode ctx m
+    => EducatorUUID -> Async Void -> m LoadedEducatorContext
+waitForContextLoad educatorId contextKeeper = do
+    educatorContexts <- view $ lensOf @MultiEducatorResources . merEducatorData
+
+    atomically . modifyTVarS educatorContexts . onTerminatedThrow . zoom (at educatorId) $ do
+        mctx' <- get
+        mterminated <- lift $ pollSTM contextKeeper
+        case (mctx', mterminated) of
+            (Just (FullyLoadedEducatorContext ctx), _) -> return ctx
+            (_, Just term)                             -> either throwM absurd term
+            (Just LockedEducatorContext, Nothing)      -> lift STM.retry
+            -- context has been unloaded, need to read exception from the context keeper
+            (Nothing, Nothing)                         -> lift STM.retry
+
+-- | An action which is happening in the context keeping thread.
+-- It allocates resources, launches workers and waits till async exception
+-- after which everything is stoped/cleaned up.
+serveEducatorContext
+    :: MultiEducatorWorkMode ctx m
+    => FillingEducatorContext E.EducatorRealMode
+    -> EducatorAuthLogin
+    -> m a
+serveEducatorContext fillingContext educatorAuthLogin = do
     logDebug $ "Loading educator " +| educatorId |+ ""
 
-    ctxVar <- newEmptyMVar
-
-    -- we will not ignore this async once DSCP-494 is completed
-    _ <- async $ launchSingleEducatorMode educatorAuthLogin $ do
+    launchSingleEducatorMode educatorAuthLogin $ do
         educatorContext <- ask
         let singleEducatorClients =
                 educatorClients & traversed . wIdL %~ (<> "_of_" <> encodeUtf8 eid)
 
-        withWorkers singleEducatorClients $ do
-            putMVar ctxVar LoadedEducatorContext
-                { lecCtx = educatorContext
-                }
-            forever $ threadDelay (hour 1)
+        withWorkers singleEducatorClients $
+            fillingContext educatorContext $
+                forever $ threadDelay (hour 1)
 
-    takeMVar ctxVar
+            -- TODO: wrap each LoadedEducatorContext entry into own tvar for performance?
   where
     educatorId@(EducatorUUID eid) = ealId educatorAuthLogin
 
-normalToMulti :: MultiEducatorWorkMode ctx m => LoadedEducatorContext -> E.EducatorRealMode a -> m a
-normalToMulti LoadedEducatorContext{..} = runRIO lecCtx
+-- | Find a context in state. If it is not present, load a new context and return it.
+lookupEducator
+    :: MultiEducatorWorkMode ctx m
+    => EducatorAuthLogin
+    -> Async a
+    -> m LoadedEducatorContext
+lookupEducator educatorAuthLogin userAsync = do
+    educatorContexts <- view $ lensOf @MultiEducatorResources . merEducatorData
+    curTime <- getCurTime
+    let educatorId = ealId educatorAuthLogin
+
+    mask_ $ do
+        mctx <- getContextOrLock educatorAuthLogin curTime userAsync
+
+        whenNothing mctx $ do
+            let fillingContext :: Async Void -> FillingEducatorContext E.EducatorRealMode
+                fillingContext contextKeeper ctx =
+                    fillingEducatorContext educatorContexts educatorId $
+                        LoadedEducatorContext
+                        { lecCtx = ctx
+                        , lecLastActivity = curTime
+                        , lecUsers = S.singleton (void userAsync)
+                        , lecContextKeeper = contextKeeper
+                        }
+
+            contextKeeper <- mfix $ \contextKeeper ->
+                async $ serveEducatorContext (fillingContext contextKeeper) educatorAuthLogin
+                          `finally` (cleanLockedContext educatorId)
+
+            waitForContextLoad educatorId contextKeeper
+
+-- | Execute an action in educator context.
+withSingleEducator
+    :: MultiEducatorWorkMode ctx m
+    => EducatorAuthLogin -> E.EducatorRealMode a -> m a
+withSingleEducator educatorAuthLogin action = do
+    bracket prepare terminate wait
+  where
+    prepare = mfix $ \actionAsync -> do
+        ctx <- lookupEducator educatorAuthLogin actionAsync
+        async $ runRIO (lecCtx ctx) action
+    terminate actionAsync =
+        forgetUser (ealId educatorAuthLogin) actionAsync
+
+-- | Synchronously unload educator context waiting for requests to server
+-- to complete and releasing all associated resources.
+unloadEducator
+    :: (MonadUnliftIO m, MonadLogging m)
+    => LoadedEducatorContext -> m ()
+unloadEducator ctx =
+    logWarningWaitInf (sec 1) "Educator context shutdown" $
+        cancel $ lecContextKeeper ctx

--- a/multi-educator/src/Dscp/MultiEducator/Launcher/Educator/Load.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Launcher/Educator/Load.hs
@@ -158,6 +158,7 @@ getContextOrLock educatorAuthLogin curTime userAsync = do
 
             Just ctxVar -> lift $ do
                 ctx <- readTVar ctxVar >>= retryOnContextLocked
+                when (lecNoFurtherUsers ctx) $ STM.retry
                 let ctx' = updateOldCtx ctx
                 writeTVar ctxVar (FullyLoadedEducatorContext ctx')
                 return (Right ctx')
@@ -265,6 +266,7 @@ lookupEducator educatorAuthLogin userAsync = do
                             , lecLastActivity = curTime
                             , lecUsers = S.singleton (void userAsync)
                             , lecContextKeeper = contextKeeper
+                            , lecNoFurtherUsers = False
                             }
 
                 contextKeeper <- mfix $ \contextKeeper ->

--- a/multi-educator/src/Dscp/MultiEducator/Launcher/Mode.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Launcher/Mode.hs
@@ -19,6 +19,7 @@ module Dscp.MultiEducator.Launcher.Mode
     ) where
 
 import Control.Lens (makeLenses)
+import Control.Monad.Fix (MonadFix)
 import Loot.Base.HasLens (HasLens')
 import Loot.Network.Class (NetworkingCli, NetworkingServ)
 import Loot.Network.ZMQ (ZmqTcp)
@@ -39,6 +40,7 @@ import qualified Dscp.Witness as W
 -- | Set of typeclasses which define capabilities of bare Educator node.
 type MultiEducatorWorkMode ctx m =
     ( W.WitnessWorkMode ctx m
+    , MonadFix m
 
     , HasMultiEducatorConfig
     , HasLens' ctx EducatorContextsVar

--- a/multi-educator/src/Dscp/MultiEducator/Launcher/Resource.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Launcher/Resource.hs
@@ -31,8 +31,7 @@ instance AllocResource EducatorContextsVar where
                 ActiveEducatorContexts ctxs ->
                     forConcurrently_ ctxs $ \ctxVar -> do
                         ctx <- atomically $ readTVar ctxVar >>= retryOnContextLocked
-                        unloadEducator ctx
-                        -- TODO: throw 'MultiEducatorIsTerminating' exception to context users
+                        unloadEducator MultiEducatorIsTerminating ctx
 
 instance AllocResource MultiEducatorResources where
     type Deps MultiEducatorResources = MultiEducatorConfigRec

--- a/multi-educator/src/Dscp/MultiEducator/Web/Educator/API.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Web/Educator/API.hs
@@ -98,8 +98,6 @@ type MultiStudentAPI =
 
 type ProtectedMultiStudentAPI =
     Capture "educator" EducatorUUID :> ProtectedStudentAPI
-    -- @martoon: I guess it's weird that we accept uuid here?
-    -- Does student even know it?
 
 multiStudentAPI :: Proxy MultiStudentAPI
 multiStudentAPI = Proxy

--- a/multi-educator/src/Dscp/MultiEducator/Web/Server.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Web/Server.hs
@@ -55,7 +55,7 @@ mkEducatorApiServer' educatorAuthLogin =
     hoistServerWithContext
         rawEducatorAPI
         (Proxy :: Proxy '[])
-        (\x -> lookupEducator educatorAuthLogin >>= \c -> normalToMulti c x)
+        (withSingleEducator educatorAuthLogin)
         (toServant educatorApiHandlers)
 
 mkMultiEducatorApiServer
@@ -84,7 +84,7 @@ mkStudentApiServer nat host =
         in hoistServerWithContext
                 protectedStudentAPI
                 (Proxy :: Proxy '[StudentCheckAction, NoAuthContext "student"])
-                (\x -> nat $ lookupEducator ealogin >>= \c -> normalToMulti c x)
+                (nat . withSingleEducator ealogin)
                 (\student -> toServant $ studentApiHandlers student)
 
 mkCertificatesApiServer

--- a/multi-educator/src/Dscp/MultiEducator/Workers.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Workers.hs
@@ -1,8 +1,81 @@
+{-# LANGUAGE OverloadedLists #-}
+
 module Dscp.MultiEducator.Workers
     ( multiEducatorWorkers
     ) where
 
-import Dscp.Network.Wrapped
+import qualified Control.Concurrent.STM as STM
+import qualified Data.Map as M
+import Loot.Base.HasLens (lensOf)
+import Loot.Config (option, sub)
+import Serokell.Util (modifyTVarS)
+import Time (minute, sec, threadDelay, timeAdd)
+import UnliftIO (handle)
 
-multiEducatorWorkers :: [Client m]
-multiEducatorWorkers = []
+import Dscp.MultiEducator.Config
+import Dscp.MultiEducator.Launcher.Context
+import Dscp.MultiEducator.Launcher.Educator
+import Dscp.MultiEducator.Launcher.Mode
+import Dscp.Network
+import Dscp.Util.Time
+
+multiEducatorWorkers
+    :: MultiEducatorWorkMode ctx m
+    => [Client m]
+multiEducatorWorkers =
+    [ privateBlockCreatorWorker
+    ]
+
+----------------------------------------------------------------------------
+-- Educator contexts expiration
+----------------------------------------------------------------------------
+
+privateBlockCreatorWorker :: MultiEducatorWorkMode ctx m => Client m
+privateBlockCreatorWorker =
+    simpleWorker "expiredEducatorsUnload" $ do
+        educatorContexts <- view $ lensOf @MultiEducatorResources . merEducatorData
+
+        handleTerminatedException . forever $ do
+            time <- getCurTime
+            let isExpired = \case
+                    LockedEducatorContext -> False
+                    FullyLoadedEducatorContext ctx -> and @[_]
+                        [ expiryDuration `timeAdd` lecLastActivity ctx > time
+                        , null (lecUsers ctx)
+                        ]
+
+            -- Phase 1: remove all expired contexts
+
+            expiredCtxs <- atomically . modifyTVarS educatorContexts . onTerminatedThrow $ do
+                ictx <- get
+                let (expired, nonExpired) = M.partition isExpired ictx
+                put nonExpired
+                return (M.elems expired)
+
+            -- TODO: there is a major problem: right here there is a probability
+            -- to get another request to server using expired context, and eventually
+            -- this request may be killed along with the context unload and this is very undesired.
+
+            forM_ expiredCtxs $ \case
+                LockedEducatorContext -> error "impossible"
+                FullyLoadedEducatorContext ctx -> unloadEducator ctx
+
+            -- Phase 2: wait for the next expiring context
+
+            nextExpiry <- atomically . modifyTVarS educatorContexts . onTerminatedThrow $ do
+                las <- gets (map lastActivity . M.elems)
+                when (null las) $ lift STM.retry
+                return $ timeAdd expiryDuration (minimum las)
+
+            let tillNextExpiry = nextExpiry `timeDiffNonNegative` time
+            sleep $ max minimalCheckPeriod tillNextExpiry
+  where
+    lastActivity = \case
+        LockedEducatorContext -> infiniteFuture
+        FullyLoadedEducatorContext ctx -> lecLastActivity ctx
+    expiryDuration = multiEducatorConfig ^. sub #educator . option #contextExpiry
+    minimalCheckPeriod = sec 1
+    handleTerminatedException =
+        handle $ \MultiEducatorIsTerminating ->
+            -- waiting for this worker to be killed outside
+            forever $ threadDelay (minute 1)

--- a/multi-educator/src/Dscp/MultiEducator/Workers.hs
+++ b/multi-educator/src/Dscp/MultiEducator/Workers.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedLists #-}
-
 module Dscp.MultiEducator.Workers
     ( multiEducatorWorkers
     ) where
@@ -33,15 +31,13 @@ multiEducatorWorkers =
 -- | Exception used to kill users of expired contexts.
 -- Well, as you can guess this should never occur to be thrown eventually.
 data TerminatedByContextsCleaner = TerminatedByContextsCleaner
-
 instance Show TerminatedByContextsCleaner where
     show _ = "Thread terminated by contexts cleaner"
-
 instance Exception TerminatedByContextsCleaner
 
 expiredEducatorContextsCleaner :: MultiEducatorWorkMode ctx m => Client m
 expiredEducatorContextsCleaner =
-    simpleWorker "expiredEducatorsUnload" $ do
+    simpleWorker "expiredEducatorsUnload" $
         handleTerminatedException . forever $ cleanup >> nap
   where
     expiryDuration = multiEducatorConfig ^. sub #educator . option #contextExpiry
@@ -96,8 +92,7 @@ expiredEducatorContextsCleaner =
             -- would potentially cause too high contention.
             -- So we keep all 'atomically' blocks no more than constant-size in time.
 
-        lastActivities <- forM ctxs $ \ctxVar -> do
-            atomically $ lastActivity <$> readTVar ctxVar
+        lastActivities <- forM ctxs $ fmap lastActivity . readTVarIO
 
         let nextExpiry = timeAdd expiryDuration (minimum @(NonEmpty _) lastActivities)
         let tillNextExpiry = nextExpiry `timeDiffNonNegative` curTime

--- a/scripts/launch/node.sh
+++ b/scripts/launch/node.sh
@@ -125,6 +125,7 @@ multi_educator_params="
 --pdf-resource-path ../pdfs/template
 --aaa-service-url https://stage-teachmeplease-aaa.stage.tchmpls.com
 --aaa-public-key 2gSNy2wKSaI4YtGZe_Eaxsdv_BLCfi5kkT9xvxt_O0k
+--educator-context-expiry 1s
 "
 # Note: Student address in --student-api-no-auth parameter corresponds to secret
 # key with seed 456 (use dscp-keygen to generate one)


### PR DESCRIPTION
### Description

Added opportunity to terminate node context in a thread-safe manner and added a worker which does that after a while of inactivity.

While reviewing this PR you may experience a significant amount of "wtf what is it for :why:" reactions, feel free to ask questions. Hopefully, I will explain possible problems and maybe we manage to simplify things.

### YT issue

https://issues.serokell.io/issue/DSCP-494

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [ ] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
