### PR TITLE
[DSCP-504] Disable Darwin builds temporarily

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,20 +16,21 @@ steps:
       system: x86_64-linux
     label: build
 
-  - command: nix-build --no-out-link
-    agents:
-      system: x86_64-darwin
-    label: build-darwin
+  # NOTE: Darwin builds are temporarily disabled until they are fixed
+  # - command: nix-build --no-out-link
+  #   agents:
+  #     system: x86_64-darwin
+  #   label: build-darwin
 
   - command: nix-build shell.nix --no-out-link
     agents:
       system: x86_64-linux
     label: shell
 
-  - command: nix-build shell.nix --no-out-link
-    agents:
-      system: x86_64-darwin
-    label: shell-darwin
+  # - command: nix-build shell.nix --no-out-link
+  #   agents:
+  #     system: x86_64-darwin
+  #   label: shell-darwin
 
   - wait
 
@@ -47,12 +48,12 @@ steps:
     - haddock.tar.gz
     label: haddock
 
-  - command: nix-build release.nix -A disciplina-wallet-macos-zip -o disciplina-wallet-macos.zip
-    agents:
-      system: x86_64-darwin
-    artifact_paths:
-    - disciplina-wallet-macos.zip
-    label: macos-zip
+  # - command: nix-build release.nix -A disciplina-wallet-macos-zip -o disciplina-wallet-macos.zip
+  #   agents:
+  #     system: x86_64-darwin
+  #   artifact_paths:
+  #   - disciplina-wallet-macos.zip
+  #   label: macos-zip
 
   - command: nix-build specs -o specs/result
     agents:


### PR DESCRIPTION
### Description

We've been experiencing problems with Darwin builds for a while, which make CI not pass. I decided to disable it until those problems are resolved, since we have to merge PRs which build normally for Linux anyway.

### YT issue

https://issues.serokell.io/issue/DSCP-504

### Checklist

Hint: a perfect PR has all the checkmarks set.

Possible related changes (conditional):
- [x] I added tests if required, in case they are:
  - Covering new introduced functionality (feature).
  - Regression tests preventing the bug from silently reappearing again (bugfix).
- [x] I have checked the [sample config](../tree/master/docs/config-full-sample.yaml) and [launch scripts](../tree/master/scripts/launch) and updated them if it was necessary (especially if executables or CLIs were changed).
- [x] I have checked READMEs and changed them accordingly if it's necessary (the main [README.md](../tree/master/README.md) as well as subproject READMEs for all related executables).
- [x] If a public API structure or/and data serialization was changed, I made sure that these changes are reflected in the:
  - [Swagger](../tree/master/specs/disciplina) API specs.
  - Any [related documentation](../tree/master/docs/api-types.md).
- [x] If any public documentation was written, I have spellchecked it.

Stylistic (obligatory):
- [x] My commit history is clean, descriptive and do not contain merge or revert commits or commits like "WIP".
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
- [x] My code is documented (haddock) and these docs are decent (full enough and spellchecked).
